### PR TITLE
为插件发版增加双层门禁

### DIFF
--- a/.agents/skills/moviepilot-plugin-release/SKILL.md
+++ b/.agents/skills/moviepilot-plugin-release/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: moviepilot-plugin-release
+description: Use when publishing, releasing, version-bumping, or preparing a pull request for a v1 or v2 plugin in the InfinityPacer/MoviePilot-Plugins repository.
+---
+
+# MoviePilot 插件发版
+
+## 核心原则
+
+以插件仓源码、市场元数据和 GitHub Release 的实际结果形成闭环。不得把“本地改完”、
+“PR 已创建”或“Action 已触发”当成发版完成。
+
+只操作 `InfinityPacer/MoviePilot-Plugins`。发版统一走功能分支、PR Required Check、
+Auto-merge 和 `main` Release workflow，不直接 push `main`。
+
+## 1. 确认范围
+
+1. 运行 `git remote -v`，确认仓库是 `InfinityPacer/MoviePilot-Plugins`。
+2. 运行 `git status --short --branch`，保留并避开用户已有改动。
+3. v2 插件只修改 `plugins.v2/<plugin_id>/` 和 `package.v2.json`；除非用户明确要求，
+   不修改 `plugins/`。
+4. 若当前在 `main`，从最新 `origin/main` 创建当前代理对应的协作分支：
+   - Codex：`codex/release/<plugin>-<version>`
+   - Claude Code：`claude/release/<plugin>-<version>`
+
+## 2. 同步发布事实
+
+按以下顺序核对，不要只搜索版本字符串：
+
+1. 插件类的 `plugin_version`；
+2. `package.json` 或 `package.v2.json` 对应条目的 `version`；
+3. 对应 `history["v<version>"]` 的用户可读说明；
+4. 若插件存在独立 README，其顶部“版本更新日志”必须有同版本、同语义条目；
+5. 插件目录、package key、插件 ID 和 `plugin_version` 必须属于同一插件。
+
+版本说明描述发布后的当前行为，不写 commit message 视角，不写源码行号或本机信息。
+
+## 3. 启用本地门禁
+
+先读取现有配置：
+
+```bash
+git config --get core.hooksPath
+```
+
+- 无输出：运行 `git config core.hooksPath .githooks`。
+- 输出 `.githooks`：继续。
+- 输出其他路径：停止并说明冲突，不得覆盖用户已有 Hook。
+
+随后直接运行：
+
+```bash
+.githooks/pre-push
+```
+
+版本门禁不通过时先修复，不得使用 `--no-verify` 绕过。
+
+## 4. 验证
+
+使用工作区 `.venv-test`，worktree 中显式指定后端：
+
+```bash
+MOVIEPILOT_BACKEND_PATH=<workspace>/MoviePilot \
+  <workspace>/.venv-test/bin/python -m pytest tests/<v1|v2>/<plugin_id> -q
+MOVIEPILOT_BACKEND_PATH=<workspace>/MoviePilot \
+  <workspace>/.venv-test/bin/python tests/run.py -q
+python .github/scripts/check_plugin_versions.py package.json package.v2.json
+python -m json.tool package.v2.json >/dev/null
+python -m compileall -q plugins.v2/<plugin_id>
+git diff --check
+```
+
+外部服务必须 mock；全量测试不得真实出站。任何失败都要修复或明确报告，不能带失败进入 PR。
+
+## 5. 提交前确认
+
+展示以下内容并取得维护者明确确认后，才能 commit 或 push：
+
+- 分支名；
+- 版本同步位置；
+- 测试和门禁结果；
+- `git diff --stat`；
+- 拟用的单行英文 Conventional Commit subject。
+
+确认一次可以覆盖紧接着执行的 commit 和 push；用户只确认 commit 时，不得推送。
+
+## 6. 创建并自动合并 PR
+
+commit、push 后，用真实换行的临时 Markdown 文件创建中文 PR：
+
+```bash
+gh pr create \
+  --repo InfinityPacer/MoviePilot-Plugins \
+  --base main \
+  --head <branch> \
+  --title "<中文标题>" \
+  --body-file <body-file>
+```
+
+PR 必须包含变更说明、影响路径、验证结果和协作来源。纯 Codex 写
+“本 PR 为 Codex 协作提交”，纯 Claude Code 写“本 PR 为 Claude Code 协作提交”；
+两者都实际参与时写“本 PR 为 Claude Code & Codex 协作提交”。
+
+回读 PR 正文确认渲染和隐私无误，并等待 `Plugin release gate` 至少出现一次。仓库首次
+启用保护时，先创建要求该检查的 `main` Ruleset，再为 PR 启用 Auto-merge；不得在
+Ruleset 生效前提前启用，否则 PR 可能在没有保护条件时直接合并。
+
+只对刚创建并核对过 URL/编号与 head SHA 的 PR 启用：
+
+```bash
+gh pr merge <pr-number> \
+  --repo InfinityPacer/MoviePilot-Plugins \
+  --auto --squash --delete-branch \
+  --match-head-commit <head-sha>
+```
+
+不得扫描并批量启用其他 PR 的 Auto-merge，不得使用 `--admin` 绕过 Ruleset。
+
+## 7. 回查发布
+
+等待 PR 合并后依次确认：
+
+1. PR 的 `mergedAt`、`mergeCommit` 和目标分支为 `main`；
+2. `Plugin Release` workflow 对该 merge commit 成功；
+3. tag 为 `<PluginId>_v<version>`；
+4. Release 标题、说明和 zip 资产版本正确；
+5. `main` 上 `package`、README 和 `plugin_version` 仍一致。
+
+若 workflow 失败，读取失败 step 和日志，修复后重新走分支 PR；不要直接改 `main`。
+
+## 常见错误
+
+| 错误 | 处理 |
+| --- | --- |
+| 只改 package 版本 | 同步 `plugin_version`，有独立 README 时同步版本日志 |
+| Required Check 一直缺失 | PR workflow 不得使用 `paths` 过滤 |
+| 本地 Hook 没执行 | 检查 `core.hooksPath`，不要覆盖已有自定义路径 |
+| PR 检查通过就宣称发布完成 | 继续回查合并、Release workflow、tag 和资产 |
+| 为所有 PR 开启 Auto-merge | 只操作本次 skill 创建并核对过 head SHA 的 PR |
+| 为赶发版使用 `--admin` 或 `--no-verify` | 修复门禁失败原因，不绕过保护 |

