### PR TITLE
补回订阅助手（增强版）生命周期通知收敛

### DIFF
--- a/plugins.v2/subscribeassistantenhanced/__init__.py
+++ b/plugins.v2/subscribeassistantenhanced/__init__.py
@@ -511,9 +511,11 @@ class SubscribeAssistantEnhanced(_PluginBase):
             f"跳过 {results['skipped']} 个，累计补写 {results['filled_episodes']} 集"
         )
         self._notify_subscribe(
-            "【订阅助手】洗版订阅按集优先级回填",
-            f"扫描 {results['scanned']} 个订阅，成功回填 {results['updated']} 个，"
-            f"跳过 {results['skipped']} 个，累计补写 {results['filled_episodes']} 集",
+            "洗版订阅按集优先级回填",
+            action=(
+                f"扫描 {results['scanned']} 个订阅，成功回填 {results['updated']} 个，"
+                f"跳过 {results['skipped']} 个，累计补写 {results['filled_episodes']} 集"
+            ),
         )
 
     def run_download_timeout_check(self):
@@ -989,19 +991,28 @@ class SubscribeAssistantEnhanced(_PluginBase):
             )
             subscribe_id = subscribe.id
             if action == "pause":
-                logger.info(f"无下载处理：{format_subscribe(subscribe)}(id={subscribe_id}) 上映后超期且无下载，暂停订阅")
+                logger.info(
+                    f"无下载处理：{format_subscribe(subscribe)}(id={subscribe_id}) "
+                    "原因=上映后超期且无下载，处理=暂停订阅"
+                )
                 pause_manager.pause(subscribe, PauseRecord(
                     reason="no_download",
                     since=time.time(),
                     detail="上映后超期且无下载",
                 ))
             elif action == "complete":
-                logger.info(f"无下载处理：{format_subscribe(subscribe)}(id={subscribe_id}) 上映后超期且无下载，写入完成历史并删除订阅")
+                logger.info(
+                    f"无下载处理：{format_subscribe(subscribe)}(id={subscribe_id}) "
+                    "原因=上映后超期且无下载，处理=写入完成历史并删除订阅"
+                )
                 payload = subscribe.to_dict()
                 self._subscribe_oper.add_history(**payload)
                 self._subscribe_oper.delete(subscribe_id)
             elif action == "delete":
-                logger.info(f"无下载处理：{format_subscribe(subscribe)}(id={subscribe_id}) 上映后超期且无下载，删除订阅")
+                logger.info(
+                    f"无下载处理：{format_subscribe(subscribe)}(id={subscribe_id}) "
+                    "原因=上映后超期且无下载，处理=删除订阅"
+                )
                 self._subscribe_oper.delete(subscribe_id)
             else:
                 continue
@@ -1432,14 +1443,11 @@ class SubscribeAssistantEnhanced(_PluginBase):
         action_name = {"pause": "暂停", "complete": "完成", "delete": "删除"}.get(action, action)
         days = self._config.tv_no_download_days if subscribe.type == "电视剧" else self._config.movie_no_download_days
         title = f"{self._format_subscribe_desc(subscribe, mediainfo)} 近 {days} 天未有下载记录，已标记{action_name}"
-        text_parts = []
-        if mediainfo.vote_average:
-            text_parts.append(f"评分：{mediainfo.vote_average}")
-        if subscribe.username:
-            text_parts.append(f"来自用户：{subscribe.username}")
         self._notify_subscribe(
             title,
-            "，".join(text_parts) if text_parts else None,
+            score=mediainfo.vote_average,
+            user=subscribe.username,
+            reason="上映后超期且无下载",
             image=mediainfo.get_message_image(),
             link="#/subscribe/tv?tab=mysub" if subscribe.type == "电视剧" else "#/subscribe/movie?tab=mysub",
         )
@@ -1449,30 +1457,64 @@ class SubscribeAssistantEnhanced(_PluginBase):
         """发送订阅状态变更通知，沿用状态类消息的标题和正文结构。"""
         mediainfo = mediainfo or self._recognize_mediainfo(subscribe)
         title = f"{self._format_subscribe_desc(subscribe, mediainfo)} {title_suffix}"
-        text_parts = []
-        if mediainfo and mediainfo.vote_average:
-            text_parts.append(f"评分：{mediainfo.vote_average}")
-        if subscribe.username:
-            text_parts.append(f"来自用户：{subscribe.username}")
-        if detail:
-            text_parts.append(detail)
         media_type = mediainfo.type.value if mediainfo else subscribe.type
         self._notify_subscribe(
             title,
-            "，".join(text_parts) if text_parts else None,
+            score=mediainfo.vote_average if mediainfo else None,
+            user=subscribe.username,
+            reason=detail,
             image=mediainfo.get_message_image() if mediainfo else None,
             link="#/subscribe/tv?tab=mysub" if media_type == "电视剧" else "#/subscribe/movie?tab=mysub",
         )
 
