### PR TITLE
修正订阅助手增强版状态通知文案

### DIFF
--- a/plugins.v2/subscribeassistantenhanced/pause/airing.py
+++ b/plugins.v2/subscribeassistantenhanced/pause/airing.py
@@ -48,7 +48,7 @@ class AiringPauseChecker:
                 return PauseRecord(
                     reason="pre_air",
                     since=0.0,
-                    detail=f"电影 {release_date} 上映，暂未到订阅窗口",
+                    detail=f"{release_date} 上映，暂未到订阅窗口",
                 )
             return None
 
@@ -73,7 +73,7 @@ class AiringPauseChecker:
             return PauseRecord(
                 reason="pre_air",
                 since=0.0,
-                detail=f"电视剧 {air_date} 开播，暂未到订阅窗口",
+                detail=f"{air_date} 开播，暂未到订阅窗口",
             )
         return None
 

--- a/plugins.v2/subscribeassistantenhanced/pause/manager.py
+++ b/plugins.v2/subscribeassistantenhanced/pause/manager.py
@@ -1,4 +1,5 @@
 """域 ④：暂停管理——优先级覆盖 + 用户名自动暂停 + 双向恢复。"""
+import re
 import time
 from typing import Callable, Optional
 
@@ -160,13 +161,33 @@ class PauseManager:
         """发送暂停恢复状态通知。"""
         if not self._notify:
             return
+        reason_key = record.reason if record else ""
         reason = {
             "pre_air": "上映",
             "airing_gap": "播出",
             "auto_user": "用户规则",
-        }.get(record.reason if record else "", "暂停")
+        }.get(reason_key, "暂停")
+        detail = self._resume_detail(reason_key, record)
         self._notify(
             subscribe,
             f"{reason}不再满足订阅暂停，已标记订阅中",
-            detail=record.detail if record else None,
+            detail=detail,
         )
+
+    @staticmethod
+    def _resume_detail(reason_key: str, record: Optional[PauseRecord]) -> str:
+        """生成恢复通知正文，保留原暂停窗口上下文但改写为当前状态。"""
+        pause_detail = record.detail if record else ""
+        if reason_key == "pre_air":
+            pause_detail = re.sub(r"^(?:电影|电视剧)\s+", "", pause_detail)
+            if pause_detail and "暂未到订阅窗口" in pause_detail:
+                return pause_detail.replace("暂未到订阅窗口", "已进入订阅窗口")
+            return "已进入订阅窗口"
+        if reason_key == "airing_gap":
+            match = re.search(r"(下一集\s+\d{4}-\d{2}-\d{2})", pause_detail)
+            if match:
+                return f"{match.group(1)}，已进入播出窗口"
+            return "已进入播出窗口"
+        if reason_key == "auto_user":
+            return "用户规则暂停已解除"
+        return "暂停条件已解除"

--- a/plugins.v2/subscribeassistantenhanced/pending/judge.py
+++ b/plugins.v2/subscribeassistantenhanced/pending/judge.py
@@ -114,8 +114,9 @@ class PendingJudge:
             source=self._read_subscribe_task(subscribe).get("source", "pending_judge"),
             reason=reason,
         )
