### PR TITLE
docs(subscribeassistantenhanced): update lifecycle references

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ MoviePilot环境变量添加本项目地址，具体参见 https://github.com/jx
 ### 29. [订阅助手](https://github.com/InfinityPacer/MoviePilot-Plugins/blob/main/plugins.v2/subscribeassistant/README.md)
 
 - 实现多场景管理系统订阅与状态同步
-- 本插件仅支持 TMDB 数据源，相关订阅状态说明，请查阅 [#3330](https://github.com/jxxghp/MoviePilot/pull/3330)
+- 本插件仅支持 TMDB 数据源，相关订阅状态说明，请查阅 [#3330](https://github.com/jxxghp/MoviePilot/pull/3330)、[#6015](https://github.com/jxxghp/MoviePilot/pull/6015)
 
 ![](images/2024-12-28-01-21-45.png)
 ![](images/2024-12-28-01-21-56.png)

--- a/plugins.v2/subscribeassistantenhanced/README.md
+++ b/plugins.v2/subscribeassistantenhanced/README.md
@@ -59,7 +59,7 @@
 - **自动纠错**：所有订阅完成时都会保存总集数和订阅配置；开启自动纠错后周期性复查 TMDB，发现新增集数时按季和剧集组精确重建订阅并通知。
 
 ## 不在范围内
-- 仅支持 **TMDB 数据源**，不覆盖豆瓣 / Bangumi 等其它来源的订阅。
+- 仅支持 **TMDB 数据源**，不覆盖豆瓣 / Bangumi 等其它来源的订阅；订阅状态和生命周期语义可参考 [主程序订阅生命周期文档](https://github.com/jxxghp/MoviePilot/blob/v2/docs/subscribe-lifecycle.md) 以及 [#3330](https://github.com/jxxghp/MoviePilot/pull/3330)、[#477](https://github.com/jxxghp/MoviePilot-Frontend/pull/477)、[#6015](https://github.com/jxxghp/MoviePilot/pull/6015)。
 - 不替代 MoviePilot 主程序订阅识别、搜索召回和下载链路；识别增强只在订阅候选选择阶段做准入保护。
 - 不在下载发起后做识别增强硬拦截，已进入下载链路的资源仍由下载管理、订阅清理和主程序流程处理。
 
@@ -420,5 +420,5 @@
 
 ## 致谢 / 参考
 
-- 订阅待定、暂停、删种和洗版能力参考 MoviePilot 订阅生命周期中的常见运维场景。
-- 完结状态相关行为参考 MoviePilot 订阅状态链路与 TMDB 剧集数据。
+- 订阅待定、暂停、删种和洗版能力参考 MoviePilot [订阅生命周期与订阅模式](https://github.com/jxxghp/MoviePilot/blob/v2/docs/subscribe-lifecycle.md) 中的常见运维场景。
+- 完结状态相关行为参考 MoviePilot 订阅状态链路、TMDB 剧集数据以及 [#3330](https://github.com/jxxghp/MoviePilot/pull/3330)、[#477](https://github.com/jxxghp/MoviePilot-Frontend/pull/477)、[#6015](https://github.com/jxxghp/MoviePilot/pull/6015)。

--- a/plugins.v2/subscribeassistantenhanced/form/__init__.py
+++ b/plugins.v2/subscribeassistantenhanced/form/__init__.py
@@ -384,6 +384,10 @@ def _footer() -> list:
             {"component": "a",
              "props": {"href": "https://github.com/jxxghp/MoviePilot-Frontend/pull/477", "target": "_blank"},
              "content": [{"component": "u", "text": "#477"}]},
+            {"component": "span", "text": "、"},
+            {"component": "a",
+             "props": {"href": "https://github.com/jxxghp/MoviePilot/pull/6015", "target": "_blank"},
+             "content": [{"component": "u", "text": "#6015"}]},
         ]),
         alert_row("error", text="注意：本插件可能导致订阅数据异常、媒体文件丢失，相关风险请自行评估与承担"),
     ]


### PR DESCRIPTION
## 变更说明

- 在订阅助手（增强版）的 TMDB 数据源说明中补充主程序订阅生命周期文档链接。
- 将主程序 PR #6015 补充到订阅状态相关参考，与 #3330、前端 #477 放在同一语境。
- 同步更新插件配置页底部提示中的订阅状态参考链接。

## 影响路径

- `plugins.v2/subscribeassistantenhanced/README.md`
- `plugins.v2/subscribeassistantenhanced/form/__init__.py`
- `README.md`

## 验证

- `.githooks/pre-push`
- `python -m json.tool package.json`
- `python -m json.tool package.v2.json`
- `python -m compileall -q plugins.v2/subscribeassistantenhanced`
- `git diff --check`

## 交付路径

PR-only 文档与提示链接更新；不包含版本升级、tag 或 GitHub Release。