-    def _notify_subscribe(self, title, text=None, image=None, link=None):
-        """按通知开关发送订阅类通知（洗版清理等场景）。"""
+    def _notify_subscribe(self, title, text=None, image=None, link=None,
+                          score=None, user=None, reason=None, action=None,
+                          follow_up=None, next_step=None, diagnostic: bool = False):
+        """按通知开关发送订阅卡片，并统一正文字段顺序。
+
+        状态结果使用单行字段，诊断明细使用多行字段；没有值的字段不输出。
+        """
         if not self._config or not self._config.notify:
             return
         from app.schemas import NotificationType
         from app.core.config import settings
         if link and link.startswith("#"):
             link = settings.MP_DOMAIN(link)
+        text = self._format_notification_text(
+            text=text,
+            score=score,
+            user=user,
+            reason=reason,
+            action=action,
+            follow_up=follow_up if follow_up is not None else next_step,
+            diagnostic=diagnostic,
+        )
+        image = image or self.plugin_icon
         self.post_message(mtype=NotificationType.Subscribe, title=title, text=text, image=image, link=link)
+
+    @staticmethod
+    def _format_notification_text(text=None, score=None, user=None, reason=None,
+                                  action=None, follow_up=None, diagnostic: bool = False):
+        """按评分、用户、原因、处理、后续顺序生成通知正文。"""
+        fields = [
+            ("评分", score),
+            ("用户", user),
+            ("原因", reason),
+            ("处理", action),
+            ("后续", follow_up),
+        ]
+        parts = []
+        if text not in (None, ""):
+            parts.append(str(text))
+        parts.extend([
+            f"{label}：{str(value).replace(chr(10), '；')}"
+            for label, value in fields
+            if value not in (None, "")
+        ])
+        if not parts:
+            return text
+        separator = "\n" if diagnostic else "，"
+        return separator.join(parts)
 
     @staticmethod
     def _get_subscribe_image(subscribe):

--- a/plugins.v2/subscribeassistantenhanced/best_version/converter.py
+++ b/plugins.v2/subscribeassistantenhanced/best_version/converter.py
@@ -47,7 +47,7 @@ class BestVersionConverter:
                 self._clear_tasks(sid)
         except Exception as err:
             self._remove_history_snapshot(subscribe_dict)
-            logger.error(f"{subscribe_desc} 删除分集洗版订阅失败，停止转全集处理: {err}")
+            logger.error(f"{subscribe_desc} 原因=删除分集洗版订阅失败，处理=停止转全集处理，错误={err}")
             self._notify_failure(subscribe_desc, str(err), mediainfo=mediainfo)
             return False
 
@@ -57,13 +57,16 @@ class BestVersionConverter:
             new_sid, err_msg = None, str(err)
 
         if new_sid:
-            logger.info(f"{subscribe_desc} 已从分集洗版成功转为全集洗版订阅 (ID: {new_sid})")
+            logger.info(f"{subscribe_desc} 原因=分集洗版集数已符合目标集数，处理=已转为全集洗版订阅 (ID: {new_sid})")
             self._send_subscribe_added(new_sid, mediainfo)
             self._notify_success(subscribe_desc, mediainfo)
             return True
 
         restored = self._restore(subscribe_dict, mediainfo) if self._restore else False
-        logger.error(f"{subscribe_desc} 转为全集洗版订阅失败，错误信息: {err_msg}，分集订阅重建状态: {restored}")
+        logger.error(
+            f"{subscribe_desc} 原因=转为全集洗版订阅失败，处理=尝试重建分集订阅，"
+            f"错误信息={err_msg}，分集订阅重建状态={restored}"
+        )
         restore_text = "分集洗版订阅已尝试重建" if restored else "分集洗版订阅重建失败，请手动检查"
         self._notify_failure(subscribe_desc, f"{err_msg}\n{restore_text}", mediainfo=mediainfo)
         return False
@@ -101,13 +104,10 @@ class BestVersionConverter:
         """发送转全集成功通知。"""
         if not self._notify:
             return
-        text_parts = []
-        if mediainfo.vote_average:
-            text_parts.append(f"评分：{mediainfo.vote_average}")
-        text_parts.append(f"来自用户：{self._plugin_name}")
         self._notify(
-            f"{subscribe_desc} 已从分集洗版转为全集洗版订阅",
-            "，".join(text_parts),
+            f"{subscribe_desc} 分集洗版集数已符合目标集数，已从分集洗版转为全集洗版订阅",
+            score=mediainfo.vote_average,
+            user=self._plugin_name,
             image=mediainfo.get_message_image(),
             link="#/subscribe/tv?tab=mysub",
         )
