### PR TITLE
feat(subscribeassistantenhanced): 新增"搜索诊断"——订阅按原规则长期搜不到时发诊断通知

### DIFF
--- a/plugins.v2/subscribeassistantenhanced/__init__.py
+++ b/plugins.v2/subscribeassistantenhanced/__init__.py
@@ -415,7 +415,6 @@ class SubscribeAssistantEnhanced(_PluginBase):
             tm.update,
             subscribe_oper=self._subscribe_oper,
             notify_fn=self._notify_subscribe,
-            get_subscribe_image_fn=self._get_subscribe_image,
         )
 
         self._event_proxy = EventProxy(

--- a/plugins.v2/subscribeassistantenhanced/__init__.py
+++ b/plugins.v2/subscribeassistantenhanced/__init__.py
@@ -40,6 +40,7 @@ from .pause.airing import AiringPauseChecker
 from .pause.manager import PauseManager
 from .pause.nodownload import NoDownloadPolicy
 from .pause.probe import PausedProbeCoordinator
+from .noresult import NoResultDiagnosticCoordinator
 from .best_version.priority import PriorityManager
 from .best_version.converter import BestVersionConverter
 from .best_version.orchestrator import BestVersionOrchestrator
@@ -408,6 +409,15 @@ class SubscribeAssistantEnhanced(_PluginBase):
         )
         self._paused_probe_coordinator = paused_probe
 
+        no_result_diagnostic = NoResultDiagnosticCoordinator(
+            cfg,
+            tm.read,
+            tm.update,
+            subscribe_oper=self._subscribe_oper,
+            notify_fn=self._notify_subscribe,
+            get_subscribe_image_fn=self._get_subscribe_image,
+        )
+
         self._event_proxy = EventProxy(
             task_manager=tm,
             subscribe_oper=self._subscribe_oper,
@@ -460,6 +470,7 @@ class SubscribeAssistantEnhanced(_PluginBase):
             "no_download_policy": no_download_policy,
             "download_monitor": download_monitor,
             "paused_probe": paused_probe,
+            "no_result_diagnostic": no_result_diagnostic,
             "torrent_cleanup": torrent_cleanup,
             "deletes_store": deletes_store,
             "guard": guard,
@@ -611,6 +622,7 @@ class SubscribeAssistantEnhanced(_PluginBase):
             "deletes",
             "volatility",
             "site_evidence",
+            "no_result",
             "subscription_cleanup_histories",
         ]:
             self.save_data(key, {})
@@ -995,6 +1007,7 @@ class SubscribeAssistantEnhanced(_PluginBase):
         tasks.append(("待定状态一致性检查", self.run_pending_state_reconcile))
         tasks.append(("无下载处理", self.run_no_download_check))
         tasks.append(("暂停订阅低频补搜", self.run_paused_probe_check))
+        tasks.append(("搜索诊断", self.run_no_result_diagnostic))
         tasks.append(("站点证据采样", self.run_site_evidence_scan))
         if self._config.download_monitor_enabled:
             tasks.append(("删除记录清理", self.run_deletes_cleanup))
@@ -1011,6 +1024,12 @@ class SubscribeAssistantEnhanced(_PluginBase):
     def run_paused_probe_check(self):
         """暂停订阅低频补搜巡检：登记外部暂停，并按配置安排单订阅搜索。"""
         coordinator = self._modules.get("paused_probe")
+        if coordinator:
+            coordinator.run()
+
+    def run_no_result_diagnostic(self):
+        """搜索诊断巡检：识别按原规则长期搜不到的订阅并发出诊断通知。"""
+        coordinator = self._modules.get("no_result_diagnostic")
         if coordinator:
             coordinator.run()
 

--- a/plugins.v2/subscribeassistantenhanced/form/__init__.py
+++ b/plugins.v2/subscribeassistantenhanced/form/__init__.py
@@ -60,6 +60,10 @@ LABELS = {
     "paused_probe_reasons": "暂停订阅补搜场景",
     "paused_probe_min_pause_days": "暂停满N天后补搜",
     "paused_probe_interval_hours": "补搜间隔（小时）",
+    # 搜索诊断
+    "no_result_diagnostic_enabled": "搜索诊断",
+    "no_result_diagnostic_rounds": "连续未搜到轮数",
+    "no_result_diagnostic_cooldown_hours": "通知冷却（小时）",
     # 订阅洗版
     "best_version_type": "洗版类型",
     "best_version_episode_to_full": "分集转全集",
@@ -137,6 +141,10 @@ HINTS = {
     "paused_probe_reasons": "选择哪些暂停原因需要低频补搜",
     "paused_probe_min_pause_days": "暂停满N天后才补搜，为0时不处理",
     "paused_probe_interval_hours": "同一订阅两次补搜的最小间隔",
+    # 搜索诊断
+    "no_result_diagnostic_enabled": "订阅按原规则长期搜不到时发诊断通知；只读观察，不改搜索规则/站点、不下载",
+    "no_result_diagnostic_rounds": "缺失集数连续 N 轮巡检未减少后提醒；0=不处理",
+    "no_result_diagnostic_cooldown_hours": "同一订阅两次诊断通知的最小间隔，避免反复打扰",
     # 订阅洗版
     "best_version_type": "选择需要自动洗版的类型，关闭时不自动创建和巡检洗版订阅",
     "best_version_episode_to_full": "订阅目标集数满足时，从分集洗版切换为全集洗版",
@@ -206,6 +214,9 @@ TABS = [
         ["recognition_guard_mode", "recognition_guard_notify", "recognition_guard_notify_interval"],
         ["recognition_guard_tmdb_recheck_mode", "recognition_guard_cache_maxsize"],
         [("recognition_guard_custom_config", 12)],
+    ]),
+    ("搜索诊断", [
+        ["no_result_diagnostic_enabled", "no_result_diagnostic_rounds", "no_result_diagnostic_cooldown_hours"],
     ]),
 ]
 

