### PR TITLE
ci(pr-agent): keep inline review history

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   pr-agent:
-    name: PR-Agent describe and inline review
+    name: PR-Agent inline review
     # 所有非 Bot PR 自动处理；手动命令仍限制在可信贡献者的 PR 评论中。
     if: >-
       github.event.sender.type != 'Bot' &&
@@ -59,19 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Remove stale PR-Agent summary comments
-        # Gemini 风格只保留 GitHub Review/行内 discussion；旧版 PR-Agent summary comment 不再留在时间线里。
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-        run: |
-          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '.[] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## PR Reviewer Guide")) or (.body | startswith("## PR Code Suggestions")) or (.body | contains("Persistent review updated")) or (.body | contains("Persistent suggestions updated")))) | .id' \
-          | while read -r comment_id; do
-              gh api -X DELETE "repos/${REPO}/issues/comments/${comment_id}"
-            done
-
       - name: Run PR-Agent
         id: pragent
         # 使用版本号加 digest 固定容器构建，避免 tag 被重推后改变运行内容。
@@ -97,15 +84,15 @@ jobs:
           config.ignore_pr_title: '["^\\[Auto\\]", "^Auto"]'
           config.ignore_pr_labels: '["skip pr-agent"]'
 
-          # PR 初次进入评审或后续 push 时，使用 GitHub Review 的行内建议形态对标 Gemini。
+          # PR 初次进入评审或后续 push 时，使用 GitHub Review 的行内建议形态对标 Gemini/Codex Reviewer。
           github_action_config.auto_review: "false"
-          github_action_config.auto_describe: "true"
+          github_action_config.auto_describe: "false"
           github_action_config.auto_improve: "true"
 
           # synchronize 由 push_commands 单独处理；每次 push 重新生成行内 Review，旧行评由 GitHub 标记 outdated。
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'
           github_action_config.handle_push_trigger: "true"
-          github_action_config.push_commands: '["/describe --pr_description.final_update_message=false", "/improve"]'
+          github_action_config.push_commands: '["/improve"]'
 
           # 保留 action outputs，便于后续 workflow 编排或排查。
           github_action_config.enable_output: "true"


### PR DESCRIPTION
### **User description**
## 变更说明

将 PR-Agent 自动评审收敛到更接近 Gemini Code Assist / Codex Reviewer 的形态：

- 不再删除旧的 PR-Agent summary comment，便于观察历史变化。
- 自动流程只执行 `/improve`，通过 GitHub Review 产生新的行内 discussion / suggestion。
- 不再自动执行 `/describe`，避免自动改写 PR description。
- 后续 push 继续重新运行 `/improve`，旧行内评论由 GitHub 按 diff/commit 关系显示 outdated。

## 调研结论

- Gemini 示例 PR 的多次 review 都是新的 GitHub Review，旧行内评论保留并绑定各自 commit。
- Codex Reviewer 的官方形态是标准 GitHub code review，聚焦严重问题，不是持续编辑 persistent summary。

## 验证

- workflow YAML 解析通过。
- `git diff --check`
- `.githooks/pre-push`

## 交付边界

PR-only：仅调整 PR-Agent workflow，不涉及插件版本、tag 或 GitHub Release。


___

### **PR Type**
Enhancement


___

### **Description**
- 仅保留行内评审流程

- 禁用自动 PR 描述

- push 仅执行 `/improve`

- 保留历史 review 记录


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>改为仅执行行内改进评审</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>将任务名称改为 <code>PR-Agent inline review</code><br> <li> 停止自动执行 <code>/describe</code><br> <li> push 触发时仅运行 <code>/improve</code><br> <li> 让旧行内评论由 GitHub 标记 outdated</ul>


</details>


  </td>
  <td><a href="https://github.com/InfinityPacer/MoviePilot-Plugins/pull/276/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+4/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