@@ -117,8 +117,10 @@ class BestVersionConverter:
         if not self._notify:
             return
         self._notify(
-            f"{subscribe_desc} 转为全集洗版订阅失败！",
-            text,
+            f"{subscribe_desc} 转为全集洗版订阅失败",
+            text=text,
+            follow_up="请检查订阅状态",
+            diagnostic=True,
             image=mediainfo.get_message_image() if mediainfo else None,
         )
 

--- a/plugins.v2/subscribeassistantenhanced/best_version/orchestrator.py
+++ b/plugins.v2/subscribeassistantenhanced/best_version/orchestrator.py
@@ -130,22 +130,30 @@ class BestVersionOrchestrator:
         sid, err_msg = self._subscribe_oper.add(mediainfo=mediainfo, **payload)
         if sid:
             mode_label = "电影洗版" if is_movie else "全集洗版"
-            logger.info(f"洗版编排：{format_subscribe_desc(subscribe)} 已创建{mode_label}订阅（id={sid}）")
+            logger.info(
+                f"洗版编排：{format_subscribe_desc(subscribe)} "
+                f"原因=订阅完成，处理=已创建{mode_label}订阅（id={sid}）"
+            )
             if self._send_subscribe_added:
                 self._send_subscribe_added(sid, mediainfo, username=self._plugin_name)
             if self._notify:
-                text = f"评分：{mediainfo.vote_average}，来自用户：{self._plugin_name}"
                 self._notify(
                     f"{format_subscribe_desc(subscribe)} 已添加{mode_label}订阅",
-                    text,
+                    score=mediainfo.vote_average,
+                    user=self._plugin_name,
                     image=mediainfo.get_message_image(),
                     link="#/subscribe/movie?tab=mysub" if is_movie else "#/subscribe/tv?tab=mysub",
                 )
         elif self._notify:
-            logger.error(f"洗版编排：{format_subscribe_desc(subscribe)} 添加洗版订阅失败：{err_msg}")
+            logger.error(
+                f"洗版编排：{format_subscribe_desc(subscribe)} "
+                f"原因=添加洗版订阅失败，处理=请检查订阅创建错误，错误={err_msg}"
+            )
             self._notify(
-                f"{format_subscribe_desc(subscribe)} 添加洗版订阅失败！",
-                err_msg,
+                f"{format_subscribe_desc(subscribe)} 添加洗版订阅失败",
+                reason=err_msg,
+                follow_up="请检查订阅创建错误",
+                diagnostic=True,
                 image=mediainfo.get_message_image(),
             )
         return sid
@@ -257,16 +265,21 @@ class BestVersionOrchestrator:
         actual_desc = StringUtils.format_ep(actual_episodes) if actual_episodes else "未知"
         source_desc = source or "未知来源"
         logger.warning(
-            f"洗版清理：{format_subscribe_desc(subscribe)} 当前全集资源未覆盖订阅目标范围，"
-            f"跳过旧整理记录清理；目标集数={target_desc}，资源集数={actual_desc}，"
-            f"来源={source_desc}，种子={torrent_title}"
+            f"洗版清理：{format_subscribe_desc(subscribe)} "
+            f"原因=全集资源未覆盖订阅目标范围（目标集数={target_desc}，资源集数={actual_desc}，"
+            f"来源={source_desc}，种子={torrent_title}），处理=已跳过历史清理，后续=请人工核对资源覆盖范围"
         )
         if self._notify:
             image = self._get_subscribe_image(subscribe) if self._get_subscribe_image else None
             self._notify(
                 f"{format_subscribe_desc(subscribe)} 洗版资源未覆盖目标范围，已跳过历史清理",
-                f"目标集数：{target_desc}\n资源集数：{actual_desc}\n"
-                f"来源：{source_desc}\n种子：{torrent_title}",
+                text=(
+                    f"目标集数：{target_desc}\n"
+                    f"资源集数：{actual_desc}\n"
+                    f"种子：{torrent_title}"
+                ),
+                follow_up="请人工核对资源覆盖范围",
+                diagnostic=True,
                 image=image,
             )
 
@@ -404,8 +417,8 @@ class BestVersionOrchestrator:
 
         if self._notify:
             self._notify(
-                f"{format_subscribe_desc(subscribe)} 即将开始{mode_label}下载",
-                f"{mode_label}已删除 {len(histories)} 条整理记录对应的源文件",
+                f"{format_subscribe_desc(subscribe)} "
+                f"即将开始{mode_label}下载，已删除 {len(histories)} 条整理记录对应的源文件",
                 image=subscribe_image,
             )
 