--- a/plugins.v2/subscribeassistantenhanced/noresult/__init__.py
+++ b/plugins.v2/subscribeassistantenhanced/noresult/__init__.py
@@ -1,0 +1,7 @@
+"""搜索诊断子模块：订阅按原规则长期搜不到资源时发出诊断通知。
+
+只做只读观察与通知，不改动订阅的搜索规则、站点范围或下载行为。
+"""
+from .diagnostic import NoResultDiagnosticCoordinator
+
+__all__ = ["NoResultDiagnosticCoordinator"]

--- a/plugins.v2/subscribeassistantenhanced/noresult/diagnostic.py
+++ b/plugins.v2/subscribeassistantenhanced/noresult/diagnostic.py
@@ -1,10 +1,12 @@
-"""搜索诊断协调器：识别"按原规则长期搜不到"的订阅并发出诊断通知。
+"""搜索诊断协调器：识别"订阅长期无新进展"并发出保守的诊断提示。
 
 设计约束（重要）：
 - 只读观察，不触发搜索、不修改订阅的 include/exclude/站点范围、不下载。
-- "搜不到"的判据采用事实信号法：连续多轮巡检中订阅缺失集数（lack_episode）
-  未减少，即视为该轮"未搜到新资源"，累计达到阈值后提醒用户检查过滤规则/站点。
-  该判据不依赖主程序 search 返回值，因此不介入搜索召回链路。
+- 判据采用事实信号法：连续多轮巡检中订阅缺失集数（lack_episode）未减少，
+  即视为该轮"无新进展"，累计达到阈值后发出保守提示。该判据只能说明订阅
+  暂无进展，不足以确定具体原因（资源暂缺、仍在播出、规则或站点过窄、识别或
+  下载异常等），因此通知文案不对原因下定论，仅供用户参考。
+- 判据不依赖主程序 search 返回值，不介入搜索召回链路。
 - 通知带冷却，避免同一订阅反复打扰。
 
 状态持久化在任务数据的独立 key ``no_result`` 下，结构为::
@@ -26,9 +28,6 @@ from ..shared.subscribe import format_subscribe, format_subscribe_label
 
 # 任务数据 key，与其它子模块（subscribes/blocks/...）并列
 NO_RESULT_TASK_KEY = "no_result"
-
-# 单轮巡检最多处理的候选数，避免大量订阅时单轮耗时过长
-MAX_CANDIDATES = 50
 
 
 class NoResultDiagnosticCoordinator:
@@ -76,23 +75,24 @@ class NoResultDiagnosticCoordinator:
         now = self._now()
         cooldown_seconds = self._cooldown_hours() * 3600
         subscribes = self._subscribe_oper.list(state="R") or []
-        alive_sids = set()
-        processed = 0
+
+        # 本轮实际完整扫描到的订阅集合。诊断为纯只读观察 + 轻量状态更新，
+        # 不发起搜索请求，开销很小，因此不做固定截断，避免订阅较多时列表
+        # 尾部订阅永远无法累计轮数、且其历史状态被误清理导致漏诊断。
+        scanned_sids = set()
         for subscribe in subscribes:
-            if processed >= MAX_CANDIDATES:
-                detail(f"搜索诊断：本轮已达到 {MAX_CANDIDATES} 个候选上限")
-                break
             sid = str(subscribe.id)
+            scanned_sids.add(sid)
             lack = self._lack_episode(subscribe)
-            # 只诊断"仍缺集"的订阅；已补齐的订阅不属于搜不到
             if lack <= 0:
+                # 已补齐：不属于搜不到，清掉可能存在的历史计数
+                self._clear(sid)
                 continue
-            alive_sids.add(sid)
-            processed += 1
             self._evaluate(subscribe, sid, lack, now, rounds_threshold, cooldown_seconds)
 
-        # 清理已不再需要跟踪的订阅记录（已补齐/已删除/已非启用）
-        self._prune(alive_sids)
+        # 仅清理"已不在启用订阅列表中"（删除/暂停/完成）的历史记录；
+        # 只按本轮完整扫描到的订阅全集判断，不受任何截断影响。
+        self._prune(scanned_sids)
 
     def _evaluate(self, subscribe, sid: str, lack: int, now: float,
                   rounds_threshold: int, cooldown_seconds: int):
@@ -136,8 +136,8 @@ class NoResultDiagnosticCoordinator:
         self._update(NO_RESULT_TASK_KEY, updater)
 
     def _send_notification(self, subscribe, lack: int, miss_rounds: int):
-        """发送诊断通知，提示用户检查过滤规则与站点范围。"""
-        title = f"{format_subscribe_label(subscribe, str(subscribe.id))} 长期未搜到资源"
+        """发送保守的诊断提示：仅告知长期无进展，不对具体原因下定论。"""
+        title = f"{format_subscribe_label(subscribe, str(subscribe.id))} 长期无新进展"
         image = None
         if self._get_image:
             try:
@@ -152,22 +152,40 @@ class NoResultDiagnosticCoordinator:
         self._notify(
             title,
             reason=f"连续 {miss_rounds} 轮巡检缺失集数未减少，当前仍缺 {lack} 集",
-            action="请检查订阅的过滤规则（include/exclude）、优先级规则组与站点范围是否过严",
-            image=image,
-            link=link,
+            action=(
+                "可能原因较多（资源暂未发布、仍在播出、订阅规则或站点范围较窄、识别或下载异常等），"
+                "本提示仅供参考，建议在方便时留意该订阅"
+            ),
+            follow_up="如确认规则或站点范围过窄，可在原生订阅中调整后由订阅链路继续搜索",
             diagnostic=True,
         )
 
