### PR TITLE
优化插件发布门禁

### DIFF
--- a/.github/scripts/check_plugin_versions.py
+++ b/.github/scripts/check_plugin_versions.py
@@ -29,20 +29,34 @@ def _plugin_dir(package_file: Path, plugin_id: str) -> Path | None:
     """按 package 文件定位对应插件目录，避免 v1/v2 同名插件互相串线。"""
     plugin_id_lc = plugin_id.lower()
     base_dir = Path("plugins.v2") if package_file.name == "package.v2.json" else Path("plugins")
-    candidate = base_dir / plugin_id_lc
+    candidate = package_file.parent / base_dir / plugin_id_lc
     return candidate if candidate.is_dir() else None
 
 
+def _expected_plugin_dir(package_file: Path, plugin_id: str) -> Path:
+    """返回 package 条目对应的插件目录，用于缺失目录时输出可定位错误。"""
+    plugin_id_lc = plugin_id.lower()
+    base_dir = Path("plugins.v2") if package_file.name == "package.v2.json" else Path("plugins")
+    return package_file.parent / base_dir / plugin_id_lc
+
+
 def _plugin_version(init_file: Path) -> str | None:
-    """从 __init__.py 顶层类属性中提取 plugin_version 字面量。"""
+    """从 __init__.py 类级属性中提取 plugin_version 字面量。"""
     tree = ast.parse(init_file.read_text(encoding="utf-8"), filename=str(init_file))
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign):
-            continue
-        if not any(isinstance(target, ast.Name) and target.id == "plugin_version" for target in node.targets):
-            continue
-        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
-            return node.value.value
+    for class_node in (node for node in tree.body if isinstance(node, ast.ClassDef)):
+        for node in class_node.body:
+            value_node = None
+            if isinstance(node, ast.Assign):
+                if any(isinstance(target, ast.Name) and target.id == "plugin_version" for target in node.targets):
+                    value_node = node.value
+            elif (
+                isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Name)
+                and node.target.id == "plugin_version"
+            ):
+                value_node = node.value
+            if isinstance(value_node, ast.Constant) and isinstance(value_node.value, str):
+                return value_node.value
     return None
 
 
@@ -56,6 +70,7 @@ def check_package(path: Path) -> list[str]:
         package_version = str(meta.get("version") or "").strip()
         plugin_dir = _plugin_dir(path, plugin_id)
         if not plugin_dir:
+            errors.append(f"{path}: {plugin_id} 缺少插件目录 {_expected_plugin_dir(path, plugin_id)}")
             continue
         init_file = plugin_dir / "__init__.py"
         if not init_file.exists():
@@ -63,7 +78,7 @@ def check_package(path: Path) -> list[str]:
             continue
         source_version = _plugin_version(init_file)
         if not source_version:
