### PR TITLE
修改Plex中文本地化延长超时时间,

### DIFF
--- a/plugins.v2/plexlocalization/__init__.py
+++ b/plugins.v2/plexlocalization/__init__.py
@@ -73,7 +73,7 @@ class PlexLocalization(_PluginBase):
     # 每批次处理数量
     _batch_size = None
     # timeout
-    _timeout = 10
+    _timeout = 999
     # tags_json
     _tags_json = None
     # tags


### PR DESCRIPTION
修复以下报错

【ERROR】2025-10-04 22:15:16,489 - plexlocalization - 第77批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:15:16,488 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:15:06,350 - plexlocalization - 第74批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:15:06,349 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:14:56,118 - plexlocalization - 第69批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:14:56,116 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:14:46,106 - plexlocalization - 第68批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:14:46,104 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:14:36,011 - plexlocalization - 第66批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:14:36,009 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:14:25,794 - plexlocalization - 第62批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:14:25,792 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:14:15,282 - plexlocalization - 第53批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:14:15,281 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:14:04,691 - plexlocalization - 第43批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:14:04,689 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:13:54,341 - plexlocalization - 第37批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:13:54,340 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:13:44,043 - plexlocalization - 第34批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:13:44,041 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:13:32,948 - plexlocalization - 第16批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:13:32,946 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:13:22,757 - plexlocalization - 第12批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:13:22,756 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:13:12,745 - plexlocalization - 第11批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:13:12,742 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:13:02,675 - plexlocalization - 第9批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:13:02,672 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:12:52,599 - plexlocalization - 第7批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:12:52,598 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:12:42,508 - plexlocalization - 第5批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:12:42,506 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:12:32,493 - plexlocalization - 第4批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:12:32,492 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【ERROR】2025-10-04 22:12:22,482 - plexlocalization - 第3批次处理过程中发生错误: 'NoneType' object has no attribute 'json'
【ERROR】2025-10-04 22:12:22,480 - plex.py - 连接Plex出错：HTTPConnectionPool(host='127.0.0.1', port=32400): Read timed out. (read timeout=10)
【INFO】2025-10-04 22:12:12,281 - plexlocalization - 总条目：1694，每批处理条数：10，总批次数：170，准备开始执行
【INFO】2025-10-04 22:12:12,263 - plexlocalization - <电视节目 show> 类型共计 629 个
【INFO】2025-10-04 22:12:11,754 - plexlocalization - <电影 movie> 类型共计 93 个合集
【INFO】2025-10-04 22:12:11,728 - plexlocalization - <电影 movie> 类型共计 972 个
【INFO】2025-10-04 22:12:10,943 - plexlocalization - 开始处理媒体服务器 Plex
【INFO】2025-10-04 22:12:10,941 - plexlocalization - 正在运行中文本地化，线程数：1，锁定元数据：True
【INFO】2025-10-04 22:12:10,938 - plexlocalization - 当前标签本地化配置为：{'Anime': '动画', 'Action': '动作', 'Mystery': '悬疑', 'Tv Movie': '电视电影', 'Animation': '动画', 'Crime': '犯罪', 'Family': '家庭', 'Fantasy': '奇幻', 'Disaster': '灾难', 'Adventure': '冒险', 'Short': '短片', 'Horror': '恐怖', 'History': '历史', 'Suspense': '悬疑', 'Biography': '传记', 'Sport': '运动', 'Comedy': '喜剧', 'Romance': '爱情', 'Thriller': '惊悚', 'Documentary': '纪录', 'Indie': '独立', 'Music': '音乐', 'Sci-Fi': '科幻', 'Western': '西部', 'Children': '儿童', 'Martial Arts': '武侠', 'Drama': '剧情', 'War': '战争', 'Musical': '歌舞', 'Film-noir': '黑色', 'Science Fiction': '科幻', 'Film-Noir': '黑色', 'Food': '饮食', 'War & Politics': '战争与政治', 'Sci-Fi & Fantasy': '科幻与奇幻', 'Mini-Series': '迷你剧', 'Reality': '真人秀', 'Home and Garden': '家居与园艺', 'Game Show': '游戏节目', 'Awards Show': '颁奖典礼', 'News': '新闻', 'Talk': '访谈', 'Talk Show': '脱口秀', 'Travel': '旅行', 'Soap': '肥皂剧', 'Rap': '说唱', 'Adult': '成人'}
【INFO】2025-10-04 22:12:10,937 - plexlocalization - 正在准备本地化的媒体库 {'Plex': {3: MovieSection:3:电影, 4: ShowSection:4:电视节目}}
【INFO】2025-10-04 22:12:10,933 - plexlocalization - 正在准备执行本地化服务
【INFO】2025-10-04 22:12:07,966 - plexlocalization - Plex中文本地化定时服务启动，时间间隔 0 1 * * *
【INFO】2025-10-04 22:12:07,927 - plexlocalization - Plex中文本地化服务，立即运行一次