-        self._notify_status(subscribe, "不再满足上映待定，已标记订阅中", detail=reason)
-        if not restored:
+        if restored:
+            self._notify_status(subscribe, "不再满足上映待定，已标记订阅中", detail=reason)
+        else:
             self._update_subscribe_task(subscribe, {
                 "exit_reason": reason,
                 "exit_at": time.time(),

--- a/tests/v2/subscribeassistantenhanced/test_pause.py
+++ b/tests/v2/subscribeassistantenhanced/test_pause.py
@@ -76,6 +76,7 @@ class TestAiringPause:
 
         assert result is not None
         assert result.reason == "pre_air"
+        assert result.detail == "2026-01-31 上映，暂未到订阅窗口"
 
     def test_pre_air_within_window_returns_none(self):
         """电影进入上映前订阅窗口后不暂停。"""
@@ -116,6 +117,7 @@ class TestAiringPause:
 
         assert result is not None
         assert result.reason == "pre_air"
+        assert result.detail == "2026-02-01 开播，暂未到订阅窗口"
 
     def test_pre_air_unknown_media_type_returns_none(self):
         """未知媒体类型不走电影或剧集上映前暂停，避免脏数据被误暂停。"""
@@ -173,6 +175,7 @@ class TestAiringPause:
                                as_of=date(2026, 6, 1))
         assert result is not None
         assert result.reason == "airing_gap"
+        assert result.detail == "下一集 2026-07-01，距今 30 天"
 
     def test_next_episode_dict_far_away_pauses(self):
         """下一集为 TMDB dict 形态时，仍按 air_date 判断播出间隔。"""
@@ -725,6 +728,47 @@ class TestPauseManager:
 
         notify.assert_called_once()
         assert "不再满足订阅暂停，已标记订阅中" in notify.call_args.args[1]
+
+    def test_resume_notification_does_not_reuse_stale_pause_detail(self):
+        """恢复通知正文应描述当前恢复动作，不复用旧暂停窗口说明。"""
+        notify = MagicMock()
+        mgr = self._make_manager(notify=notify)
+        sub = _sub()
+        mgr.pause(sub, PauseRecord(reason="pre_air", detail="2026-06-25 开播，暂未到订阅窗口"))
+        notify.reset_mock()
+
+        assert mgr.resume(sub) is True
+
+        notify.assert_called_once()
+        assert "不再满足订阅暂停，已标记订阅中" in notify.call_args.args[1]
+        assert notify.call_args.kwargs["detail"] == "2026-06-25 开播，已进入订阅窗口"
+
+    def test_resume_notification_strips_legacy_media_type_prefix(self):
+        """恢复旧暂停记录时不重复输出媒体类型前缀。"""
+        notify = MagicMock()
+        mgr = self._make_manager(notify=notify)
+        sub = _sub()
+        mgr.pause(sub, PauseRecord(reason="pre_air", detail="电视剧 2026-06-25 开播，暂未到订阅窗口"))
+        notify.reset_mock()
+
+        assert mgr.resume(sub) is True
+
+        notify.assert_called_once()
+        assert notify.call_args.kwargs["detail"] == "2026-06-25 开播，已进入订阅窗口"
+
+    def test_resume_notification_keeps_airing_gap_date(self):
+        """播出暂停恢复通知应保留下一集日期。"""
+        notify = MagicMock()
+        mgr = self._make_manager(notify=notify)
+        sub = _sub()
+        mgr.pause(sub, PauseRecord(reason="airing_gap", detail="下一集 2026-07-01，距今 30 天"))
+        notify.reset_mock()
+
+        assert mgr.resume(sub) is True
+
+        notify.assert_called_once()
+        assert "不再满足订阅暂停，已标记订阅中" in notify.call_args.args[1]
+        assert notify.call_args.kwargs["detail"] == "下一集 2026-07-01，已进入播出窗口"
 
     def test_auto_pause_for_user_sends_status_notification(self):
         """用户名自动暂停应发送状态通知。"""

--- a/tests/v2/subscribeassistantenhanced/test_pending.py
+++ b/tests/v2/subscribeassistantenhanced/test_pending.py
@@ -251,13 +251,14 @@ class TestExitPending:
         store = {"subscribes": {"1": {"state": "P", "source": "pending_judge"}}}
         j = _judge(store=store, notify=notify)
 
-        j._exit_pending(_sub(), "待定条件不再满足")
+        j._exit_pending(_sub(state="P"), "待定条件不再满足")
 
         notify.assert_called_once()
         assert "不再满足上映待定，已标记订阅中" in notify.call_args.args[1]
 
     def test_exit_keeps_p_when_download_pending_active(self):
         """业务待定退出时若下载待定仍活跃，则订阅保持 P。"""
+        notify = MagicMock()
         store = {"subscribes": {"1": {
             "state": "P",
             "source": "pending_judge",
@@ -266,7 +267,7 @@ class TestExitPending:
                 "download_pending": {"reason": "下载中"},
             },
         }}}
-        j = _judge(store=store)
+        j = _judge(store=store, notify=notify)
 
         j._exit_pending(_sub(state="P"), "待定条件不再满足")
 
@@ -277,3 +278,4 @@ class TestExitPending:
             call_args.args[1]["state"] == "R"
             for call_args in j._subscribe_oper.update.call_args_list
         )
+        notify.assert_not_called()


### PR DESCRIPTION
## 变更说明

本 PR 调整订阅助手增强版的状态通知文案，避免恢复类通知继续复用旧暂停原因导致语义反向。

- 上映/开播暂停通知正文去掉“电影 / 电视剧”前缀，订阅标题已包含媒体信息
- 上映/开播恢复通知保留日期，并将“暂未到订阅窗口”改写为“已进入订阅窗口”
- 兼容旧暂停记录中已保存的“电视剧 / 电影”前缀，恢复通知会自动剥离
- 播出间隔恢复通知保留下一集日期，例如“下一集 2026-07-01，已进入播出窗口”
- 多来源待定中，单个待定原因解除但订阅状态仍为 P 时不再推送，仅保留日志；真正恢复为 R 时才发送“已标记订阅中”

## 影响范围

- `plugins.v2/subscribeassistantenhanced/pause/`
- `plugins.v2/subscribeassistantenhanced/pending/`
- `tests/v2/subscribeassistantenhanced/`

不包含版本号调整，不触发插件发版。

## 验证

- `.githooks/pre-push`
- `python .github/scripts/check_plugin_versions.py package.json package.v2.json`
- `python -m json.tool package.v2.json`
- `python -m compileall -q plugins.v2/subscribeassistantenhanced`
- `git diff --check`
- `MOVIEPILOT_BACKEND_PATH=<workspace>/MoviePilot <workspace>/.venv-test/bin/python -m pytest tests/v2/subscribeassistantenhanced/test_pause.py tests/v2/subscribeassistantenhanced/test_pending.py`
- `MOVIEPILOT_BACKEND_PATH=<workspace>/MoviePilot <workspace>/.venv-test/bin/python tests/run.py -q`

本 PR 为 Codex 协作提交。
