### PR TITLE
解决H&R种子满足条件时未删除H&R标签的bug

### DIFF
--- a/plugins/hitandrun/helper.py
+++ b/plugins/hitandrun/helper.py
@@ -296,7 +296,7 @@ class TorrentHelper:
             unique_tags = list(set(tags))
 
             if self.dl_type == "qbittorrent":
-                self.downloader.remove_torrents_tag(ids=torrent_hash, tags=unique_tags)
+                self.downloader.remove_torrents_tag(ids=torrent_hash, tag=unique_tags)
             else:
                 if updated_tags is not None:
                     # 如果提供了 updated_tags，直接设置这些标签


### PR DESCRIPTION
大佬，调qbittorrent的remove_torrents_tag方法时，传参有点问题，那边删除用的是tag，不是tags。