-    def _prune(self, alive_sids: set):
-        """移除不在本轮活跃集合中的历史记录，避免无限增长。"""
+    def _prune(self, scanned_sids: set):
+        """移除已不在启用订阅列表中的历史记录（删除/暂停/完成），避免无限增长。
+
+        仅依据本轮完整扫描到的订阅全集判断，不做候选截断，因此不会误删
+        尚未轮到扫描的活跃订阅状态。
+        """
         current = self._read(NO_RESULT_TASK_KEY) or {}
-        stale = [sid for sid in current if sid not in alive_sids]
+        stale = [sid for sid in current if sid not in scanned_sids]
         if not stale:
             return
 
         def updater(data: dict) -> dict:
             for sid in stale:
                 data.pop(sid, None)
+            return data
+
+        self._update(NO_RESULT_TASK_KEY, updater)
+
+    def _clear(self, sid: str):
+        """清除单个订阅的诊断计数（例如已补齐缺集）。"""
+        current = self._read(NO_RESULT_TASK_KEY) or {}
+        if sid not in current:
+            return
+
+        def updater(data: dict) -> dict:
+            data.pop(sid, None)
             return data
 
         self._update(NO_RESULT_TASK_KEY, updater)

--- a/plugins.v2/subscribeassistantenhanced/noresult/diagnostic.py
+++ b/plugins.v2/subscribeassistantenhanced/noresult/diagnostic.py
@@ -1,0 +1,197 @@
+"""搜索诊断协调器：识别"按原规则长期搜不到"的订阅并发出诊断通知。
+
+设计约束（重要）：
+- 只读观察，不触发搜索、不修改订阅的 include/exclude/站点范围、不下载。
+- "搜不到"的判据采用事实信号法：连续多轮巡检中订阅缺失集数（lack_episode）
+  未减少，即视为该轮"未搜到新资源"，累计达到阈值后提醒用户检查过滤规则/站点。
+  该判据不依赖主程序 search 返回值，因此不介入搜索召回链路。
+- 通知带冷却，避免同一订阅反复打扰。
+
+状态持久化在任务数据的独立 key ``no_result`` 下，结构为::
+
+    data[str(sid)] = {
+        "miss_rounds": int,        # 连续未减少缺集的巡检轮数
+        "last_lack": int,          # 上轮记录的缺失集数
+        "last_notified_at": float, # 上次诊断通知时间戳，用于冷却
+    }
+"""
+import time
+from typing import Callable, Optional
+
+from app.log import logger
+
+from ..shared.log import detail
+from ..shared.subscribe import format_subscribe, format_subscribe_label
+
+
+# 任务数据 key，与其它子模块（subscribes/blocks/...）并列
+NO_RESULT_TASK_KEY = "no_result"
+
+# 单轮巡检最多处理的候选数，避免大量订阅时单轮耗时过长
+MAX_CANDIDATES = 50
+
+
+class NoResultDiagnosticCoordinator:
+    """维护"长期搜不到"诊断状态并按阈值/冷却发出通知。
+
+    该协调器只观察订阅的缺失集数变化，不触发搜索、不改动搜索规则、不下载。
+    """
+
+    def __init__(self, config, task_data_read: Callable, task_data_update: Callable,
+                 subscribe_oper, notify_fn: Callable,
+                 get_subscribe_image_fn: Optional[Callable] = None,
+                 now_fn: Optional[Callable] = None):
+        """注入配置、任务数据读写、订阅查询和通知入口。
+
+        :param config: 插件配置对象（稳定的内部结构）。
+        :param task_data_read: 任务数据读取函数（TaskDataManager.read）。
+        :param task_data_update: 任务数据读-改-写函数（TaskDataManager.update）。
+        :param subscribe_oper: 订阅查询操作对象。
+        :param notify_fn: 通知发送函数（插件的 _notify_subscribe）。
+        :param get_subscribe_image_fn: 可选，返回订阅海报图片的函数。
+        :param now_fn: 可选，可替换时钟，便于测试。
+        """
+        self._config = config
+        self._read = task_data_read
+        self._update = task_data_update
+        self._subscribe_oper = subscribe_oper
+        self._notify = notify_fn
+        self._get_image = get_subscribe_image_fn
+        self._now = now_fn or time.time
+
+    def run(self):
+        """扫描启用中的订阅，累计"未搜到"轮数并按阈值发出诊断通知。"""
+        if not self._enabled():
+            detail("搜索诊断：未开启，跳过")
+            return
+        if not self._subscribe_oper:
+            detail("搜索诊断：订阅查询依赖未就绪，跳过")
+            return
+
+        rounds_threshold = self._rounds_threshold()
+        if rounds_threshold <= 0:
+            detail("搜索诊断：轮数阈值为 0，跳过")
+            return
+
+        now = self._now()
+        cooldown_seconds = self._cooldown_hours() * 3600
+        subscribes = self._subscribe_oper.list(state="R") or []
+        alive_sids = set()
+        processed = 0
+        for subscribe in subscribes:
+            if processed >= MAX_CANDIDATES:
+                detail(f"搜索诊断：本轮已达到 {MAX_CANDIDATES} 个候选上限")
+                break
+            sid = str(subscribe.id)
+            lack = self._lack_episode(subscribe)
+            # 只诊断"仍缺集"的订阅；已补齐的订阅不属于搜不到
+            if lack <= 0:
+                continue
+            alive_sids.add(sid)
+            processed += 1
+            self._evaluate(subscribe, sid, lack, now, rounds_threshold, cooldown_seconds)
+
+        # 清理已不再需要跟踪的订阅记录（已补齐/已删除/已非启用）
+        self._prune(alive_sids)
+
+    def _evaluate(self, subscribe, sid: str, lack: int, now: float,
+                  rounds_threshold: int, cooldown_seconds: int):
+        """比对本轮与上轮缺集数，更新轮数并在达标时通知。"""
+        record = (self._read(NO_RESULT_TASK_KEY) or {}).get(sid, {})
+        last_lack = record.get("last_lack")
+        last_notified_at = float(record.get("last_notified_at") or 0)
+
+        if last_lack is None:
+            # 首次观察：仅登记基线，不计轮数
+            miss_rounds = 0
+        elif lack < int(last_lack):
+            # 缺集减少，说明搜到并下载了新资源，重置计数
+            miss_rounds = 0
+        else:
+            # 缺集未减少，累计一轮"未搜到"
+            miss_rounds = int(record.get("miss_rounds", 0)) + 1
+
+        should_notify = (
+            miss_rounds >= rounds_threshold
+            and (last_notified_at <= 0 or now - last_notified_at >= cooldown_seconds)
+        )
+
+        notified_at = last_notified_at
+        if should_notify:
+            self._send_notification(subscribe, lack, miss_rounds)
+            notified_at = now
+            logger.info(
+                f"搜索诊断：{format_subscribe(subscribe)} 连续 {miss_rounds} 轮未搜到资源，"
+                f"缺 {lack} 集，已发送诊断通知"
+            )
+
+        def updater(data: dict) -> dict:
+            task = data.get(sid, {})
+            task["miss_rounds"] = miss_rounds
+            task["last_lack"] = lack
+            task["last_notified_at"] = notified_at
+            data[sid] = task
+            return data
+
+        self._update(NO_RESULT_TASK_KEY, updater)
+
+    def _send_notification(self, subscribe, lack: int, miss_rounds: int):
+        """发送诊断通知，提示用户检查过滤规则与站点范围。"""
+        title = f"{format_subscribe_label(subscribe, str(subscribe.id))} 长期未搜到资源"
+        image = None
+        if self._get_image:
+            try:
+                image = self._get_image(subscribe)
+            except Exception:
+                image = None
+        link = (
+            "#/subscribe/tv?tab=mysub"
+            if getattr(subscribe, "type", "") == "电视剧"
+            else "#/subscribe/movie?tab=mysub"
+        )
+        self._notify(
+            title,
+            reason=f"连续 {miss_rounds} 轮巡检缺失集数未减少，当前仍缺 {lack} 集",
+            action="请检查订阅的过滤规则（include/exclude）、优先级规则组与站点范围是否过严",
+            image=image,
+            link=link,
+            diagnostic=True,
+        )
+
+    def _prune(self, alive_sids: set):
+        """移除不在本轮活跃集合中的历史记录，避免无限增长。"""
+        current = self._read(NO_RESULT_TASK_KEY) or {}
+        stale = [sid for sid in current if sid not in alive_sids]
+        if not stale:
+            return
+
+        def updater(data: dict) -> dict:
+            for sid in stale:
+                data.pop(sid, None)
+            return data
+
+        self._update(NO_RESULT_TASK_KEY, updater)
+
+    def _enabled(self) -> bool:
+        """读取搜索诊断总开关。"""
+        return bool(self._config.no_result_diagnostic_enabled)
+
+    def _rounds_threshold(self) -> int:
+        """读取连续未搜到的轮数阈值 N。"""
+        return int(self._config.no_result_diagnostic_rounds or 0)
+
+    def _cooldown_hours(self) -> int:
+        """读取同一订阅两次诊断通知的最小间隔小时数。"""
+        return int(self._config.no_result_diagnostic_cooldown_hours or 0)
+
+    @staticmethod
+    def _lack_episode(subscribe) -> int:
+        """读取订阅缺失集数；电影缺失以未入库视为 1。"""
+        lack = getattr(subscribe, "lack_episode", None)
+        if lack is None:
+            # 电影订阅无 lack_episode 概念，用 total-已完成近似；缺省按仍缺处理
+            return 1 if getattr(subscribe, "type", "") == "电影" else 0
+        try:
+            return int(lack)
+        except (TypeError, ValueError):
+            return 0

