### PR TITLE
feat(subscribeassistant): 优化剧集完结状态判断逻辑

### DIFF
--- a/plugins.v2/subscribeassistant/__init__.py
+++ b/plugins.v2/subscribeassistant/__init__.py
@@ -6208,13 +6208,27 @@ block: []
         if mediainfo.status in ["Ended", "Canceled"]:
             return True
 
-        episodes = self.__get_tv_episodes(mediainfo=mediainfo, season=season, episode_group=episode_group)
-        if not episodes:
+        last_episode = mediainfo.tmdb_info.get("last_episode_to_air") or {}
+
+        if last_episode.get("season_number", float("-inf")) > season:
+            return True
+
+        finale_type = {"finale", "mid_season"}
+
+        if (
+            last_episode.get("episode_type") in finale_type
+            or mediainfo.next_episode_to_air.get("episode_type") in finale_type
+        ):
+            return True
+
+        episodes = self.tmdb_chain.tmdb_episodes(
+            tmdbid=mediainfo.tmdb_id, season=season, episode_group=episode_group
+        )
+        if not last_episode and not episodes:
             return False
 
-        # 判断是否存在最终集，存在则认为已完结
-        completed = any(episode.episode_type == "finale" for episode in episodes) if episodes else False
-        return completed
+        # 判断是否最终集
+        return episodes[-1].episode_type in finale_type
 
     def __get_tv_latest_episode(self, mediainfo: MediaInfo, season: int, episode_group: Optional[str] = None) -> \
             Tuple[Optional[TmdbEpisode], Optional[TmdbEpisode]]:


### PR DESCRIPTION
### 🎯 修改意图

1. **番剧分割放送场景支持不足**：原逻辑仅通过检查是否存在 `finale` 类型剧集来判断完结，无法正确处理分割放送（Split Cour）的番剧，导致在季中完结（mid_season finale）时被误判为未完结，错过洗版时机

---

### ✨ 核心改进

#### 1. **多层次完结判断策略**（按优先级排序）

```
① 剧集整体状态检查 → Ended/Canceled 直接判定完结
② 跨季检测 → last_episode 的季数 > 当前季，判定完结  
③ 最终集类型检测 → 最后/下一集为 finale/mid_season，判定完结
④ 剧集列表兜底 → 查询完整剧集列表，检查最后一集类型
```

#### 2. **支持分割放送场景**

- 新增 `mid_season` 作为完结类型识别
- 同时检查 `last_episode_to_air` 和 `next_episode_to_air` 的 `episode_type`
- 正确识别季中完结（如分割放送的 Part 1 结束）

#### 3. **增强边界条件处理**

- 处理 `last_episode_to_air` 为空的情况
- 使用 `float("-inf")` 确保季数比较的安全性
- 空列表保护：`if not last_episode and not episodes: return False`

---

**优势**：
- ✅ 分层判断，短路优化
- ✅ 支持 mid_season 完结类型
- ✅ 更好的边界处理