-            errors.append(f"{path}: {plugin_id} 未在 {init_file} 中声明 plugin_version")
+            errors.append(f"{path}: {plugin_id} 未在 {init_file} 中声明类级 plugin_version")
             continue
         if package_version != source_version:
             errors.append(

--- a/tests/ci/test_plugin_release_gate.py
+++ b/tests/ci/test_plugin_release_gate.py
@@ -41,20 +41,90 @@ def _write_fixture(repo: Path, package_version: str, source_version: str) -> Non
     shutil.copy2(CHECKER, checker_target)
 
 
-def test_checker_rejects_mismatched_versions(tmp_path: Path) -> None:
-    """package 与源码版本不一致时必须返回失败，防止错误资产进入发布流程。"""
-    _write_fixture(tmp_path, package_version="2.0.0", source_version="1.0.0")
-
-    result = subprocess.run(
-        ["python3", ".github/scripts/check_plugin_versions.py", "package.json", "package.v2.json"],
-        cwd=tmp_path,
+def _run_checker(repo: Path, *package_files: Path | str) -> subprocess.CompletedProcess[str]:
+    """从指定目录运行 checker，便于覆盖 cwd 与 package 路径组合。"""
+    args = ["python3", str(CHECKER)]
+    args.extend(str(package_file) for package_file in package_files)
+    return subprocess.run(
+        args,
+        cwd=repo,
         text=True,
         capture_output=True,
         check=False,
     )
 
+
+def test_checker_rejects_mismatched_versions(tmp_path: Path) -> None:
+    """package 与源码版本不一致时必须返回失败，防止错误资产进入发布流程。"""
+    _write_fixture(tmp_path, package_version="2.0.0", source_version="1.0.0")
+
+    result = _run_checker(tmp_path, "package.json", "package.v2.json")
+
     assert result.returncode == 1
     assert "版本不一致" in result.stdout
+
+
+def test_checker_resolves_plugin_dir_relative_to_package_file(tmp_path: Path) -> None:
+    """从其他 cwd 调用时，插件目录应相对 package 文件定位。"""
+    repo = tmp_path / "repo"
+    _write_fixture(repo, package_version="2.0.0", source_version="2.0.0")
+
+    result = _run_checker(tmp_path, repo / "package.json", repo / "package.v2.json")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_checker_reports_missing_release_plugin_dir(tmp_path: Path) -> None:
+    """release=true 的插件缺少源码目录时应失败，避免发布项被静默跳过。"""
+    repo = tmp_path / "repo"
+    (repo / ".github/scripts").mkdir(parents=True)
+    shutil.copy2(CHECKER, repo / ".github/scripts/check_plugin_versions.py")
+    (repo / "package.json").write_text("{}\n", encoding="utf-8")
+    (repo / "package.v2.json").write_text(
+        json.dumps({"MissingPlugin": {"version": "1.0.0", "release": True}}),
+        encoding="utf-8",
+    )
+
+    result = _run_checker(repo, "package.json", "package.v2.json")
+
+    assert result.returncode == 1
+    assert "缺少插件目录" in result.stdout
+    assert "plugins.v2/missingplugin" in result.stdout
+
+
+def test_checker_reads_class_level_plugin_version_only(tmp_path: Path) -> None:
+    """只接受类级 plugin_version，避免函数内局部变量被误识别为插件版本。"""
+    repo = tmp_path / "repo"
+    _write_fixture(repo, package_version="1.2.3", source_version="0.0.0")
+    init_file = repo / "plugins.v2/example/__init__.py"
+    init_file.write_text(
+        "def helper():\n"
+        "    plugin_version = '1.2.3'\n"
+        "    return plugin_version\n",
+        encoding="utf-8",
+    )
+
+    result = _run_checker(repo, "package.json", "package.v2.json")
+
+    assert result.returncode == 1
+    assert "未在" in result.stdout
+    assert "类级 plugin_version" in result.stdout
+
+
+def test_checker_accepts_annotated_class_level_plugin_version(tmp_path: Path) -> None:
+    """类级注解赋值的 plugin_version 也是有效插件版本声明。"""
+    repo = tmp_path / "repo"
+    _write_fixture(repo, package_version="1.2.3", source_version="0.0.0")
+    init_file = repo / "plugins.v2/example/__init__.py"
+    init_file.write_text(
+        "class Example:\n"
+        "    plugin_version: str = '1.2.3'\n",
+        encoding="utf-8",
+    )
+
+    result = _run_checker(repo, "package.json", "package.v2.json")
+
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_pre_push_propagates_version_gate_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
## 变更说明

- 加强插件版本门禁：按 package 文件所在目录定位插件目录，避免在非仓库根目录调用时误判。
- release=true 的插件缺少源码目录时直接失败，避免发布条目被静默跳过。
- 只读取类级 `plugin_version`，并支持类级注解赋值，防止函数局部变量被误识别为插件版本。
- 补充 CI 单测覆盖缺失目录、跨 cwd 调用、类级版本识别和注解赋值场景。

## 影响路径

- `.github/scripts/check_plugin_versions.py`
- `tests/ci/test_plugin_release_gate.py`

## 验证

- `.githooks/pre-push`
- `python3 .github/scripts/check_plugin_versions.py package.json package.v2.json`
- `python -m py_compile .github/scripts/check_plugin_versions.py`
- `MOVIEPILOT_BACKEND_PATH=<workspace>/MoviePilot python -m pytest tests/ci/test_plugin_release_gate.py -q`：10 passed
- `python -m json.tool package.json`
- `python -m json.tool package.v2.json`
- `git diff --check`

本 PR 为 Codex 协作提交。