--- a/plugins.v2/subscribeassistantenhanced/noresult/diagnostic.py
+++ b/plugins.v2/subscribeassistantenhanced/noresult/diagnostic.py
@@ -38,7 +38,6 @@ class NoResultDiagnosticCoordinator:
 
     def __init__(self, config, task_data_read: Callable, task_data_update: Callable,
                  subscribe_oper, notify_fn: Callable,
-                 get_subscribe_image_fn: Optional[Callable] = None,
                  now_fn: Optional[Callable] = None):
         """注入配置、任务数据读写、订阅查询和通知入口。
 
@@ -47,7 +46,6 @@ class NoResultDiagnosticCoordinator:
         :param task_data_update: 任务数据读-改-写函数（TaskDataManager.update）。
         :param subscribe_oper: 订阅查询操作对象。
         :param notify_fn: 通知发送函数（插件的 _notify_subscribe）。
-        :param get_subscribe_image_fn: 可选，返回订阅海报图片的函数。
         :param now_fn: 可选，可替换时钟，便于测试。
         """
         self._config = config
@@ -55,7 +53,6 @@ class NoResultDiagnosticCoordinator:
         self._update = task_data_update
         self._subscribe_oper = subscribe_oper
         self._notify = notify_fn
-        self._get_image = get_subscribe_image_fn
         self._now = now_fn or time.time
 
     def run(self):
@@ -80,6 +77,9 @@ class NoResultDiagnosticCoordinator:
         # 不发起搜索请求，开销很小，因此不做固定截断，避免订阅较多时列表
         # 尾部订阅永远无法累计轮数、且其历史状态被误清理导致漏诊断。
         scanned_sids = set()
+        # 本轮新达到阈值、需要提醒的订阅统一收集，最后合并为一条汇总通知，
+        # 避免订阅较多时逐条推送造成通知风暴。
+        due_notify = []
         for subscribe in subscribes:
             sid = str(subscribe.id)
             scanned_sids.add(sid)
@@ -88,15 +88,22 @@ class NoResultDiagnosticCoordinator:
                 # 已补齐：不属于搜不到，清掉可能存在的历史计数
                 self._clear(sid)
                 continue
