### PR TITLE
ci(pr-agent): update describe body

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -134,11 +134,11 @@ jobs:
           # 保留 action outputs，便于后续 workflow 编排或排查。
           github_action_config.enable_output: "true"
 
-          # /describe 行为控制；使用独立 persistent comment，不改写人工 PR body，也不生成 File Walkthrough。
+          # /describe 行为控制；更新 PR body 但不改标题，不生成 File Walkthrough。
           pr_description.generate_ai_title: "false"
           pr_description.publish_labels: "false"
-          pr_description.publish_description_as_comment: "true"
-          pr_description.publish_description_as_comment_persistent: "true"
+          pr_description.publish_description_as_comment: "false"
+          pr_description.publish_description_as_comment_persistent: "false"
           pr_description.enable_pr_diagram: "false"
           pr_description.enable_pr_type: "true"
           pr_description.enable_help_text: "false"


### PR DESCRIPTION
## 变更说明

- 修正 `/describe` 发布方式：改回更新 PR body，不再发布 describe summary comment。
- 保持 `generate_ai_title=false`，不自动修改 PR 标题。
- 继续关闭 File Walkthrough、diagram、help 文案和默认更新提示。
- 保留 `/review` 首次与后续 push 更新 Guide，以及后续 push 的中文短通知逻辑。

## 验证

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-agent.yml")'`
- `git diff --check`
- `.githooks/pre-push`

## 交付边界

PR-only，不包含插件版本发布、tag 或 GitHub Release。

## 协作来源

由 Codex 协助调整。
