### PR TITLE
chore(subscribeassistantenhanced): adjust volatility window default

### DIFF
--- a/plugins.v2/subscribeassistantenhanced/README.md
+++ b/plugins.v2/subscribeassistantenhanced/README.md
@@ -162,7 +162,7 @@
 | --- | --- | --- | --- | --- | --- |
 | [完结守卫模式](#cfg-completion_guard_mode) | `completion_guard_mode` | enum | `balanced` | 选择完成检查的复核强度 | 可选 `off` / `strict` / `balanced` / `loose` |
 | 变更速率信号 | `volatility_enabled` | bool | `true` | 记录并启用目标总集数变动信号（F） | 完结守卫默认消费；剧集待定还需开启「待定参考变更速率」才消费 |
-| 变更速率窗口（天） | `volatility_window_days` | int（天） | `2` | 统计集数变动的窗口 | 窗口内变动视为不稳定 |
+| 变更速率窗口（天） | `volatility_window_days` | int（天） | `3` | 统计集数变动的窗口 | 窗口内变动视为不稳定 |
 | 播出节奏信号 | `cadence_enabled` | bool | `true` | 用播出间隔辅助判断 | 绝对季等高风险目标范围会采用更保守的判断 |
 | 节奏窗口系数 | `cadence_multiplier` | float | `2.5` | 播出间隔放大倍数 | 数值越大越宽松 |
 | 节奏窗口下限（天） | `cadence_min_window_days` | int（天） | `7` | 节奏窗口最小天数 | 防止短间隔剧集过早释放 |

--- a/plugins.v2/subscribeassistantenhanced/shared/config.py
+++ b/plugins.v2/subscribeassistantenhanced/shared/config.py
@@ -8,7 +8,7 @@ torrent banned"""
 # 自动删种默认跳过 H&R 标签，避免误删需要长期做种的任务。
 DEFAULT_DELETE_EXCLUDE_TAGS = "H&R"
 
-DEFAULT_VOLATILITY_WINDOW_DAYS = 2
+DEFAULT_VOLATILITY_WINDOW_DAYS = 3
 
 DEFAULT_RECOGNITION_GUARD_CUSTOM_CONFIG = """####### 配置说明 BEGIN #######
 # 1. 本配置只控制识别增强的策略覆盖和关键词，不控制通知、二次识别触发或缓存大小。

--- a/tests/v2/subscribeassistantenhanced/test_config.py
+++ b/tests/v2/subscribeassistantenhanced/test_config.py
@@ -36,7 +36,7 @@ class PluginConfigDefaultsTest:
         assert self.cfg.volatility_enabled is True
 
     def test_volatility_window_days_default(self):
-        assert self.cfg.volatility_window_days == 2
+        assert self.cfg.volatility_window_days == 3
 
     def test_cadence_enabled_default_true(self):
         assert self.cfg.cadence_enabled is True
@@ -194,7 +194,7 @@ class PluginConfigCoercionTest:
 
     def test_invalid_int_falls_back_to_default(self):
         cfg = PluginConfig({"volatility_window_days": "bad"})
-        assert cfg.volatility_window_days == 2
+        assert cfg.volatility_window_days == 3
 
     def test_invalid_float_falls_back_to_default(self):
         cfg = PluginConfig({"cadence_multiplier": "bad"})

--- a/tests/v2/subscribeassistantenhanced/test_evaluate.py
+++ b/tests/v2/subscribeassistantenhanced/test_evaluate.py
@@ -85,7 +85,7 @@ class TestEvaluatePipeline:
         assert sig.completed is False
         assert sig.stable is False
         assert "F:unstable" in sig.signals
-        assert sig.reason == "目标总集数最近 2 天发生变化（10 -> 15）"
+        assert sig.reason == "目标总集数最近 3 天发生变化（10 -> 15）"
         assert "total_episode" not in sig.reason
 
     def test_ended_without_scope_future_confirms_completion_despite_recent_total_change(self):

--- a/tests/v2/subscribeassistantenhanced/test_volatility.py
+++ b/tests/v2/subscribeassistantenhanced/test_volatility.py
@@ -23,15 +23,15 @@ class TestVolatilityTracker:
         self.task_mgr = TaskDataManager(get_data_fn=get_fn, save_data_fn=save_fn)
         self.tracker = VolatilityTracker(self.task_mgr, window_days=7)
 
-    def test_default_window_is_two_days(self):
-        """无参构造也应使用插件默认的两天观察窗口。"""
+    def test_default_window_is_three_days(self):
+        """无参构造也应使用插件默认的三天观察窗口。"""
         tracker = VolatilityTracker(self.task_mgr)
 
         tracker.record(total=10, subscribe_id=1)
         tracker.record(total=12, subscribe_id=1)
 
         entry = self.store["volatility"]["1"]
-        assert entry["unstable_until"] - entry["last_total_changed_at"] == 2 * 86400
+        assert entry["unstable_until"] - entry["last_total_changed_at"] == 3 * 86400
 
     def test_first_record_is_stable(self):
         """首次记录不算变动。"""


### PR DESCRIPTION
## 变更说明

- 将订阅助手增强版的变更速率窗口默认值从 2 天调整为 3 天。
- 同步 README 配置表默认值。
- 更新默认配置、无参变更速率追踪器和 F 信号原因文案测试。

## 影响范围

- `plugins.v2/subscribeassistantenhanced/shared/config.py`
- `plugins.v2/subscribeassistantenhanced/README.md`
- `tests/v2/subscribeassistantenhanced/`

## 交付路径

PR-only。本 PR 不包含版本升级、tag 或 GitHub Release。

## 验证

- `pytest tests/v2/subscribeassistantenhanced -q`：1041 passed
- `tests/run.py -q`：33 passed + 1838 passed
- `python -m compileall -q plugins.v2/subscribeassistantenhanced`
- `python .github/scripts/check_plugin_versions.py package.json package.v2.json`
- `git diff --check`
- `.githooks/pre-push`
