### PR TITLE
ci(pr-agent): use inline review workflow

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   pr-agent:
-    name: PR-Agent review, describe and improve
+    name: PR-Agent describe and inline review
     # 所有非 Bot PR 自动处理；手动命令仍限制在可信贡献者的 PR 评论中。
     if: >-
       github.event.sender.type != 'Bot' &&
@@ -59,6 +59,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Remove stale PR-Agent summary comments
+        # Gemini 风格只保留 GitHub Review/行内 discussion；旧版 PR-Agent summary comment 不再留在时间线里。
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## PR Reviewer Guide")) or (.body | startswith("## PR Code Suggestions")) or (.body | contains("Persistent review updated")) or (.body | contains("Persistent suggestions updated")))) | .id' \
+          | while read -r comment_id; do
+              gh api -X DELETE "repos/${REPO}/issues/comments/${comment_id}"
+            done
+
       - name: Run PR-Agent
         id: pragent
         # 使用版本号加 digest 固定容器构建，避免 tag 被重推后改变运行内容。
@@ -84,15 +97,15 @@ jobs:
           config.ignore_pr_title: '["^\\[Auto\\]", "^Auto"]'
           config.ignore_pr_labels: '["skip pr-agent"]'
 
-          # PR 初次进入评审时自动执行 /describe、/review 和 /improve；后续 push 只刷新总览，避免重复内联评论。
-          github_action_config.auto_review: "true"
+          # PR 初次进入评审或后续 push 时，使用 GitHub Review 的行内建议形态对标 Gemini。
+          github_action_config.auto_review: "false"
           github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "true"
 
-          # synchronize 由 push_commands 单独处理，避免每次 push 都创建新的内联改进建议。
+          # synchronize 由 push_commands 单独处理；每次 push 重新生成行内 Review，旧行评由 GitHub 标记 outdated。
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'
           github_action_config.handle_push_trigger: "true"
-          github_action_config.push_commands: '["/describe --pr_description.final_update_message=false", "/review"]'
+          github_action_config.push_commands: '["/describe --pr_description.final_update_message=false", "/improve"]'
 
           # 保留 action outputs，便于后续 workflow 编排或排查。
           github_action_config.enable_output: "true"
@@ -112,7 +125,7 @@ jobs:
             重点检查安全、权限、状态一致性、异步/缓存、副作用和测试缺口。
           pr_reviewer.num_max_findings: "5"
           pr_reviewer.persistent_comment: "true"
-          pr_reviewer.final_update_message: "true"
+          pr_reviewer.final_update_message: "false"
           pr_reviewer.publish_output_no_suggestions: "true"
           pr_reviewer.require_tests_review: "true"
           pr_reviewer.require_security_review: "true"
@@ -123,6 +136,9 @@ jobs:
           pr_reviewer.enable_review_labels_security: "true"
 
           # /improve 以 GitHub 内联建议呈现，便于像正式 review discussion 一样逐条处理。
+          pr_code_suggestions.extra_instructions: |
+            请用中文输出。
+            只给出需要维护者处理的实质性问题，避免纯格式、偏好或低价值建议。
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
           pr_code_suggestions.num_code_suggestions_per_chunk: "2"


### PR DESCRIPTION
### **User description**
## 变更说明

将 PR-Agent 自动评审切换为更接近 Gemini Code Assist 的形态：

- 自动流程不再执行 `/review`，避免在 PR 时间线发布 `PR Reviewer Guide` 聚合表格。
- 初次打开和后续 push 都执行 `/improve`，通过 GitHub Review 产生行内 discussion / suggestion。
- 后续 push 仍刷新 `/describe`，但不发布最终更新提示评论。
- 运行前清理旧版 PR-Agent 发布的普通 summary comment，只匹配 `github-actions[bot]` 的 PR-Agent summary 标记，不清理用户评论或行内 review。

## 验证

- workflow YAML 解析通过。
- `git diff --check`
- `.githooks/pre-push`
- 使用测试 PR #274 的真实评论验证清理条件仅命中旧 PR-Agent summary comment。

## 交付边界

PR-only：仅调整 PR-Agent workflow，不涉及插件版本、tag 或 GitHub Release。


___

### **PR Type**
Enhancement


___

### **Description**
- 切换为行内 `/improve` 评审

- 清理旧 PR-Agent 总结评论

- push 时刷新描述与建议

- 优化中文建议输出策略


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>调整 PR-Agent 行内评审流程</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>重命名任务为描述与行内评审。<br> <li> 新增步骤删除旧 PR-Agent 总结评论。<br> <li> 关闭自动 <code>/review</code>，启用自动 <code>/improve</code>。<br> <li> push 时执行 <code>/describe</code> 与 <code>/improve</code>。</ul>


</details>


  </td>
  <td><a href="https://github.com/InfinityPacer/MoviePilot-Plugins/pull/275/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+22/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