-            self._evaluate(subscribe, sid, lack, now, rounds_threshold, cooldown_seconds)
+            if self._evaluate(subscribe, sid, lack, now, rounds_threshold, cooldown_seconds):
+                due_notify.append((subscribe, lack))
+
+        if due_notify:
+            self._send_summary(due_notify)
 
         # 仅清理"已不在启用订阅列表中"（删除/暂停/完成）的历史记录；
         # 只按本轮完整扫描到的订阅全集判断，不受任何截断影响。
         self._prune(scanned_sids)
 
     def _evaluate(self, subscribe, sid: str, lack: int, now: float,
-                  rounds_threshold: int, cooldown_seconds: int):
-        """比对本轮与上轮缺集数，更新轮数并在达标时通知。"""
+                  rounds_threshold: int, cooldown_seconds: int) -> bool:
+        """比对本轮与上轮缺集数并更新轮数。
+
+        返回本轮是否"新达到阈值且已过冷却"，由调用方收集后合并为一条汇总通知。
+        """
         record = (self._read(NO_RESULT_TASK_KEY) or {}).get(sid, {})
         last_lack = record.get("last_lack")
         last_notified_at = float(record.get("last_notified_at") or 0)
@@ -116,13 +123,11 @@ class NoResultDiagnosticCoordinator:
             and (last_notified_at <= 0 or now - last_notified_at >= cooldown_seconds)
         )
 
-        notified_at = last_notified_at
+        notified_at = now if should_notify else last_notified_at
         if should_notify:
-            self._send_notification(subscribe, lack, miss_rounds)
-            notified_at = now
             logger.info(
                 f"搜索诊断：{format_subscribe(subscribe)} 连续 {miss_rounds} 轮未搜到资源，"
-                f"缺 {lack} 集，已发送诊断通知"
+                f"缺 {lack} 集，纳入本轮诊断汇总"
             )
 
         def updater(data: dict) -> dict:
@@ -134,29 +139,38 @@ class NoResultDiagnosticCoordinator:
             return data
 
         self._update(NO_RESULT_TASK_KEY, updater)
+        return should_notify
 
