### PR TITLE
ci: make pr-agent manual only

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,15 +1,6 @@
 name: PR Agent
 
 on:
-  pull_request:
-    # PR-Agent 读取 PR diff，并写入 Review 评论或更新 PR 描述。
-    # synchronize 用于在 PR 推送新 commit 后刷新审查结果。
-    types:
-      - opened
-      - reopened
-      - ready_for_review
-      - review_requested
-      - synchronize
   issue_comment:
     # 手动命令如 "/review"、"/describe"、"/improve" 和 "/ask ..." 只在 PR 评论中有意义。
     # issue_comment 同时覆盖普通 issue，因此 job 里还会再判断是否属于 PR。
@@ -27,30 +18,21 @@ permissions:
 
 jobs:
   pr-agent:
-    name: PR-Agent review and describe
-    # 同仓 PR 可自动处理；fork PR 由允许身份在 PR 下用评论命令触发，避免任意评论消耗模型配额。
+    name: PR-Agent manual command
+    # 仅允许指定身份在 PR 下用评论命令触发，避免任意评论消耗模型配额。
     if: >-
       github.event.sender.type != 'Bot' &&
+      github.event.issue.pull_request != null &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR"]'), github.event.comment.author_association) &&
       (
-        (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        ) ||
-        (
-          github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request != null &&
-          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR"]'), github.event.comment.author_association) &&
-          (
-            github.event.comment.body == '/review' ||
-            startsWith(github.event.comment.body, '/review ') ||
-            github.event.comment.body == '/describe' ||
-            startsWith(github.event.comment.body, '/describe ') ||
-            github.event.comment.body == '/improve' ||
-            startsWith(github.event.comment.body, '/improve ') ||
-            github.event.comment.body == '/ask' ||
-            startsWith(github.event.comment.body, '/ask ')
-          )
-        )
+        github.event.comment.body == '/review' ||
+        startsWith(github.event.comment.body, '/review ') ||
+        github.event.comment.body == '/describe' ||
+        startsWith(github.event.comment.body, '/describe ') ||
+        github.event.comment.body == '/improve' ||
+        startsWith(github.event.comment.body, '/improve ') ||
+        github.event.comment.body == '/ask' ||
+        startsWith(github.event.comment.body, '/ask ')
       )
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -80,13 +62,10 @@ jobs:
           config.ignore_pr_title: '["^\\[Auto\\]", "^Auto"]'
           config.ignore_pr_labels: '["skip pr-agent"]'
 
-          # pull_request 事件默认自动执行 /review 和 /describe；/improve 保持手动触发。
-          github_action_config.auto_review: "true"
-          github_action_config.auto_describe: "true"
+          # 自动 PR 事件工具保持关闭；评论命令由评论正文决定，不依赖这些开关。
+          github_action_config.auto_review: "false"
+          github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "false"
-
-          # 允许触发自动工具的 PR 动作。包含 synchronize，便于新 commit 推送后刷新结果。
-          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested", "synchronize"]'
 
           # 保留 action outputs，便于后续 workflow 编排或排查。
           github_action_config.enable_output: "true"

--- a/docs/pr-agent.md
+++ b/docs/pr-agent.md
@@ -1,6 +1,6 @@
 # PR-Agent 使用说明
 
-本仓库通过 GitHub Actions 运行开源 PR-Agent，用于自动生成 PR 说明和进行 AI Review。
+本仓库通过 GitHub Actions 运行开源 PR-Agent，用于在 PR 评论中手动生成 PR 说明和进行 AI Review。
 
 ## Secrets
 
@@ -15,12 +15,11 @@
 
 `.github/workflows/pr-agent.yml` 监听：
 
-- `pull_request`：PR 打开、重新打开、标记 ready、请求 review、推送新 commit 时自动运行。
 - `issue_comment`：允许身份在 PR 评论里写允许的命令时手动运行。
 
-`pull_request` 自动运行仅处理同仓 PR。fork PR 不自动注入仓库 secret 和写权限，允许身份可以在 PR
-评论中使用允许的命令触发受控审查。允许身份包括 `OWNER`、`MEMBER`、`COLLABORATOR`、
-`CONTRIBUTOR` 和 `FIRST_TIME_CONTRIBUTOR`。
+默认不监听 `pull_request`，因此 PR 打开、重新打开、标记 ready、请求 review、推送新 commit
+时都不会自动运行 PR-Agent。允许身份可以在 PR 评论中使用允许的命令触发受控审查。允许身份包括
+`OWNER`、`MEMBER`、`COLLABORATOR`、`CONTRIBUTOR` 和 `FIRST_TIME_CONTRIBUTOR`。
 
 ## Workflow 权限
 
@@ -32,14 +31,15 @@ workflow 设置了最小可用权限：
 
 没有开启 `contents: write`。当前配置不让 PR-Agent 往仓库推代码或提交 changelog，因此不需要内容写权限。
 
-默认自动执行：
+默认可手动执行：
 
 - `/review`：检查 PR 风险、潜在 bug、安全问题、测试缺口和可维护性问题。
 - `/describe`：生成或更新 PR 描述、变更摘要和文件说明。
 
