### PR TITLE
test(pr-agent): comment notification probe

### DIFF
--- a/scripts/pr_agent_comment_notification_probe.py
+++ b/scripts/pr_agent_comment_notification_probe.py
@@ -1,0 +1,18 @@
+"""Temporary probe for validating PR-Agent comments and push notifications."""
+
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class ProbeCommand:
+    """PR-Agent 测试命令，模拟由外部输入拼接出的执行参数。"""
+
+    endpoint: str
+    token: str
+
+
+def run_probe(command: ProbeCommand) -> str:
+    """执行测试命令并返回输出。"""
+    shell_command = f"curl -sS {command.endpoint}?token={command.token}"
+    return subprocess.check_output(shell_command, shell=True, text=True)


### PR DESCRIPTION
## 测试目的

这是 PR-Agent comment 与 push 通知流程的干净测试 PR，不计划合并。

用于确认合入 #280 后的 workflow 是否：

- 首次打开 PR 时发布 `/describe` summary comment；
- summary comment 不包含 File Walkthrough；
- 首次打开 PR 时发布 `PR Reviewer Guide`；
- 首次打开 PR 时发布 inline review；
- 首次打开 PR 不额外发布中文短通知；
- 后续 push 更新 summary、Guide 和 inline review；
- 后续 push 仅在有新增 Review/inline comment 时发布中文短通知；
- 下一次 push 清理上一条中文短通知。

## 测试内容

新增一个临时探针脚本，保留明确可评审的 `shell=True` 调用，用于观察 PR-Agent 行内评论和通知触发。

## 本地验证

- `python3 -m py_compile scripts/pr_agent_comment_notification_probe.py`
- `git diff --check`
- `.githooks/pre-push`

## 交付边界

测试完成后关闭该 PR；不合并此探针文件。
