### PR TITLE
docs(subscribeassistantenhanced): align module comments with current semantics

### DIFF
--- a/plugins.v2/subscribeassistantenhanced/best_version/converter.py
+++ b/plugins.v2/subscribeassistantenhanced/best_version/converter.py
@@ -1,4 +1,4 @@
-"""域 ⑤：分集→全集转换——以替换订阅方式切换为全集洗版。"""
+"""分集到全集转换：以替换订阅方式切换为全集洗版。"""
 
 from app.log import logger
 from app.schemas.types import EventType

--- a/plugins.v2/subscribeassistantenhanced/guard.py
+++ b/plugins.v2/subscribeassistantenhanced/guard.py
@@ -1,4 +1,4 @@
-"""域 ②：完成守卫——CompletionCheck 事件处理。"""
+"""完成守卫：处理 CompletionCheck 事件并按证据流水线裁决是否完成。"""
 from typing import Callable
 
 from app.log import logger

--- a/plugins.v2/subscribeassistantenhanced/pause/airing.py
+++ b/plugins.v2/subscribeassistantenhanced/pause/airing.py
@@ -1,4 +1,4 @@
-"""域 ④：播出暂停——完结信号前置过滤后按间隔判断。"""
+"""播出暂停：完结信号前置过滤后按间隔判断是否暂停订阅。"""
 import re
 from datetime import date, timedelta
 from typing import Optional

--- a/plugins.v2/subscribeassistantenhanced/pause/manager.py
+++ b/plugins.v2/subscribeassistantenhanced/pause/manager.py
@@ -1,4 +1,4 @@
-"""域 ④：暂停管理——优先级覆盖 + 用户名自动暂停 + 双向恢复。"""
+"""暂停管理：处理优先级覆盖、用户名自动暂停和双向恢复。"""
 import re
 import time
 from typing import Callable, Optional

--- a/plugins.v2/subscribeassistantenhanced/pause/nodownload.py
+++ b/plugins.v2/subscribeassistantenhanced/pause/nodownload.py
@@ -1,4 +1,4 @@
-"""域 ④：无下载处理策略——上映后超期且无下载时按配置暂停、完成或删除订阅。"""
+"""无下载处理策略：上映后超期且无下载时按配置暂停、完成或删除订阅。"""
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Optional

--- a/plugins.v2/subscribeassistantenhanced/pending/refresh.py
+++ b/plugins.v2/subscribeassistantenhanced/pending/refresh.py
@@ -1,4 +1,4 @@
-"""域 ③：EpisodesRefresh 待定观察。
+"""EpisodesRefresh 待定观察。
 
 P 状态只保护订阅生命周期，不覆盖主程序计算出的 total_episode。
 """
@@ -7,7 +7,7 @@ from app.schemas.event import SubscribeEpisodesRefreshEventData
 
 
 class PendingRefresh:
-    """EpisodesRefresh 事件处理：保留域边界，不修改搜索目标范围。"""
+    """EpisodesRefresh 事件处理：保持职责边界，不修改搜索目标范围。"""
 
     def handle_refresh(self, data: SubscribeEpisodesRefreshEventData):
         """待定状态不覆盖 total_episode，主程序继续使用自己的刷新结果。"""

--- a/plugins.v2/subscribeassistantenhanced/postcheck/timeout.py
+++ b/plugins.v2/subscribeassistantenhanced/postcheck/timeout.py
@@ -1,4 +1,4 @@
-"""域 ⑦J：完成前观察状态机，防止守卫待定永久卡住。"""
+"""完成前观察状态机：管理守卫待定与一次性低置信放行令牌。"""
 import time
 from typing import Callable, Optional
 


### PR DESCRIPTION
## 变更说明

- 清理 SubscribeAssistantEnhanced 模块注释中的旧域编号表述，改为当前业务语义。
- 保留完成守卫、完成前观察、待定观察、暂停、无下载策略和分集转全集的职责说明，但不再沿用旧设计编号。

## 影响路径

- plugins.v2/subscribeassistantenhanced/best_version/converter.py
- plugins.v2/subscribeassistantenhanced/guard.py
- plugins.v2/subscribeassistantenhanced/pause/airing.py
- plugins.v2/subscribeassistantenhanced/pause/manager.py
- plugins.v2/subscribeassistantenhanced/pause/nodownload.py
- plugins.v2/subscribeassistantenhanced/pending/refresh.py
- plugins.v2/subscribeassistantenhanced/postcheck/timeout.py

## 验证

- .githooks/pre-push
- python -m compileall -q plugins.v2/subscribeassistantenhanced
- python -m json.tool package.json >/dev/null
- python -m json.tool package.v2.json >/dev/null
- git diff --check origin/main...HEAD
- tests/run.py -q：CI gate 33 passed，插件 v2 全量 1962 passed

## 交付路径

PR-only：不包含版本升级、tag 或 GitHub Release。

## 隐私检查

PR 正文不包含本机路径、私有日志路径、token、配置内容或其他敏感信息。
