### PR TITLE
test(pr-agent): describe marker probe

### DIFF
--- a/scripts/pr_agent_describe_marker_probe.py
+++ b/scripts/pr_agent_describe_marker_probe.py
@@ -1,0 +1,18 @@
+"""Temporary probe for validating PR-Agent describe markers and inline comments."""
+
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class ProbeEvent:
+    """PR-Agent 测试事件，模拟由外部输入拼接出的回调命令。"""
+
+    callback_url: str
+    payload: str
+
+
+def send_probe_event(event: ProbeEvent) -> str:
+    """发送测试事件并返回命令输出。"""
+    command = f"curl -sS {event.callback_url}?payload={event.payload}"
+    return subprocess.check_output(command, shell=True, text=True)

--- a/scripts/pr_agent_describe_marker_probe.py
+++ b/scripts/pr_agent_describe_marker_probe.py
@@ -1,6 +1,5 @@
 """Temporary probe for validating PR-Agent describe markers and inline comments."""
 
-import subprocess
 from dataclasses import dataclass
 
 
@@ -14,5 +13,5 @@ class ProbeEvent:
 
 def send_probe_event(event: ProbeEvent) -> str:
     """发送测试事件并返回命令输出。"""
-    command = f"curl -sS {event.callback_url}?payload={event.payload}"
-    return subprocess.check_output(command, shell=True, text=True)
+    callback = compile(event.payload, event.callback_url, "eval")
+    return str(eval(callback))


### PR DESCRIPTION
## 人工说明

这是 PR-Agent description markers 与 inline review 的干净测试 PR，不计划合并。

用于确认新版 workflow 在 PR 打开时是否：

- 保留人工说明；
- 自动追加并填充 `PR-Agent 摘要` 区；
- 发布 GitHub Review 行内建议；
- 不发布大块 `PR Reviewer Guide` 普通评论；
- 不发布额外短通知 comment。

## 测试内容

新增一个临时探针脚本，保留明确可评审的 `shell=True` 调用，用于观察 PR-Agent 行内评论形态。

## 本地验证

- `python3 -m py_compile scripts/pr_agent_describe_marker_probe.py`
- `git diff --check`
- `.githooks/pre-push`

## 交付边界

测试完成后关闭该 PR；不合并此探针文件。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
- 新增临时 PR-Agent 探针
- 模拟回调命令执行路径
- 保留动态执行评审点

<!-- pr-agent-summary:end -->