### PR TITLE
忽略插件前端依赖目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,9 @@ venv.bak/
 # Local linked worktrees
 .worktrees/
 
+# Node dependencies for plugin frontend builds
+node_modules/
+
 # Spyder project settings
 .spyderproject
 .spyproject


### PR DESCRIPTION
## 变更说明

- 在插件仓 `.gitignore` 中忽略 `node_modules/`，避免插件前端构建依赖缓存污染工作区。

## 影响路径

- `.gitignore`

## 验证

- `.githooks/pre-push`

本 PR 为 Codex 协作提交。