-    def _send_notification(self, subscribe, lack: int, miss_rounds: int):
-        """发送保守的诊断提示：仅告知长期无进展，不对具体原因下定论。"""
-        title = f"{format_subscribe_label(subscribe, str(subscribe.id))} 长期无新进展"
-        image = None
-        if self._get_image:
-            try:
-                image = self._get_image(subscribe)
-            except Exception:
-                image = None
-        link = (
-            "#/subscribe/tv?tab=mysub"
-            if getattr(subscribe, "type", "") == "电视剧"
-            else "#/subscribe/movie?tab=mysub"
+    def _send_summary(self, due_notify: list):
+        """把本轮所有新达标订阅合并为一条保守的诊断汇总通知，避免通知风暴。
+
+        :param due_notify: [(subscribe, lack), ...]
+        """
+        count = len(due_notify)
+        # 逐条明细，条数较多时截断展示，完整数量在标题体现
+        max_lines = 20
+        lines = []
+        for subscribe, lack in due_notify[:max_lines]:
+            lines.append(f"· {format_subscribe_label(subscribe, str(subscribe.id))}（仍缺 {lack} 集）")
+        if count > max_lines:
+            lines.append(f"…… 等共 {count} 个订阅")
+
+        title = (
+            f"{count} 个订阅长期无新进展"
+            if count > 1
+            else f"{format_subscribe_label(due_notify[0][0], str(due_notify[0][0].id))} 长期无新进展"
         )
+        # 跳转到订阅管理页；汇总覆盖多个订阅，不附单个海报
+        link = "#/subscribe/tv?tab=mysub"
         self._notify(
             title,
-            reason=f"连续 {miss_rounds} 轮巡检缺失集数未减少，当前仍缺 {lack} 集",
+            text="\n".join(lines),
             action=(
                 "可能原因较多（资源暂未发布、仍在播出、订阅规则或站点范围较窄、识别或下载异常等），"
-                "本提示仅供参考，建议在方便时留意该订阅"
+                "本提示仅供参考，建议在方便时留意这些订阅"
             ),
             follow_up="如确认规则或站点范围过窄，可在原生订阅中调整后由订阅链路继续搜索",
+            link=link,
             diagnostic=True,
         )
 

--- a/plugins.v2/subscribeassistantenhanced/shared/config.py
+++ b/plugins.v2/subscribeassistantenhanced/shared/config.py
@@ -435,6 +435,23 @@ class PluginConfig:
         """同一订阅主动补搜的最小间隔，运行时不低于 24 小时。"""
         return max(self.get_int("paused_probe_interval_hours", 72), 24)
 
+    # ---- 搜索诊断 ----
+
+    @property
+    def no_result_diagnostic_enabled(self) -> bool:
+        """搜索诊断：订阅按原规则长期搜不到资源时发出诊断通知；只读观察，不改搜索规则/站点、不下载。"""
+        return self.get_bool("no_result_diagnostic_enabled", False)
+
+    @property
+    def no_result_diagnostic_rounds(self) -> int:
+        """连续未搜到轮数阈值：缺失集数连续 N 轮巡检未减少后发出诊断通知；0=不处理。"""
+        return self.get_int("no_result_diagnostic_rounds", 3)
+
+    @property
+    def no_result_diagnostic_cooldown_hours(self) -> int:
+        """同一订阅两次诊断通知的最小间隔小时数，避免反复打扰。"""
+        return self.get_int("no_result_diagnostic_cooldown_hours", 24)
+
     # ---- 订阅洗版 ----
 
     @property

--- a/tests/v2/subscribeassistantenhanced/test_form.py
+++ b/tests/v2/subscribeassistantenhanced/test_form.py
@@ -50,11 +50,11 @@ class TestBuildForm:
         for key in PluginConfig({}).declared_keys():
             assert key in model, f"表单 model 缺少配置键 {key}"
 
-    def test_six_tabs(self):
-        """配置表单使用 6 个 Tab；顶部 BETA 提示不改变 Tab 数量。"""
+    def test_seven_tabs(self):
+        """配置表单使用 7 个 Tab（含搜索诊断）；顶部 BETA 提示不改变 Tab 数量。"""
         conf, _model = build_form()
         assert conf[3]["component"] == "VTabs"
-        assert len(conf[3]["content"]) == 6
+        assert len(conf[3]["content"]) == 7
 
     def test_beta_alert_precedes_form_controls(self):
         """BETA 风险提示固定显示在开关、周期和分页配置之前。"""

--- a/tests/v2/subscribeassistantenhanced/test_form.py
+++ b/tests/v2/subscribeassistantenhanced/test_form.py
@@ -148,8 +148,8 @@ def test_tabs_renders_vtabs_and_vwindow():
     assert out[1]["content"][0]["component"] == "VWindowItem"
 
 
-def test_form_has_top_switches_periods_and_six_tabs():
-    """配置布局：顶部开关行 + 公共周期行 + 6 个 Tab；关键新参数可编辑；多选控件存在。"""
+def test_form_has_top_switches_periods_and_seven_tabs():
+    """配置布局：顶部开关行 + 公共周期行 + 7 个 Tab；关键新参数可编辑；多选控件存在。"""
     import json
     conf, model = build_form()
     flat = json.dumps(conf, ensure_ascii=False)
@@ -160,8 +160,8 @@ def test_form_has_top_switches_periods_and_six_tabs():
     for key in ("download_check_interval_minutes", "meta_check_interval_hours",
                 "auto_check_interval_minutes", "best_version_cron"):
         assert f'"{key}"' in flat
-    # 6 个 Tab + VTabs/VWindow 绑定
-    assert flat.count('"VTab"') == 6
+    # 7 个 Tab + VTabs/VWindow 绑定
+    assert flat.count('"VTab"') == 7
     assert '"_tab"' in flat
     # 关键新参数可编辑
     for key in ("best_version_type", "no_download_actions", "movie_air_pause_days",
@@ -183,7 +183,7 @@ def test_recognition_guard_tab_and_controls_are_rendered():
     conf, model = build_form()
     flat = json.dumps(conf, ensure_ascii=False)
 
-    assert flat.count('"VTab"') == 6
+    assert flat.count('"VTab"') == 7
     assert "识别增强" in flat
     for key in (
         "recognition_guard_mode",

--- a/tests/v2/subscribeassistantenhanced/test_no_result_diagnostic.py
+++ b/tests/v2/subscribeassistantenhanced/test_no_result_diagnostic.py
@@ -166,14 +166,28 @@ def test_zero_rounds_threshold_disables_diagnostic():
 
 
 def test_no_candidate_truncation_covers_all_subscribes():
-    """不做固定候选截断：订阅较多时尾部订阅同样累计并触发通知，不漏诊断。"""
+    """不做固定候选截断：订阅较多时尾部订阅同样累计，不漏诊断。"""
     subs = [_sub(sid=i, lack=5) for i in range(80)]
     coord, data, notify, _ = _coordinator(subs, cfg=_cfg(no_result_diagnostic_rounds=3))
     for _ in range(4):  # 基线 + 3 轮
         coord.run()
-    # 80 个订阅应全部通知，且尾部订阅状态被正确累计（旧版 50 截断会漏后 30 个）
-    assert notify.call_count == 80
+    # 80 个订阅合并为一条汇总通知（不再逐条），且尾部订阅状态被正确累计
+    # （旧版 50 截断会漏后 30 个）
+    assert notify.call_count == 1
     assert data[NO_RESULT_TASK_KEY]["79"]["miss_rounds"] == 3
+
+
+def test_multiple_due_subscribes_merge_into_one_summary():
+    """多个订阅同轮达标时合并为单条汇总通知，避免通知风暴。"""
+    subs = [_sub(sid=i, lack=i + 1) for i in range(5)]
+    coord, data, notify, _ = _coordinator(subs, cfg=_cfg(no_result_diagnostic_rounds=3))
+    for _ in range(4):
+        coord.run()
+    assert notify.call_count == 1
+    args, kwargs = notify.call_args
+    # 标题体现订阅数量，正文包含逐条明细
+    assert "5 个订阅" in args[0]
+    assert kwargs["text"].count("·") == 5
 
 
 def test_notification_wording_is_conservative():

--- a/tests/v2/subscribeassistantenhanced/test_no_result_diagnostic.py
+++ b/tests/v2/subscribeassistantenhanced/test_no_result_diagnostic.py
@@ -1,0 +1,165 @@
+"""搜索诊断协调器单测。
+
+覆盖：首次登记不计轮、缺集未减少累计、达标发通知、冷却抑制、过冷却重发、
+缺集减少重置、补齐后 prune、开关/阈值关闭时不动作。
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from subscribeassistantenhanced.noresult import NoResultDiagnosticCoordinator
+from subscribeassistantenhanced.noresult.diagnostic import NO_RESULT_TASK_KEY
+
+
+def _sub(sid=1, lack=5, type="电视剧"):
+    """构造仍缺集的启用订阅替身。"""
+    return SimpleNamespace(
+        id=sid,
+        name=f"测试{sid}",
+        tmdbid=100 + sid,
+        season=1,
+        type=type,
+        state="R",
+        total_episode=12,
+        lack_episode=lack,
+    )
+
+
+def _cfg(**kwargs):
+    """构造搜索诊断所需配置替身。"""
+    defaults = dict(
+        no_result_diagnostic_enabled=True,
+        no_result_diagnostic_rounds=3,
+        no_result_diagnostic_cooldown_hours=24,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _store(initial=None):
+    """构造 TaskDataManager 兼容的内存读写闭包。"""
+    data = {NO_RESULT_TASK_KEY: initial or {}}
+
+    def read(key):
+        return dict(data.get(key, {}))
+
+    def update(key, updater):
+        cur = data.get(key, {})
+        data[key] = updater(cur)
+        return data[key]
+
+    return data, read, update
+
+
+def _coordinator(subs, cfg=None, initial=None, now=1000.0):
+    """组装被测协调器与内存存储、订阅查询、通知替身。"""
+    data, read, update = _store(initial)
+    oper = MagicMock()
+    oper.list.return_value = subs
+    notify = MagicMock()
+    clock = {"t": now}
+    coord = NoResultDiagnosticCoordinator(
+        cfg or _cfg(),
+        read,
+        update,
+        subscribe_oper=oper,
+        notify_fn=notify,
+        now_fn=lambda: clock["t"],
+    )
+    return coord, data, notify, clock
+
+
+def _rounds(data, sid=1):
+    return data[NO_RESULT_TASK_KEY].get(str(sid), {}).get("miss_rounds")
+
+
+def test_first_round_only_records_baseline():
+    """首次观察只登记基线缺集数，不计轮、不通知。"""
+    coord, data, notify, _ = _coordinator([_sub(lack=5)])
+    coord.run()
+    assert _rounds(data) == 0
+    assert data[NO_RESULT_TASK_KEY]["1"]["last_lack"] == 5
+    notify.assert_not_called()
+
+
+def test_unchanged_lack_accumulates_rounds():
+    """缺集连续未减少时逐轮累计 miss_rounds。"""
+    coord, data, notify, _ = _coordinator([_sub(lack=5)])
+    coord.run()  # 基线
+    coord.run()
+    assert _rounds(data) == 1
+    coord.run()
+    assert _rounds(data) == 2
+    notify.assert_not_called()
+
+
+def test_reaching_threshold_sends_notification():
+    """达到轮数阈值后发出一次诊断通知，且标记 diagnostic=True。"""
+    coord, data, notify, _ = _coordinator([_sub(lack=5)], cfg=_cfg(no_result_diagnostic_rounds=3))
+    for _ in range(4):  # 基线 + 3 轮未减少
+        coord.run()
+    assert notify.call_count == 1
+    _, kwargs = notify.call_args
+    assert kwargs.get("diagnostic") is True
+    assert kwargs.get("action")
+
+
+def test_cooldown_suppresses_repeat_notification():
+    """冷却期内不重复通知。"""
+    coord, data, notify, clock = _coordinator([_sub(lack=5)], cfg=_cfg(no_result_diagnostic_rounds=3))
+    for _ in range(4):
+        coord.run()
+    assert notify.call_count == 1
+    coord.run()  # 仍在 24h 冷却内
+    assert notify.call_count == 1
+
+
+def test_notification_resent_after_cooldown():
+    """超过冷却时长后允许再次通知。"""
+    coord, data, notify, clock = _coordinator([_sub(lack=5)], cfg=_cfg(no_result_diagnostic_rounds=3))
+    for _ in range(4):
+        coord.run()
+    assert notify.call_count == 1
+    clock["t"] += 25 * 3600
+    coord.run()
+    assert notify.call_count == 2
+
+
+def test_lack_decrease_resets_rounds():
+    """缺集减少（搜到并下载了新集）时重置轮数。"""
+    sub = _sub(lack=5)
+    coord, data, notify, _ = _coordinator([sub])
+    coord.run()
+    coord.run()
+    assert _rounds(data) == 1
+    sub.lack_episode = 3
+    coord.run()
+    assert _rounds(data) == 0
+
+
+def test_completed_subscribe_is_pruned():
+    """缺集补齐后订阅从跟踪记录中移除。"""
+    sub = _sub(lack=5)
+    coord, data, notify, _ = _coordinator([sub])
+    coord.run()
+    assert "1" in data[NO_RESULT_TASK_KEY]
+    sub.lack_episode = 0
+    coord.run()
+    assert "1" not in data[NO_RESULT_TASK_KEY]
+
+
+def test_disabled_switch_does_nothing():
+    """总开关关闭时不观察、不写记录、不通知。"""
+    coord, data, notify, _ = _coordinator([_sub(lack=5)], cfg=_cfg(no_result_diagnostic_enabled=False))
+    for _ in range(5):
+        coord.run()
+    assert data[NO_RESULT_TASK_KEY] == {}
+    notify.assert_not_called()
+
+
+def test_zero_rounds_threshold_disables_diagnostic():
+    """轮数阈值为 0 时视为关闭，不处理。"""
+    coord, data, notify, _ = _coordinator([_sub(lack=5)], cfg=_cfg(no_result_diagnostic_rounds=0))
+    for _ in range(5):
+        coord.run()
+    assert data[NO_RESULT_TASK_KEY] == {}
+    notify.assert_not_called()

--- a/tests/v2/subscribeassistantenhanced/test_no_result_diagnostic.py
+++ b/tests/v2/subscribeassistantenhanced/test_no_result_diagnostic.py
@@ -163,3 +163,27 @@ def test_zero_rounds_threshold_disables_diagnostic():
         coord.run()
     assert data[NO_RESULT_TASK_KEY] == {}
     notify.assert_not_called()
+
+
+def test_no_candidate_truncation_covers_all_subscribes():
+    """不做固定候选截断：订阅较多时尾部订阅同样累计并触发通知，不漏诊断。"""
+    subs = [_sub(sid=i, lack=5) for i in range(80)]
+    coord, data, notify, _ = _coordinator(subs, cfg=_cfg(no_result_diagnostic_rounds=3))
+    for _ in range(4):  # 基线 + 3 轮
+        coord.run()
+    # 80 个订阅应全部通知，且尾部订阅状态被正确累计（旧版 50 截断会漏后 30 个）
+    assert notify.call_count == 80
+    assert data[NO_RESULT_TASK_KEY]["79"]["miss_rounds"] == 3
+
+
+def test_notification_wording_is_conservative():
+    """诊断文案保守：不对具体原因下定论，标注仅供参考并回到原生订阅链路。"""
+    coord, data, notify, _ = _coordinator([_sub(lack=5)], cfg=_cfg(no_result_diagnostic_rounds=3))
+    for _ in range(4):
+        coord.run()
+    assert notify.call_count == 1
+    _, kwargs = notify.call_args
+    assert "仅供参考" in kwargs["action"]
+    assert "可能原因" in kwargs["action"]
+    assert kwargs.get("follow_up")
+    assert kwargs.get("diagnostic") is True

--- a/tests/v2/subscribeassistantenhanced/test_plugin_entry.py
+++ b/tests/v2/subscribeassistantenhanced/test_plugin_entry.py
@@ -382,7 +382,8 @@ class TestEventRegistration:
         assert "已将 1 个自动暂停订阅恢复为启用：暂停剧 S2" in kwargs["text"]
         assert set(saved) == {
             "subscribes", "torrents", "blocks", "releases", "snapshots",
-            "deletes", "volatility", "site_evidence", "subscription_cleanup_histories",
+            "deletes", "volatility", "site_evidence", "no_result",
+            "subscription_cleanup_histories",
         }
 
     def test_plugin_data_reset_event_logs_without_notify_when_nothing_recovered(self, monkeypatch):


### PR DESCRIPTION
### **User description**
## 背景与动机

订阅设置较严的 include/filter 规则（例如限定某压制组 + 某平台源）时命中率高，但遇到某集资源迟迟未出、或只有其他组先放出时，订阅会**长期搜不到、缺集卡住**，用户往往不自知，只能手动排查。

本 PR 新增一个可选的「搜索诊断」功能：当订阅按原规则连续多轮巡检仍未搜到新资源时，发出一条诊断通知，提示用户检查过滤规则/优先级规则组/站点范围。

## 设计原则（贴合本插件既有边界）

我注意到 README 明确强调「不替代主程序搜索召回、不改动搜索范围」。本功能严格遵守这条边界：

- **只读观察，不介入召回**：判据采用事实信号法——比对每轮巡检的订阅缺失集数（`lack_episode`），连续 N 轮未减少即视为「未搜到新资源」。**不读取也不依赖主程序 search 返回值，不触发搜索，不修改 include/exclude/站点范围，不下载。**
- **带冷却**：同一订阅两次通知有最小间隔，避免反复打扰。
- **自动收敛**：缺集减少即重置计数；补齐后从跟踪记录中移除。

## 实现

- 新增 `noresult/` 子模块（`NoResultDiagnosticCoordinator`），构造签名与注入方式对齐现有 `PausedProbeCoordinator`，状态存独立任务数据 key `no_result`。
- 挂入现有 `run_common_check` 巡检编排（新增 `("搜索诊断", self.run_no_result_diagnostic)` 子任务，独立 try/except）。
- 配置新增 3 项（默认关闭）：`no_result_diagnostic_enabled` / `no_result_diagnostic_rounds`（默认 3）/ `no_result_diagnostic_cooldown_hours`（默认 24），并在配置表单新增「搜索诊断」页签。
- `_reset_task_data` 清空列表加入 `no_result`，避免重置遗漏。

## 测试

新增 `tests/v2/subscribeassistantenhanced/test_no_result_diagnostic.py`，9 个用例覆盖：首次登记不计轮、缺集未减少累计、达标通知、冷却抑制、过冷却重发、缺集减少重置、补齐后 prune、开关关闭、阈值为 0 关闭。

本地已验证：新测试全过；配置默认值与表单 `model 覆盖 declared_keys` 契约通过（不影响既有 `test_config` / `test_form`）。

## 说明

这是刻意做小的最小增量实现，默认关闭、零侵入现有流程。功能形态（判据、是否需要更丰富的诊断信息等）完全欢迎作者指正调整。如方向不合适也完全理解。


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- 新增长期无结果诊断

- 汇总冷却通知避免打扰

- 配置表单增加诊断页

- 补充诊断与表单测试


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>接入搜索诊断巡检与数据重置</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/InfinityPacer/MoviePilot-Plugins/pull/269/files#diff-265e5e8e3a35b888b98cd311835558430c7e49075afe0da15f1625792668f324">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>增加搜索诊断配置表单项</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/InfinityPacer/MoviePilot-Plugins/pull/269/files#diff-a640e68e5581a8f43f1fcc8250b8bd23cf56bba5570d61280158104f4514f4f2">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>暴露搜索诊断子模块入口</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/InfinityPacer/MoviePilot-Plugins/pull/269/files#diff-96b461fa63ff6c439e44b9b8184e0f9b19341e8a77af24598ffd1398f2c8e427">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>diagnostic.py</strong><dd><code>实现长期无进展诊断协调器</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/InfinityPacer/MoviePilot-Plugins/pull/269/files#diff-cdef8a2461bff204fc1e78746003a222b1e8202b806adfb1461918f19fd12b0c">+229/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config.py</strong><dd><code>新增搜索诊断配置读取项</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/InfinityPacer/MoviePilot-Plugins/pull/269/files#diff-b8ce85512974d2b9cd9b889efb7ac8baaf809f898100ce17e4f396072085d6d8">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_form.py</strong><dd><code>更新表单七标签页断言</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/InfinityPacer/MoviePilot-Plugins/pull/269/files#diff-699000a4eaa56283e2d89922f6a0b265e7454462b9c8567c57d87b0afdbbcc36">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_no_result_diagnostic.py</strong><dd><code>覆盖搜索诊断核心行为测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/InfinityPacer/MoviePilot-Plugins/pull/269/files#diff-d6aef5208b2107b4acd83287a35c0b226c07156f8e2bb0f3da32f8825710a918">+203/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_plugin_entry.py</strong><dd><code>校验重置清理诊断数据</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/InfinityPacer/MoviePilot-Plugins/pull/269/files#diff-c342bcdb034610bb77bde20769c4cc4d89487b412864358d37b50454b838b937">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

