### PR TITLE
test(pr-agent): clean inline review probe

### DIFF
--- a/scripts/pr_agent_inline_review_probe.py
+++ b/scripts/pr_agent_inline_review_probe.py
@@ -1,0 +1,10 @@
+"""Temporary PR-Agent inline review probe.
+
+This file is only used to validate the repository PR-Agent workflow on a
+same-repository pull request and is not intended to be merged.
+"""
+
+
+def evaluate_probe_expression(expression: str, event: dict) -> bool:
+    """Evaluate a temporary probe expression."""
+    return bool(eval(expression, {"event": event}))

--- a/scripts/pr_agent_inline_review_probe.py
+++ b/scripts/pr_agent_inline_review_probe.py
@@ -5,6 +5,13 @@ same-repository pull request and is not intended to be merged.
 """
 
 
-def evaluate_probe_expression(expression: str, event: dict) -> bool:
-    """Evaluate a temporary probe expression."""
-    return bool(eval(expression, {"event": event}))
+def match_probe_event(expected_type: str, event: dict) -> bool:
+    """Match a temporary probe event by type."""
+    return event.get("type") == expected_type
+
+
+def collect_probe_output(command: str) -> str:
+    """Collect temporary probe output from a shell command."""
+    import subprocess
+
+    return subprocess.check_output(command, shell=True, text=True)


### PR DESCRIPTION
## 测试目的

这是 PR-Agent 最终 workflow 的 clean 验证 PR，不计划合并。

用于确认从新开同仓 PR 开始，自动流程是否只产生 GitHub Review / inline suggestion，不再发布 `PR Reviewer Guide` 普通 summary comment，也不自动改写 PR description。

## 测试内容

新增 `scripts/pr_agent_inline_review_probe.py`，其中保留一个明确可评审的临时 `eval` probe，用于观察 PR-Agent 行内评论形态。

## 验证

- `python3 -m py_compile scripts/pr_agent_inline_review_probe.py`
- `git diff --cached --check`
- `.githooks/pre-push`

## 交付边界

测试完成后关闭该 PR；不合并此探针文件。