@@ -488,8 +501,8 @@ class BestVersionOrchestrator:
         )
         if self._notify:
             self._notify(
-                f"{(task or {}).get('subscribe_desc', '洗版订阅')} 即将开始{mode_label}整理",
-                f"{mode_label}已删除 {len(histories)} 条整理记录对应的媒体库文件",
+                f"{(task or {}).get('subscribe_desc', '洗版订阅')} "
+                f"即将开始{mode_label}整理，已删除 {len(histories)} 条整理记录对应的媒体库文件",
                 image=(task or {}).get("subscribe_image"),
             )
         return True

--- a/plugins.v2/subscribeassistantenhanced/download/cleanup.py
+++ b/plugins.v2/subscribeassistantenhanced/download/cleanup.py
@@ -101,20 +101,28 @@ class TorrentCleanup:
         if not self._notify:
             return
         torrent_task = self._read_torrent_task(torrent_hash) or {}
-        msg_parts = []
+        detail_parts = []
         if torrent_task.get("title"):
-            msg_parts.append(f"标题：{torrent_task.get('title')}")
+            detail_parts.append(f"标题：{torrent_task.get('title')}")
         if torrent_task.get("description"):
-            msg_parts.append(f"内容：{torrent_task.get('description')}")
-        msg_parts.extend([
-            f"原因：{reason_detail}",
-            f"处理：已保留当前种子，{ignore_hours} 小时内不再自动删除，请手动判断",
-        ])
+            detail_parts.append(f"内容：{torrent_task.get('description')}")
+        action = f"已保留当前种子，{ignore_hours} 小时内不再自动删除"
+        detail(f"种子删除处理：{format_subscribe(subscribe)} 原因={reason_detail}，处理={action}，后续=请手动判断")
         self._notify(
-            f"{format_subscribe(subscribe)} 下载连续超时，请手动处理",
-            "\n".join(msg_parts),
+            f"{format_subscribe(subscribe)} {self._manual_review_title_reason(reason_detail)}，{action}",
+            "\n".join(detail_parts) if detail_parts else None,
             image=self._subscribe_image(subscribe),
+            follow_up="请手动判断",
+            diagnostic=True,
         )
+
+    @staticmethod
+    def _manual_review_title_reason(reason_detail: str) -> str:
+        """将低进度诊断改写为通知标题语序，保留下载时长与进度判断信息。"""
+        prefix = "订阅种子，"
+        if reason_detail.startswith(prefix):
+            return f"{prefix}下载连续超时，{reason_detail[len(prefix):]}"
+        return f"下载连续超时，{reason_detail}"
 
     def _read_torrent_task(self, torrent_hash: str) -> Optional[dict]:
         """删除前读取种子任务，供删除指纹归档与按集基线回滚。"""
@@ -181,18 +189,25 @@ class TorrentCleanup:
             "manual": "订阅种子手动删除",
             "download_timeout": "超时无进度",
         }.get(reason, reason)
-        msg_parts = []
+        detail_parts = []
         if torrent_task:
             if torrent_task.get("title"):
-                msg_parts.append(f"标题：{torrent_task.get('title')}")
+                detail_parts.append(f"标题：{torrent_task.get('title')}")
             if torrent_task.get("description"):
-                msg_parts.append(f"内容：{torrent_task.get('description')}")
+                detail_parts.append(f"内容：{torrent_task.get('description')}")
+        follow_up = None
         if search_delay_seconds is not None:
-            msg_parts.append(f"补全：将在 {search_delay_seconds / 60:.2f} 分钟 后触发搜索")
+            follow_up = f"将在 {search_delay_seconds / 60:.2f} 分钟后触发搜索补全"
+        detail(
+            f"种子删除处理：{format_subscribe(subscribe)} 原因={reason_detail or reason_text}，"
+            f"处理=已删除，后续={follow_up or '无'}"
+        )
         self._notify(
             f"{format_subscribe(subscribe)} {reason_detail or reason_text}，已删除",
-            "\n".join(msg_parts) if msg_parts else None,
+            "\n".join(detail_parts) if detail_parts else None,
             image=self._subscribe_image(subscribe),
+            follow_up=follow_up,
+            diagnostic=True,
         )
 
     def _subscribe_image(self, subscribe):

--- a/plugins.v2/subscribeassistantenhanced/download/monitor.py
+++ b/plugins.v2/subscribeassistantenhanced/download/monitor.py
@@ -9,7 +9,7 @@ from app.log import logger
 from .torrent import TorrentInfo
 from ..shared.log import detail
 