--- a/.agents/skills/moviepilot-plugin-release/agents/openai.yaml
+++ b/.agents/skills/moviepilot-plugin-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MoviePilot 插件发版"
+  short_description: "完整校验插件版本、提 PR、自动合并并核验 GitHub Release"
+  default_prompt: "Use $moviepilot-plugin-release to release a MoviePilot plugin through the guarded PR workflow."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/sh
+# 在对象上传前复用发布版本校验，避免市场元数据与插件自报版本分离。
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+python3 .github/scripts/check_plugin_versions.py package.json package.v2.json

--- a/.github/workflows/plugin-gate.yml
+++ b/.github/workflows/plugin-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-release-gate:
+    name: Plugin release gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check plugin versions
+        run: python .github/scripts/check_plugin_versions.py package.json package.v2.json

--- a/plugins.v2/subscribeassistantenhanced/__init__.py
+++ b/plugins.v2/subscribeassistantenhanced/__init__.py
@@ -70,7 +70,7 @@ class SubscribeAssistantEnhanced(_PluginBase):
     # 插件图标
     plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/subscribeassistantenhanced.png"
     # 插件版本
-    plugin_version = "0.2.1"
+    plugin_version = "0.2.2"
     # 插件作者
     plugin_author = "InfinityPacer"
     # 作者主页

