### PR TITLE
fix(torrentclassifier): escape regex sample

### DIFF
--- a/plugins.v2/torrentclassifier/__init__.py
+++ b/plugins.v2/torrentclassifier/__init__.py
@@ -1042,7 +1042,7 @@ class TorrentClassifier(_PluginBase):
 
 - torrent_filter:
     # 种子标题的过滤条件，支持使用正则表达式匹配
-    torrent_title: '.*\.测试标题2'
+    torrent_title: '.*\\.测试标题2'
     # 种子必须属于的分类
     torrent_category: '测试分类2'
     # 种子必须具有的标签，多个标签时，任一满足即可


### PR DESCRIPTION
## 变更说明

修正 `TorrentClassifier` 配置示例中的正则字符串转义，避免全量测试输出 Python `SyntaxWarning`。

本次不修改 `TorrentClassifier` 版本号和 changelog，继续使用当前版本 `1.5.1`。

## 验证

- `.githooks/pre-push`
- `python -m json.tool package.v2.json`
- `python -W error::SyntaxWarning -m py_compile plugins.v2/torrentclassifier/__init__.py`
- `python -m compileall -q plugins.v2/torrentclassifier`
- `pytest tests/v2/torrentclassifier -q`
- `tests/run.py -q`
- `git diff --check`

## 交付路径

旧的 `TorrentClassifier_v1.5.1` Release 和 tag 已清理。PR 合并后手动触发 `Plugin Release` workflow，按同一版本号重新发布 `TorrentClassifier_v1.5.1`，并回查 `torrentclassifier_v1.5.1.zip` 资产。