-TIMEOUT_MANUAL_REVIEW_IGNORE_HOURS = 48
+TIMEOUT_MANUAL_REVIEW_IGNORE_HOURS = 24
 
 
 class DownloadMonitor:

--- a/plugins.v2/subscribeassistantenhanced/postcheck/verifier.py
+++ b/plugins.v2/subscribeassistantenhanced/postcheck/verifier.py
@@ -126,8 +126,10 @@ class CompletionVerifier:
 
         if self._notify:
             name = config.get("name", f"TMDB {tmdbid}")
+            season = config.get("season", season)
+            season_text = f" S{season}" if season is not None else ""
             self._notify(
-                f"检测到 {name} 新增集数（{old_total}→{current_total}），已自动重建订阅"
+                f"{name}{season_text} 检测到新增集数（{old_total}→{current_total}），已自动重建订阅",
             )
         return True
 

--- a/tests/v2/subscribeassistantenhanced/test_cleanup.py
+++ b/tests/v2/subscribeassistantenhanced/test_cleanup.py
@@ -163,10 +163,14 @@ class TestHandleTorrentDeleted:
         search_fn.assert_called_once_with(sub)
         assert "h1" not in store.get("torrents", {})
         notify.assert_called_once()
-        title, text = notify.call_args.args[:2]
+        title = notify.call_args.args[0]
         assert "订阅种子，下载时长 2.00 小时" in title
         assert "（低进度删除 1/3 次），已删除" in title
-        assert "补全：将在 4.78 分钟 后触发搜索" in text
+        assert notify.call_args.args[1] == "标题：测试种子\n内容：测试内容"
+        assert "reason" not in notify.call_args.kwargs
+        assert "action" not in notify.call_args.kwargs
+        assert notify.call_args.kwargs["follow_up"] == "将在 4.78 分钟后触发搜索补全"
+        assert notify.call_args.kwargs["diagnostic"] is True
         assert notify.call_args.kwargs["image"] == "subscribe.jpg"
 
     def test_manual_review_notification_keeps_torrent(self):
@@ -189,9 +193,15 @@ class TestHandleTorrentDeleted:
         )
 
         assert "h1" in store["torrents"]
-        assert "下载连续超时，请手动处理" in notify.call_args.args[0]
-        assert "低进度删除 3/3 次" in notify.call_args.args[1]
-        assert "已保留当前种子，6 小时内不再自动删除" in notify.call_args.args[1]
+        assert notify.call_args.args[0] == (
+            "测试剧 S1 订阅种子，下载连续超时，下载时长 6.00 小时，超时窗口 2 小时内进度增长 0.00%，"
+            "低于 10%（低进度删除 3/3 次），已保留当前种子，6 小时内不再自动删除"
+        )
+        assert notify.call_args.args[1] == "标题：测试种子\n内容：测试内容"
+        assert "reason" not in notify.call_args.kwargs
+        assert "action" not in notify.call_args.kwargs
+        assert notify.call_args.kwargs["follow_up"] == "请手动判断"
+        assert notify.call_args.kwargs["diagnostic"] is True
         assert notify.call_args.kwargs["image"] == "subscribe.jpg"
 
     def test_manual_delete_skips_pause_but_keeps_fingerprint_and_search(self):

--- a/tests/v2/subscribeassistantenhanced/test_converter.py
+++ b/tests/v2/subscribeassistantenhanced/test_converter.py
@@ -69,7 +69,8 @@ class TestConvertToFull:
         send_event.assert_called_once()
         assert send_event.call_args.args[1]["subscribe_id"] == 9
         notify.assert_called_once()
-        assert notify.call_args.args[0] == "测试剧 S1 已从分集洗版转为全集洗版订阅"
+        assert notify.call_args.args[0] == "测试剧 S1 分集洗版集数已符合目标集数，已从分集洗版转为全集洗版订阅"
+        assert "reason" not in notify.call_args.kwargs
 
     def test_failure_keeps_original(self):
         """删除分集订阅失败时不得创建全集洗版，并通知失败。"""
@@ -88,7 +89,7 @@ class TestConvertToFull:
         oper.add.assert_not_called()
         oper.remove_history.assert_called_once()
         notify.assert_called_once()
-        assert notify.call_args.args[0] == "测试剧 S1 转为全集洗版订阅失败！"
+        assert notify.call_args.args[0] == "测试剧 S1 转为全集洗版订阅失败"
 
     def test_no_oper_returns_false(self):
         conv = BestVersionConverter(subscribe_oper=None)
