### PR TITLE
fix(plexautolanguages): align dateutil dependency

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -137,11 +137,12 @@
         "name": "Plex自动语言",
         "description": "实现自动选择Plex电视节目的音轨和字幕语言。",
         "labels": "Plex",
-        "version": "0.3",
+        "version": "0.4",
         "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/plexautolanguages.png",
         "author": "InfinityPacer",
         "level": 1,
         "history": {
+            "v0.4": "兼容 MoviePilot v2.13.14 的 python-dateutil 运行依赖",
             "v0.3": "MoviePilot V2 版本Plex自动语言插件"
         },
         "release": true

--- a/plugins.v2/plexautolanguages/__init__.py
+++ b/plugins.v2/plexautolanguages/__init__.py
@@ -20,7 +20,7 @@ class PlexAutoLanguages(_PluginBase):
     # 插件图标
     plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/plexautolanguages.png"
     # 插件版本
-    plugin_version = "0.3"
+    plugin_version = "0.4"
     # 插件作者
     plugin_author = "InfinityPacer"
     # 作者主页

--- a/plugins.v2/plexautolanguages/requirements.txt
+++ b/plugins.v2/plexautolanguages/requirements.txt
@@ -1,2 +1,2 @@
 websocket-client~=1.8
-python-dateutil~=2.8.2
+python-dateutil~=2.9.0.post0

--- a/plugins/plexautolanguages/requirements.txt
+++ b/plugins/plexautolanguages/requirements.txt
@@ -1,2 +1,2 @@
 websocket-client~=1.8
-python-dateutil~=2.8.2
+python-dateutil~=2.9.0.post0

--- a/tests/ci/test_plugin_dependency_constraints.py
+++ b/tests/ci/test_plugin_dependency_constraints.py
@@ -1,0 +1,92 @@
+"""插件依赖约束必须兼容当前主程序运行环境。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKSPACE_ROOT = REPO_ROOT.parent
+BACKEND_REQUIREMENTS = WORKSPACE_ROOT / "MoviePilot/requirements.in"
+
+
+def _normalize_package_name(package_name: str) -> str:
+    """按 PEP 503 规则归一化包名，避免大小写和分隔符差异影响比对。"""
+    return package_name.lower().replace("_", "-").replace(".", "-")
+
+
+def _read_requirements(requirements_file: Path) -> dict[str, Requirement]:
+    """读取 requirements 文件中的普通依赖声明。"""
+    requirements: dict[str, Requirement] = {}
+    for raw_line in requirements_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        requirement = Requirement(line)
+        requirements[_normalize_package_name(requirement.name)] = requirement
+    return requirements
+
+
+def _backend_runtime_versions() -> dict[str, str]:
+    """提取主程序根依赖声明中的当前运行版本。"""
+    versions: dict[str, str] = {}
+    for package_name, requirement in _read_requirements(BACKEND_REQUIREMENTS).items():
+        compatible_release = next(
+            (spec.version for spec in requirement.specifier if spec.operator == "~="),
+            None,
+        )
+        if compatible_release:
+            versions[package_name] = compatible_release
+    return versions
+
+
+def _plugin_dependency_cases() -> list:
+    """收集所有插件依赖中与主程序根依赖同名的约束。"""
+    backend_versions = _backend_runtime_versions()
+    cases = []
+    requirement_files = [
+        *sorted((REPO_ROOT / "plugins").glob("*/requirements.txt")),
+        *sorted((REPO_ROOT / "plugins.v2").glob("*/requirements.txt")),
+    ]
+    for requirements_file in requirement_files:
+        generation = requirements_file.relative_to(REPO_ROOT).parts[0]
+        plugin_id = f"{generation}/{requirements_file.parent.name}"
+        for package_name, requirement in _read_requirements(requirements_file).items():
+            backend_version = backend_versions.get(package_name)
+            if backend_version is None:
+                continue
+            cases.append(
+                pytest.param(
+                    plugin_id,
+                    requirement.name,
+                    str(requirement.specifier),
+                    backend_version,
+                    id=f"{plugin_id}:{requirement.name}",
+                )
+            )
+    return cases
+
+
+@pytest.mark.parametrize(
+    ("plugin_id", "package_name", "plugin_specifier", "backend_version"),
+    _plugin_dependency_cases(),
+)
+def test_plugin_dependency_allows_backend_runtime_version(
+        plugin_id: str,
+        package_name: str,
+        plugin_specifier: str,
+        backend_version: str,
+) -> None:
+    """插件依赖不得要求低于主程序当前运行依赖的版本窗口。"""
+    requirement = Requirement(f"{package_name}{plugin_specifier}")
+
+    assert requirement.specifier.contains(
+        backend_version,
+        prereleases=True,
+    ), (
+        f"{plugin_id} 要求 {package_name}{plugin_specifier}，"
+        f"不兼容主程序当前 {package_name}=={backend_version}"
+    )


### PR DESCRIPTION
## 变更说明

- 将 v2 `PlexAutoLanguages` 发布版本提升到 `0.4`。
- 将 v1/v2 `PlexAutoLanguages` 的 `python-dateutil` 依赖约束同步为 `~=2.9.0.post0`，避免与 MoviePilot v2.13.14 当前运行依赖冲突。
- 新增 CI 测试，扫描 `plugins/` 与 `plugins.v2/` 下所有插件的 `requirements.txt`，检查与主程序根运行依赖同名的插件约束不会排斥当前主程序版本。

## 影响路径

- `plugins.v2/plexautolanguages/`
- `plugins/plexautolanguages/`
- `package.v2.json`
- `tests/ci/test_plugin_dependency_constraints.py`

## 交付路径

发版路径。v2 `PlexAutoLanguages` 的 `plugin_version`、`package.v2.json` 版本和 history 已同步为 `0.4`。

Refs #227

## 验证

- 新增依赖兼容测试在旧 `python-dateutil~=2.8.2` 约束下失败，修复后通过。
- `python -m pytest tests/ci/test_plugin_dependency_constraints.py -q`
- `.githooks/pre-push`
- `python tests/run.py -q`
- `python -m json.tool package.json`
- `python -m json.tool package.v2.json`
- `python -m compileall -q plugins/plexautolanguages plugins.v2/plexautolanguages`
- `git diff --check`
