### PR TITLE
优化订阅助手增强版订阅日志标签

### DIFF
--- a/plugins.v2/subscribeassistantenhanced/events.py
+++ b/plugins.v2/subscribeassistantenhanced/events.py
@@ -45,23 +45,23 @@ class EventProxy:
     def get(self, name):
         return self._modules.get(name)
 
-    def _format_subscribe_label(self, subscribe_id):
-        """按订阅 ID 生成日志标签；查库成功时带名称/季号/ID，失败时保留 ID 兜底。"""
+    def _format_subscribe_label(self, subscribe_id, subscribe_info=None):
+        """按订阅 ID 生成日志标签；事件快照或查库成功时带名称、季号和 ID。"""
         if subscribe_id is None:
             return "未知订阅"
+        if isinstance(subscribe_info, dict) and subscribe_info:
+            return format_subscribe_label(SimpleNamespace(**subscribe_info), subscribe_id)
         subscribe_oper = self.get("subscribe_oper")
         subscribe = subscribe_oper.get(subscribe_id) if subscribe_oper else None
         return format_subscribe_label(subscribe, subscribe_id)
 
     @staticmethod
     def _format_episodes_refresh_label(data: SubscribeEpisodesRefreshEventData) -> str | None:
-        """格式化集数刷新事件来源；创建场景无订阅 ID 时用媒体信息兜底。"""
-        subscribe_id = data.subscribe_id
-        if subscribe_id is not None:
-            return None
+        """格式化集数刷新事件来源；订阅不可查或创建场景用媒体信息兜底。"""
+        subscribe_id = getattr(data, "subscribe_id", None)
         parts = []
-        mediainfo = data.mediainfo
-        tmdbid = data.tmdbid
+        mediainfo = getattr(data, "mediainfo", None)
+        tmdbid = getattr(data, "tmdbid", None)
         if isinstance(mediainfo, MediaInfo):
             if mediainfo.title_year:
                 parts.append(mediainfo.title_year)
@@ -75,14 +75,17 @@ class EventProxy:
                 parts.append(label)
             if tmdbid is None:
                 tmdbid = mediainfo.get("tmdb_id")
-        season = data.season
+        season = getattr(data, "season", None)
         if season is not None:
             parts.append(f"S{season}")
         markers = []
+        if subscribe_id:
+            markers.append(f"id={subscribe_id}")
         if tmdbid:
             markers.append(f"tmdbid={tmdbid}")
-        if data.scene:
-            markers.append(f"scene={data.scene}")
+        scene = getattr(data, "scene", None)
+        if scene:
+            markers.append(f"scene={scene}")
         if markers:
             marker_text = f"({', '.join(markers)})"
             if parts:
@@ -105,7 +108,14 @@ class EventProxy:
         data: SubscribeEpisodesRefreshEventData = _event_data(event)
         if data is None:
             return
-        label = self._format_episodes_refresh_label(data) or self._format_subscribe_label(data.subscribe_id)
+        label = None
+        if data.subscribe_id is not None:
+            label = self._format_subscribe_label(data.subscribe_id)
+            if label == f"订阅 {data.subscribe_id}":
+                label = self._format_episodes_refresh_label(data) or label
+        else:
+            label = self._format_episodes_refresh_label(data)
+        label = label or "未知订阅"
         detail(f"集数刷新事件：{label} 当前总集数 {data.current_total_episode}")
         volatility = self.get("volatility")
         if volatility:
@@ -213,9 +223,10 @@ class EventProxy:
         """SubscribeDeleted → 清理该订阅关联的全部任务数据（订阅任务 + 名下种子任务）。"""
         data = event.event_data
         subscribe_id = data.get("subscribe_id") if isinstance(data, dict) else None
+        subscribe_info = data.get("subscribe_info") if isinstance(data, dict) else None
         task_manager = self.get("task_manager")
         if subscribe_id and task_manager:
-            detail(f"订阅删除事件：清理 {self._format_subscribe_label(subscribe_id)} 关联任务数据")
+            detail(f"订阅删除事件：清理 {self._format_subscribe_label(subscribe_id, subscribe_info)} 关联任务数据")
             task_manager.clear_tasks(subscribe_id)
 
     def on_subscribe_modified(self, event):

--- a/tests/v2/subscribeassistantenhanced/test_events.py
+++ b/tests/v2/subscribeassistantenhanced/test_events.py
@@ -79,6 +79,21 @@ class TestEventOrdering:
         assert data.updated is True
         assert data.total_episode == 8
 
+    def test_episodes_refresh_label_uses_media_when_subscribe_missing(self):
+        """集数刷新事件查不到订阅时，日志标签应回退到事件携带的媒体信息。"""
+        from app.schemas.event import SubscribeEpisodesRefreshEventData
+
+        data = SubscribeEpisodesRefreshEventData(
+            current_total_episode=15,
+            subscribe_id=32,
+            season=1,
+            tmdbid=325228,
+            mediainfo={"title": "镖人", "year": 2023},
+            scene="refresh",
+        )
+
+        assert EventProxy._format_episodes_refresh_label(data) == "镖人 (2023) S1(id=32, tmdbid=325228, scene=refresh)"
+
     def test_download_added_registers_monitor_without_resuming(self):
         """DownloadAdded → 仅经 source 解析订阅后登记监控数据，不在此处恢复暂停。"""
         sub = _sub(id=1, state="S")
@@ -319,6 +334,15 @@ class TestSubscribeLifecycle:
         proxy = EventProxy(task_manager=tm)
         proxy.on_subscribe_deleted(SimpleNamespace(event_data={"subscribe_id": 9}))
         tm.clear_tasks.assert_called_once_with(9)
+
+    def test_deleted_label_uses_event_subscribe_snapshot(self):
+        """删除事件发生后订阅可能已不可查，日志标签应使用事件携带的订阅快照。"""
+        proxy = EventProxy()
+        label = proxy._format_subscribe_label(
+            9,
+            {"id": 9, "name": "将夜", "season": 1},
+        )
+        assert label == "将夜 S1(id=9)"
 
     def test_deleted_without_id_noop(self):
         tm = MagicMock()


### PR DESCRIPTION
## 变更说明

- 订阅删除事件优先使用事件携带的 `subscribe_info` 快照格式化日志标签，避免删除后查不到订阅时只显示 `订阅 ID`。
- 集数刷新事件在订阅对象不可查时，使用事件携带的媒体名、季号、TMDB ID 和触发场景生成可读日志标签。
- 保留确实无法取得订阅或媒体信息时的 `订阅 ID` 兜底。

## 影响路径

- `plugins.v2/subscribeassistantenhanced/events.py`
- `tests/v2/subscribeassistantenhanced/test_events.py`

## 验证

- `.githooks/pre-push`
- `MOVIEPILOT_BACKEND_PATH=<workspace>/MoviePilot <workspace>/.venv-test/bin/python -m pytest tests/v2/subscribeassistantenhanced`
- `MOVIEPILOT_BACKEND_PATH=<workspace>/MoviePilot <workspace>/.venv-test/bin/python tests/run.py -q`
- `python .github/scripts/check_plugin_versions.py package.json package.v2.json`
- `python -m json.tool package.v2.json`
- `python -m compileall -q plugins.v2/subscribeassistantenhanced`
- `git diff --check`

## 说明

本 PR 为 Codex 协作提交。

本次仅合并日志优化，不做版本发布。