@@ -103,7 +104,7 @@ class TestConvertToFull:
     def test_add_failure_restores_old_subscribe_and_notifies(self):
         """创建全集洗版失败时应尝试重建分集订阅并通知人工检查。"""
         oper = MagicMock()
-        oper.add.return_value = (None, "add failed")
+        oper.add.return_value = (None, "订阅创建失败")
         restore = MagicMock(return_value=True)
         notify = MagicMock()
         conv = BestVersionConverter(
@@ -120,4 +121,9 @@ class TestConvertToFull:
 
         restore.assert_called_once_with(sub.to_dict(), media)
         notify.assert_called_once()
-        assert "分集洗版订阅已尝试重建" in notify.call_args.args[1]
+        assert notify.call_args.args[0] == "测试剧 S1 转为全集洗版订阅失败"
+        assert notify.call_args.kwargs["text"] == "订阅创建失败\n分集洗版订阅已尝试重建"
+        assert "reason" not in notify.call_args.kwargs
+        assert "action" not in notify.call_args.kwargs
+        assert notify.call_args.kwargs["follow_up"] == "请检查订阅状态"
+        assert notify.call_args.kwargs["diagnostic"] is True

--- a/tests/v2/subscribeassistantenhanced/test_monitor.py
+++ b/tests/v2/subscribeassistantenhanced/test_monitor.py
@@ -3,9 +3,14 @@ import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from subscribeassistantenhanced.download.monitor import DownloadMonitor
+from subscribeassistantenhanced.download.monitor import DownloadMonitor, TIMEOUT_MANUAL_REVIEW_IGNORE_HOURS
 from subscribeassistantenhanced.download.torrent import TorrentInfo
 from subscribeassistantenhanced.pending.state import PendingStateCoordinator
+
+
+def test_timeout_manual_review_ignore_hours_is_twenty_four():
+    """连续超时人工保护期与通知文案保持一致。"""
+    assert TIMEOUT_MANUAL_REVIEW_IGNORE_HOURS == 24
 
 
 def _store_mgr(store=None):
@@ -358,6 +363,35 @@ class TestCheckTorrent:
 
         assert result == "ignored"
         assert store["subscribes"]["1"]["timeout_states"]["tv:unknown:1"]["fail_count"] == 3
+
+    def test_timeout_after_ignore_expired_reenters_manual_review(self):
+        """连续超时保护期过后仍低进度时重新进入人工处理，不直接删除当前种子。"""
+        now = time.time()
+        store = {
+            "torrents": {"h1": {
+                "baseline_progress": 0.5, "baseline_at": now - 7200,
+                "subscribe_id": 1, "episodes": [1],
+            }},
+            "subscribes": {"1": {"timeout_states": {
+                "tv:unknown:1": {
+                    "fail_count": 3,
+                    "last_torrent_hash": "h1",
+                    "ignore_until": now - 1,
+                    "window_start": now - 60,
+                },
+            }}},
+        }
+        read, update, _ = _store_mgr(store)
+        oper = MagicMock()
+        oper.get.return_value = SimpleNamespace(id=1, type="电视剧", season=None)
+        mon = DownloadMonitor(read, update, timeout_minutes=60, retry_limit=3, subscribe_oper=oper)
+
+        result = mon.check_torrent(_info(hash="h1", progress=0.5), subscribe_id=1)
+
+        assert result == "manual_review"
+        state = store["subscribes"]["1"]["timeout_states"]["tv:unknown:1"]
+        assert state["fail_count"] == 4
+        assert state["ignore_until"] > now
 
     def test_timeout_window_expired_resets_scope_count(self):
         """连续低进度统计窗口过期后，旧计数清零并从本次重新开始。"""

--- a/tests/v2/subscribeassistantenhanced/test_orchestrator.py
+++ b/tests/v2/subscribeassistantenhanced/test_orchestrator.py
@@ -146,8 +146,10 @@ class TestHistoryClear:
         assert events == [("/src/a.mkv", "hashA")]   # 携带旧 download_hash → 主程序删历史种子
         assert hist_deletes == ["1"]
         assert "100" in store["best_version_clear_histories"]   # 快照 key 为 str(tmdbid)
-        assert notifies[0][0].endswith("即将开始全集洗版下载")
-        assert "全集洗版" in notifies[0][1]
+        assert notifies[0][0].endswith("即将开始全集洗版下载，已删除 1 条整理记录对应的源文件")
+        assert notifies[0][1] is None
+        assert "reason" not in notifies[0][2]
+        assert "action" not in notifies[0][2]
         assert notifies[0][2]["image"] == "subscribe.jpg"
         assert store["best_version_clear_histories"]["100"]["subscribe_image"] == "subscribe.jpg"
 
@@ -233,10 +235,15 @@ class TestHistoryClear:
         assert events == []
         assert hist_deletes == []
         assert notify.call_args.args[0].endswith("洗版资源未覆盖目标范围，已跳过历史清理")
-        assert "目标集数：" in notify.call_args.args[1]
-        assert "资源集数：" in notify.call_args.args[1]
-        assert "来源：下载事件" in notify.call_args.args[1]
-        assert "种子：测试剧 S01E01-E02" in notify.call_args.args[1]
+        assert notify.call_args.kwargs["text"] == (
+            "目标集数：E01-E12\n"
+            "资源集数：E01-E02\n"
+            "种子：测试剧 S01E01-E02"
+        )
+        assert "reason" not in notify.call_args.kwargs
+        assert "action" not in notify.call_args.kwargs
+        assert notify.call_args.kwargs["follow_up"] == "请人工核对资源覆盖范围"
+        assert notify.call_args.kwargs["diagnostic"] is True
         assert notify.call_args.kwargs["image"] == "subscribe.jpg"
 
     def test_movie_clear_type_skips_tv_subscription(self):
@@ -411,8 +418,9 @@ class TestHistoryClear:
         orch.handle_history_clear(event)
         assert deletes == [{"path": "/dest/a.mkv"}]
         assert "100" not in store["best_version_clear_histories"]
-        assert notifies[0][0] == "X 即将开始全集洗版整理"
-        assert "全集洗版" in notifies[0][1]
+        assert notifies[0][0] == "X 即将开始全集洗版整理，已删除 1 条整理记录对应的媒体库文件"
+        assert "reason" not in notifies[0][2]
+        assert "action" not in notifies[0][2]
         assert notifies[0][2]["image"] == "subscribe.jpg"
 
     def test_transfer_intercept_without_snapshot_returns_false(self):
@@ -497,6 +505,7 @@ class TestStartBestVersion:
         assert send_event.call_args.args[0] == 5
         notify.assert_called_once()
         assert notify.call_args.args[0].endswith("已添加全集洗版订阅")
+        assert "reason" not in notify.call_args.kwargs
         _args, kwargs = oper.add.call_args
         assert kwargs["best_version"] == 1 and kwargs["season"] == 1
         assert kwargs["best_version_full"] == 1
@@ -521,8 +530,11 @@ class TestStartBestVersion:
 
         assert sid is None
         notify.assert_called_once()
-        assert notify.call_args.args[0].endswith("添加洗版订阅失败！")
-        assert notify.call_args.args[1] == "订阅已存在"
+        assert notify.call_args.args[0].endswith("添加洗版订阅失败")
+        assert notify.call_args.kwargs["reason"] == "订阅已存在"
+        assert "action" not in notify.call_args.kwargs
+        assert notify.call_args.kwargs["follow_up"] == "请检查订阅创建错误"
+        assert notify.call_args.kwargs["diagnostic"] is True
         assert notify.call_args.kwargs["image"] == "poster.jpg"
 
     def test_skips_when_already_best_version(self):

--- a/tests/v2/subscribeassistantenhanced/test_plugin_integration.py
+++ b/tests/v2/subscribeassistantenhanced/test_plugin_integration.py
@@ -918,12 +918,66 @@ def test_backfill_best_version_now_scans_existing_subscriptions_and_resets_flag(
 
     priority_manager.backfill_existing.assert_called_once_with(sub, [3])
     plugin.post_message.assert_called_once()
-    assert plugin.post_message.call_args.kwargs["title"] == "【订阅助手】洗版订阅按集优先级回填"
+    assert plugin.post_message.call_args.kwargs["title"] == "洗版订阅按集优先级回填"
     assert "扫描 1 个订阅" in plugin.post_message.call_args.kwargs["text"]
     assert "成功回填 1 个" in plugin.post_message.call_args.kwargs["text"]
     assert "累计补写 1 集" in plugin.post_message.call_args.kwargs["text"]
     plugin.update_config.assert_called_once()
     assert plugin.update_config.call_args.args[0]["backfill_best_version_now"] is False
+
+
+def test_status_notification_uses_ordered_single_line_fields(monkeypatch):
+    """状态类订阅通知按评分、用户、原因顺序输出单行正文，并带订阅卡片图片。"""
+    plugin = SubscribeAssistantEnhanced()
+    plugin.init_plugin({"notify": True})
+    plugin.post_message = MagicMock()
+    plugin._recognize_mediainfo = MagicMock(return_value=_mediainfo())
+
+    plugin._send_subscribe_status_notification(
+        _sub(username="tester"),
+        "上映满足订阅暂停，已标记暂停",
+        detail="暂未到订阅窗口",
+    )
+
+    kwargs = plugin.post_message.call_args.kwargs
+    assert kwargs["title"] == "测试 (2026) S1 上映满足订阅暂停，已标记暂停"
+    assert kwargs["text"] == "评分：8.0，用户：tester，原因：暂未到订阅窗口"
+    assert kwargs["image"] == "poster.jpg"
+
+
+def test_no_download_notification_does_not_repeat_title_action():
+    """无下载通知标题已包含处理结果，正文只保留判断依据。"""
+    plugin = SubscribeAssistantEnhanced()
+    plugin.init_plugin({"notify": True, "tv_no_download_days": 30})
+    plugin.post_message = MagicMock()
+
+    plugin._send_no_download_notification(_sub(username="tester"), _mediainfo(), "pause")
+
+    kwargs = plugin.post_message.call_args.kwargs
+    assert kwargs["title"] == "测试 (2026) S1 近 30 天未有下载记录，已标记暂停"
+    assert kwargs["text"] == "评分：8.0，用户：tester，原因：上映后超期且无下载"
+    assert "处理：" not in kwargs["text"]
+
+
+def test_diagnostic_notification_uses_ordered_multiline_fields():
+    """诊断类订阅通知按统一字段顺序输出多行正文，缺失字段不生成空行。"""
+    plugin = SubscribeAssistantEnhanced()
+    plugin.init_plugin({"notify": True})
+    plugin.post_message = MagicMock()
+
+    plugin._notify_subscribe(
+        "测试剧 S1 下载连续超时，请手动处理",
+        text="低进度删除 3/3 次",
+        follow_up="请手动判断",
+        diagnostic=True,
+    )
+
+    kwargs = plugin.post_message.call_args.kwargs
+    assert kwargs["text"] == (
+        "低进度删除 3/3 次\n"
+        "后续：请手动判断"
+    )
+    assert kwargs["image"] == plugin.plugin_icon
 
 
 def test_backfill_best_version_now_skips_full_best_version_before_detection(monkeypatch):

--- a/tests/v2/subscribeassistantenhanced/test_verifier.py
+++ b/tests/v2/subscribeassistantenhanced/test_verifier.py
@@ -95,7 +95,7 @@ class TestVerifyAll:
         store = {"snapshots": {"list": [{
             "tmdbid": 100, "season": 1, "episode_group_id": None,
             "total_at_completion": 12, "completed_at": time.time(),
-            "subscribe_config": {"name": "测试"},
+            "subscribe_config": {"name": "测试剧", "season": 1},
         }]}}
         rebuild = MagicMock(return_value=True)
         v = _verifier(store, tmdb_fn=lambda *a, **kw: [object()] * 15,
@@ -103,6 +103,10 @@ class TestVerifyAll:
         v.verify_all()
         rebuild.assert_called_once()
         assert len(store["snapshots"]["list"]) == 0
+        v._notify_mock.assert_called_once()
+        assert v._notify_mock.call_args.args[0] == "测试剧 S1 检测到新增集数（12→15），已自动重建订阅"
+        assert "action" not in v._notify_mock.call_args.kwargs
+        assert "reason" not in v._notify_mock.call_args.kwargs
 
     def test_rebuild_failure_keeps_snapshot_for_retry(self):
         """真实重建失败时必须保留快照，避免丢失后续补救机会。"""


### PR DESCRIPTION
## 变更说明

- 补回订阅助手（增强版）生命周期通知收敛逻辑。
- 订阅状态、无下载处理、洗版回填、删种和清理类通知统一使用订阅卡片结构。
- 通知正文按评分、用户、原因、处理、后续等字段稳定展示，诊断类明细使用多行格式。
- 本 PR 不修改插件版本号、package 发布记录或 README 版本日志，不触发新版本发版。

## 影响路径

- plugins.v2/subscribeassistantenhanced/
- tests/v2/subscribeassistantenhanced/

## 验证结果

- MOVIEPILOT_BACKEND_PATH=<workspace>/MoviePilot <workspace>/.venv-test/bin/python -m pytest tests/v2/subscribeassistantenhanced -q：689 passed
- MOVIEPILOT_BACKEND_PATH=<workspace>/MoviePilot <workspace>/.venv-test/bin/python tests/run.py -q：1479 passed
- python .github/scripts/check_plugin_versions.py package.json package.v2.json
- python -m json.tool package.v2.json
- <workspace>/.venv-test/bin/python -m compileall -q plugins.v2/subscribeassistantenhanced
- git diff --check

本 PR 为 Codex 协作提交。