--- a/tests/ci/test_plugin_release_gate.py
+++ b/tests/ci/test_plugin_release_gate.py
@@ -1,0 +1,129 @@
+"""验证插件版本校验在本地 push、PR 和 Release 三个入口保持一致。"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / ".github/scripts/check_plugin_versions.py"
+PRE_PUSH = REPO_ROOT / ".githooks/pre-push"
+PR_WORKFLOW = REPO_ROOT / ".github/workflows/plugin-gate.yml"
+TEST_RUNNER = REPO_ROOT / "tests/run.py"
+
+
+def _write_fixture(repo: Path, package_version: str, source_version: str) -> None:
+    """构造最小 v2 插件仓，隔离验证 checker 与 Hook 的退出码。"""
+    plugin_dir = repo / "plugins.v2/example"
+    plugin_dir.mkdir(parents=True)
+    (repo / "package.json").write_text("{}\n", encoding="utf-8")
+    (repo / "package.v2.json").write_text(
+        json.dumps(
+            {
+                "Example": {
+                    "version": package_version,
+                    "release": True,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "class Example:\n"
+        f'    plugin_version = "{source_version}"\n',
+        encoding="utf-8",
+    )
+    checker_target = repo / ".github/scripts/check_plugin_versions.py"
+    checker_target.parent.mkdir(parents=True)
+    shutil.copy2(CHECKER, checker_target)
+
+
+def test_checker_rejects_mismatched_versions(tmp_path: Path) -> None:
+    """package 与源码版本不一致时必须返回失败，防止错误资产进入发布流程。"""
+    _write_fixture(tmp_path, package_version="2.0.0", source_version="1.0.0")
+
+    result = subprocess.run(
+        ["python3", ".github/scripts/check_plugin_versions.py", "package.json", "package.v2.json"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "版本不一致" in result.stdout
+
+
+def test_pre_push_propagates_version_gate_failure(tmp_path: Path) -> None:
+    """pre-push 必须传播 checker 非零状态，确保 git push 在上传前被拒绝。"""
+    _write_fixture(tmp_path, package_version="2.0.0", source_version="1.0.0")
+    hook_target = tmp_path / ".githooks/pre-push"
+    hook_target.parent.mkdir(parents=True)
+    shutil.copy2(PRE_PUSH, hook_target)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    result = subprocess.run(
+        ["sh", ".githooks/pre-push"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "插件版本门禁失败" in result.stdout
+
+
+def test_pre_push_accepts_matching_versions(tmp_path: Path) -> None:
+    """版本一致时 pre-push 应允许上传，避免正常插件发布被误拦截。"""
+    _write_fixture(tmp_path, package_version="2.0.0", source_version="2.0.0")
+    hook_target = tmp_path / ".githooks/pre-push"
+    hook_target.parent.mkdir(parents=True)
+    shutil.copy2(PRE_PUSH, hook_target)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    result = subprocess.run(
+        ["sh", ".githooks/pre-push"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "插件版本门禁通过" in result.stdout
+
+
+def test_pr_workflow_runs_gate_for_every_main_pull_request() -> None:
+    """Required Check 不得使用 paths 过滤，否则部分 PR 会一直缺少强制状态。"""
+    workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "pull_request:" in workflow
+    assert "branches:" in workflow
+    assert "- main" in workflow
+    assert "paths:" not in workflow
+    assert "name: Plugin release gate" in workflow
+    assert "python .github/scripts/check_plugin_versions.py package.json package.v2.json" in workflow
+
+
+def test_current_repository_passes_version_gate() -> None:
+    """启用 Ruleset 前真实 main 基线必须通过，否则所有 PR 都无法合并。"""
+    result = subprocess.run(
+        ["python3", str(CHECKER), "package.json", "package.v2.json"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout
+
+
+def test_full_test_runner_includes_ci_gate_tests() -> None:
+    """push 前全量入口必须执行 CI 工具测试，防止门禁实现脱离常规回归。"""
+    runner = TEST_RUNNER.read_text(encoding="utf-8")
+
+    assert 'for generation in ("ci", "v2", "v1"):' in runner

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
-"""pytest 全局引导：按本次运行目标选择 v1/v2 插件环境并装载网络守卫。
+"""pytest 全局引导：按目标选择插件代际，CI 工具测试不加载后端。
 
 ``tests/run.py`` 会把 v1/v2 放到独立 pytest 进程中运行；这里据本次目标路径只注入对应
-插件目录，避免同一进程同时加载 ``plugins`` 与 ``plugins.v2`` 的同名包。
+插件目录，避免同一进程同时加载 ``plugins`` 与 ``plugins.v2`` 的同名包。``tests/ci``
+只校验仓库工具和 workflow，不需要 MoviePilot 运行时。
 """
 
 from __future__ import annotations
