### PR TITLE
test(subscribeassistantenhanced): cover pre-air backfill gates

### DIFF
--- a/tests/v2/subscribeassistantenhanced/test_events.py
+++ b/tests/v2/subscribeassistantenhanced/test_events.py
@@ -636,6 +636,32 @@ class TestSubscribeLifecycle:
         assert airing.check_pre_air.call_args.args[0] is sub
         assert airing.check_pre_air.call_args.kwargs["episodes"] == []
 
+    def test_added_non_tv_skips_tv_scope_lookup_and_pending_flow(self):
+        """明确识别为非剧集时只做上映前暂停，不查询 TV 分集或进入待定流程。"""
+        sub = _sub(id=7, best_version=0, tmdbid=100, season=1, type="电影")
+        oper = MagicMock()
+        oper.get.return_value = sub
+        tmdb_episodes = MagicMock()
+        pending = MagicMock()
+        airing = MagicMock()
+        airing.check_pre_air.return_value = None
+        proxy = EventProxy(
+            subscribe_oper=oper,
+            pending_judge=pending,
+            airing_checker=airing,
+            pause_manager=MagicMock(),
+            mediainfo_from_dict=lambda _data: _mi(type="movie"),
+            is_tv_fn=lambda _mi: False,
+            tmdb_episodes_fn=tmdb_episodes,
+            evaluate_fn=lambda _subscribe, _mediainfo: None,
+        )
+
+        proxy.on_subscribe_added(SimpleNamespace(event_data={"subscribe_id": 7, "mediainfo": {"x": 1}}))
+
+        tmdb_episodes.assert_not_called()
+        airing.check_pre_air.assert_called_once_with(sub, _mi(type="movie"), episodes=[])
+        pending.should_enter_pending.assert_not_called()
+
     def test_added_new_subscription_does_not_airing_pause_when_not_pending(self):
         """新增订阅仍为 N 态时不做播出暂停，需等首轮搜索后进入 R 态。"""
         sub = _sub(id=7, best_version=0, tmdbid=100, season=1, state="N")

--- a/tests/v2/subscribeassistantenhanced/test_plugin_entry.py
+++ b/tests/v2/subscribeassistantenhanced/test_plugin_entry.py
@@ -108,6 +108,19 @@ class TestPluginEntry:
 
         assert plugin._detect_backfill_episodes(subscribe) == [1, 2, 3, 4]
 
+    def test_detect_backfill_episodes_ignores_candidates_when_total_is_invalid(self):
+        """总集数异常时不回填，避免 note 或媒体库探测结果越过订阅目标边界。"""
+        plugin = SubscribeAssistantEnhanced()
+        plugin._detect_existing_episodes = MagicMock(return_value=[1, 2])
+        subscribe = SimpleNamespace(
+            id=1,
+            start_episode=1,
+            total_episode="unknown",
+            note=[1, "2"],
+        )
+
+        assert plugin._detect_backfill_episodes(subscribe) == []
+
     def test_downloader_torrent_present_distinguishes_absent_and_unknown(self):
         """手动删种监听需要区分确删、仍存在和下载器不可判定。"""
         plugin = SubscribeAssistantEnhanced()


### PR DESCRIPTION
## 变更

- 补充 `SubscribeAssistantEnhanced` 回填候选的非法总集数边界测试。
- 补充新增非剧集订阅时不查询 TV 分集、不进入待定流程的事件测试。

## 背景

`SubscribeAssistantEnhanced v0.3.7` 已发布，但 PR 的非阻塞覆盖率门禁显示 changed-line 覆盖率为 94.83%，低于 95% 阈值。本 PR 只补测试，不改运行时代码、不变更版本、不触发新的插件发版语义。

## 验证

- `pytest tests/v2/subscribeassistantenhanced/test_plugin_entry.py::TestPluginEntry::test_detect_backfill_episodes_ignores_candidates_when_total_is_invalid tests/v2/subscribeassistantenhanced/test_events.py::TestSubscribeLifecycle::test_added_non_tv_skips_tv_scope_lookup_and_pending_flow -q`：2 passed
- `scripts/plugin_coverage.py --base-ref 643db76666c52c5cb5b3d832d8f0c83f9449eb23`：插件覆盖率门禁通过，`v2/subscribeassistantenhanced` changed_line 98.28%
- `python -m json.tool package.v2.json`：通过
- `python .github/scripts/check_plugin_versions.py package.json package.v2.json`：插件版本门禁通过
- `git diff --check`：通过
- `.githooks/pre-push`：插件版本门禁通过
- `tests/run.py -q`：28 passed + 1619 passed

## 交付路径

PR-only。合并后只回查 `Plugin Gate`，不创建新 tag 或 GitHub Release。
