### PR TITLE
ci: review fork PRs with PR-Agent

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,6 +1,15 @@
 name: PR Agent
 
 on:
+  pull_request_target:
+    # PR-Agent 通过 base repo 上下文读取 PR diff 并发布 Review，不 checkout 或执行 PR 分支代码。
+    # pull_request_target 允许 fork PR 使用仓库 secrets，因此 workflow 只运行固定 digest 的 PR-Agent 容器。
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - review_requested
+      - synchronize
   issue_comment:
     # 手动命令如 "/review"、"/describe"、"/improve" 和 "/ask ..." 只在 PR 评论中有意义。
     # issue_comment 同时覆盖普通 issue，因此 job 里还会再判断是否属于 PR。
@@ -18,21 +27,30 @@ permissions:
 
 jobs:
   pr-agent:
-    name: PR-Agent manual command
-    # 仅允许指定身份在 PR 下用评论命令触发，避免任意评论消耗模型配额。
+    name: PR-Agent review and describe
+    # 仅 fork PR 自动处理；同仓 PR 可按需用评论命令触发，避免维护分支默认消耗模型配额。
     if: >-
       github.event.sender.type != 'Bot' &&
-      github.event.issue.pull_request != null &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR"]'), github.event.comment.author_association) &&
       (
-        github.event.comment.body == '/review' ||
-        startsWith(github.event.comment.body, '/review ') ||
-        github.event.comment.body == '/describe' ||
-        startsWith(github.event.comment.body, '/describe ') ||
-        github.event.comment.body == '/improve' ||
-        startsWith(github.event.comment.body, '/improve ') ||
-        github.event.comment.body == '/ask' ||
-        startsWith(github.event.comment.body, '/ask ')
+        (
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request != null &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR"]'), github.event.comment.author_association) &&
+          (
+            github.event.comment.body == '/review' ||
+            startsWith(github.event.comment.body, '/review ') ||
+            github.event.comment.body == '/describe' ||
+            startsWith(github.event.comment.body, '/describe ') ||
+            github.event.comment.body == '/improve' ||
+            startsWith(github.event.comment.body, '/improve ') ||
+            github.event.comment.body == '/ask' ||
+            startsWith(github.event.comment.body, '/ask ')
+          )
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -62,10 +80,13 @@ jobs:
           config.ignore_pr_title: '["^\\[Auto\\]", "^Auto"]'
           config.ignore_pr_labels: '["skip pr-agent"]'
 
-          # 自动 PR 事件工具保持关闭；评论命令由评论正文决定，不依赖这些开关。
-          github_action_config.auto_review: "false"
-          github_action_config.auto_describe: "false"
+          # pull_request_target 事件默认自动执行 /review 和 /describe；/improve 保持手动触发。
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "false"
+
+          # 允许触发自动工具的 PR 动作。包含 synchronize，便于新 commit 推送后刷新结果。
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested", "synchronize"]'
 
           # 保留 action outputs，便于后续 workflow 编排或排查。
           github_action_config.enable_output: "true"

--- a/docs/pr-agent.md
+++ b/docs/pr-agent.md
@@ -1,6 +1,6 @@
 # PR-Agent 使用说明
 
-本仓库通过 GitHub Actions 运行开源 PR-Agent，用于在 PR 评论中手动生成 PR 说明和进行 AI Review。
+本仓库通过 GitHub Actions 运行开源 PR-Agent，用于对 fork PR 自动生成 PR 说明和进行 AI Review。
 
 ## Secrets
 
@@ -15,11 +15,11 @@
 
 `.github/workflows/pr-agent.yml` 监听：
 
+- `pull_request_target`：fork PR 打开、重新打开、标记 ready、请求 review、推送新 commit 时自动运行。
 - `issue_comment`：允许身份在 PR 评论里写允许的命令时手动运行。
 
-默认不监听 `pull_request`，因此 PR 打开、重新打开、标记 ready、请求 review、推送新 commit
-时都不会自动运行 PR-Agent。允许身份可以在 PR 评论中使用允许的命令触发受控审查。允许身份包括
-`OWNER`、`MEMBER`、`COLLABORATOR`、`CONTRIBUTOR` 和 `FIRST_TIME_CONTRIBUTOR`。
+默认只自动处理 fork PR；同仓 PR 不自动运行，允许身份可以在 PR 评论中使用允许的命令触发受控审查。
+允许身份包括 `OWNER`、`MEMBER`、`COLLABORATOR`、`CONTRIBUTOR` 和 `FIRST_TIME_CONTRIBUTOR`。
 
 ## Workflow 权限
 
@@ -31,12 +31,12 @@ workflow 设置了最小可用权限：
 
 没有开启 `contents: write`。当前配置不让 PR-Agent 往仓库推代码或提交 changelog，因此不需要内容写权限。
 
-默认可手动执行：
+fork PR 默认自动执行：
 
 - `/review`：检查 PR 风险、潜在 bug、安全问题、测试缺口和可维护性问题。
 - `/describe`：生成或更新 PR 描述、变更摘要和文件说明。
 
-同样允许手动执行：
+同样允许手动触发：
 
 - `/improve`：给出代码改进建议。这个工具更容易产生噪音和额外成本，建议先用评论命令手动触发。
 - `/ask ...`：围绕当前 PR 提问，例如确认某类风险、测试缺口或实现意图。
@@ -102,13 +102,13 @@ PR-Agent 配置集中在 `.github/workflows/pr-agent.yml` 的 `env` 中维护。
 PR-Agent Action 会读取 `OPENAI_KEY`，因此依赖的 Docker 镜像在 workflow 中固定版本号和 digest，
 不使用浮动的 `latest` 或仅依赖可变 tag。
 
-当前只使用 `issue_comment`，不使用 `pull_request` 或 `pull_request_target`。`issue_comment` 属于
-base repo 事件，因此评论命令只允许指定身份触发。若以后要支持 fork PR 自动审查，需要重新评估
-`pull_request_target` 的安全模型，不能 checkout 或执行来自 fork 的代码。
+当前使用 `pull_request_target` 支持 fork PR 自动审查，但 workflow 不 checkout 或执行来自 fork
+的代码，只运行固定 digest 的 PR-Agent 容器并通过 GitHub API 读取 PR diff。`issue_comment` 属于
+base repo 事件，因此评论命令只允许指定身份触发。
 
 API Key 建议使用低额度、可轮换的专用 key。`OPENAI_API_BASE` 本身通常不是敏感信息，但继续按 secret 管理可以避免暴露服务商信息。
 
-## 调整手动命令行为
+## 调整自动行为
 
 PR-Agent 行为在 workflow 的 `env` 中控制：
 
@@ -118,9 +118,10 @@ config.fallback_models: '["gpt-5.4"]'
 config.reasoning_effort: "xhigh"
 config.ai_timeout: "900"
 config.response_language: "zh-CN"
-github_action_config.auto_review: "false"
-github_action_config.auto_describe: "false"
+github_action_config.auto_review: "true"
+github_action_config.auto_describe: "true"
 github_action_config.auto_improve: "false"
+github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested", "synchronize"]'
 pr_description.generate_ai_title: "false"
 pr_description.publish_labels: "false"
 pr_description.enable_pr_diagram: "false"
@@ -128,6 +129,5 @@ pr_reviewer.enable_review_labels_effort: "false"
 pr_reviewer.enable_review_labels_security: "true"
 ```
 
-`auto_review`、`auto_describe` 和 `auto_improve` 只控制 PR 事件触发时是否执行对应工具。当前
-workflow 不监听 PR 事件，因此这些开关保持关闭；评论命令由评论正文决定，不依赖这些开关。若以后
-需要 PR 打开或更新时自动运行，需要重新添加 `pull_request` 触发器，并重新评估 secret、权限和成本边界。
+`auto_review`、`auto_describe` 和 `auto_improve` 控制 PR 事件触发时是否执行对应工具。当前同仓 PR
+不自动运行；如需审查同仓 PR，可由允许身份在 PR 评论中手动发送 `/review` 或 `/describe`。


### PR DESCRIPTION
## 变更说明

将 PR-Agent workflow 调整为通过 `pull_request_target` 支持 fork PR 自动审查。

- fork PR 打开、重新打开、ready、请求 review 或推送新 commit 时自动执行 `/review` 和 `/describe`
- 同仓 PR 不自动运行，仍可由可信作者在 PR 评论中手动触发 `/review`、`/describe`、`/improve` 或 `/ask`
- 保留固定 digest 的 PR-Agent 容器、最小权限和中文输出配置

## 安全边界

- workflow 不 checkout PR 分支代码
- workflow 不执行来自 PR 分支的脚本或命令
- `pull_request_target` 仅用于 base repo 上下文读取 PR diff 并发布 Review
- API Key 继续通过 repository secrets 注入

## 验证

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-agent.yml"); puts "yaml ok"'`
- `git diff --check`
- `.githooks/pre-push`

## 交付路径

PR-only。未修改插件版本、tag 或 GitHub Release。

本 PR 为 Codex 协作提交