-默认不自动执行：
+同样允许手动执行：
 
 - `/improve`：给出代码改进建议。这个工具更容易产生噪音和额外成本，建议先用评论命令手动触发。
+- `/ask ...`：围绕当前 PR 提问，例如确认某类风险、测试缺口或实现意图。
 
 ## 常用评论命令
 
@@ -72,7 +72,7 @@ PR-Agent 配置集中在 `.github/workflows/pr-agent.yml` 的 `env` 中维护。
 - `config.ai_timeout = "900"`：模型调用最长等待 900 秒。
 - `config.response_language = "zh-CN"`：让 PR-Agent 默认中文输出。
 - `config.large_patch_policy = "clip"`：大 PR 截断分析，不直接跳过。
-- `config.ignore_pr_title` / `config.ignore_pr_labels`：跳过自动生成 PR 或带 `skip pr-agent` 标签的 PR。
+- `config.ignore_pr_title` / `config.ignore_pr_labels`：跳过匹配标题或带 `skip pr-agent` 标签的 PR。
 - `pr_reviewer.extra_instructions`：要求中文输出，优先指出 P0/P1 风险，并关注安全、权限、状态一致性、异步/缓存、副作用和测试缺口。
 - `pr_reviewer.require_security_review = true`：要求输出安全审查部分。
 - `pr_reviewer.require_tests_review = true`：要求输出测试审查部分。
@@ -102,13 +102,15 @@ PR-Agent 配置集中在 `.github/workflows/pr-agent.yml` 的 `env` 中维护。
 PR-Agent Action 会读取 `OPENAI_KEY`，因此依赖的 Docker 镜像在 workflow 中固定版本号和 digest，
 不使用浮动的 `latest` 或仅依赖可变 tag。
 
-当前使用 `pull_request` 而不是 `pull_request_target`。这样更适合避免 fork PR 直接获得仓库 secrets，但 fork PR 自动运行通常因为拿不到 `OPENAI_KEY` 而无法完整执行。`issue_comment` 属于 base repo 事件，因此评论命令只允许指定身份触发。若以后要支持 fork PR 自动审查，需要重新评估 `pull_request_target` 的安全模型，不能 checkout 或执行来自 fork 的代码。
+当前只使用 `issue_comment`，不使用 `pull_request` 或 `pull_request_target`。`issue_comment` 属于
+base repo 事件，因此评论命令只允许指定身份触发。若以后要支持 fork PR 自动审查，需要重新评估
+`pull_request_target` 的安全模型，不能 checkout 或执行来自 fork 的代码。
 
 API Key 建议使用低额度、可轮换的专用 key。`OPENAI_API_BASE` 本身通常不是敏感信息，但继续按 secret 管理可以避免暴露服务商信息。
 
-## 调整自动行为
+## 调整手动命令行为
 
-自动行为在 workflow 的 `env` 中控制：
+PR-Agent 行为在 workflow 的 `env` 中控制：
 
 ```yaml
 config.model: "gpt-5.5"
@@ -116,10 +118,9 @@ config.fallback_models: '["gpt-5.4"]'
 config.reasoning_effort: "xhigh"
 config.ai_timeout: "900"
 config.response_language: "zh-CN"
-github_action_config.auto_review: "true"
-github_action_config.auto_describe: "true"
+github_action_config.auto_review: "false"
+github_action_config.auto_describe: "false"
 github_action_config.auto_improve: "false"
-github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested", "synchronize"]'
 pr_description.generate_ai_title: "false"
 pr_description.publish_labels: "false"
 pr_description.enable_pr_diagram: "false"
@@ -127,4 +128,6 @@ pr_reviewer.enable_review_labels_effort: "false"
 pr_reviewer.enable_review_labels_security: "true"
 ```
 
-如果需要自动运行 `/improve`，把 `github_action_config.auto_improve` 改为 `"true"`。建议先观察手动 `/improve` 的质量和成本，再决定是否开启。
+`auto_review`、`auto_describe` 和 `auto_improve` 只控制 PR 事件触发时是否执行对应工具。当前
+workflow 不监听 PR 事件，因此这些开关保持关闭；评论命令由评论正文决定，不依赖这些开关。若以后
+需要 PR 打开或更新时自动运行，需要重新添加 `pull_request` 触发器，并重新评估 secret、权限和成本边界。


### PR DESCRIPTION
## 变更说明

- 关闭 PR-Agent 的 `pull_request` 自动触发，PR 打开、更新、ready 或请求 review 时不再默认运行。
- 保留 PR 评论命令触发，仅允许指定身份在 PR 下使用 `/review`、`/describe`、`/improve`、`/ask`。
- 关闭 PR 事件下的 `auto_review`、`auto_describe`、`auto_improve`，并同步更新使用文档。

## 影响范围

- `.github/workflows/pr-agent.yml`
- `docs/pr-agent.md`

## 验证

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-agent.yml"); puts "yaml ok"'`
- `git diff --check`
- `.githooks/pre-push`

## 交付路径

PR-only。未改插件版本、tag 或 GitHub Release。