@@ -26,6 +27,8 @@ def _selected_generation(config) -> str:
             generations.add("v2")
         elif "tests/v1" in path:
             generations.add("v1")
+        elif "tests/ci" in path:
+            generations.add("ci")
     if len(generations) == 1:
         return next(iter(generations))
     raise RuntimeError("插件仓单测必须按 tests/run.py 分 v1/v2 独立会话运行，避免同名插件包冲突")
@@ -33,7 +36,10 @@ def _selected_generation(config) -> str:
 
 def pytest_configure(config) -> None:
     """收集用例前隔离 CONFIG_DIR、建表并注入对应代际插件目录。"""
-    if _selected_generation(config) == "v2":
+    generation = _selected_generation(config)
+    if generation == "ci":
+        return
+    if generation == "v2":
         prepare_v2_backend()
     else:
         prepare_v1_backend()

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,8 +1,8 @@
-"""插件仓全量单测入口：v1/v2 各自独立 pytest 会话运行，命令行参数透传给 pytest。
+"""插件仓全量单测入口：CI 工具与 v1/v2 分别运行，命令行参数透传给 pytest。
 
 plugins/（v1）与 plugins.v2/（v2）存在同名插件包，同一进程无法同时加载，故各代在
-独立子进程运行；任一代非零退出码即整体失败，无用例的代直接跳过。路径以 __file__
-推导，从任意目录调用均可。
+独立子进程运行；CI 工具测试不加载插件运行时。任一组非零退出码即整体失败，无用例的
+分组直接跳过。路径以 __file__ 推导，从任意目录调用均可。
 """
 import subprocess
 import sys
@@ -27,8 +27,8 @@ def _run_generation(generation: str, extra_args: list) -> int:
 if __name__ == "__main__":
     extra = sys.argv[1:]
     exit_code = 0
-    # v1/v2 必须分会话；按代依次跑，保留首个非零退出码作为整体结果
-    for generation in ("v2", "v1"):
+    # CI 工具与 v1/v2 分会话运行；保留首个非零退出码作为整体结果。
+    for generation in ("ci", "v2", "v1"):
         rc = _run_generation(generation, extra)
         exit_code = exit_code or rc
     sys.exit(exit_code)


### PR DESCRIPTION
## 变更说明

- 新增 PR 级 `Plugin release gate`，所有目标为 `main` 的 PR 都会校验市场版本与插件源码版本。
- 新增仓库共享的 `pre-push` Hook，在上传前复用同一版本门禁。
- 将 CI 工具测试纳入插件仓全量测试入口。
- 补齐 MoviePilot 插件发版 skill，统一版本同步、验证、PR 自动合并与 Release 回查流程。
- 修正 `SubscribeAssistantEnhanced` 已发布元数据为 `0.2.2`、源码仍声明 `0.2.1` 的版本漂移。

## 影响路径

- `.github/workflows/plugin-gate.yml`
- `.githooks/pre-push`
- `.agents/skills/moviepilot-plugin-release/`
- `tests/ci/`
- `tests/conftest.py`
- `tests/run.py`
- `plugins.v2/subscribeassistantenhanced/__init__.py`

## 验证

- 插件仓全量测试：CI 工具测试 6 项通过，插件测试 1445 项通过。
- `python .github/scripts/check_plugin_versions.py package.json package.v2.json`
- `python -m json.tool package.v2.json`
- `python -m py_compile .github/scripts/check_plugin_versions.py plugins.v2/subscribeassistantenhanced/__init__.py tests/ci/test_plugin_release_gate.py`
- `git diff --check`
- 项目内、Codex 与 Claude Code 三份 skill 均通过结构校验且内容一致。

本 PR 为 Codex 协作提交
