### PR TITLE
test(pr-agent): validate inline summary workflow

### DIFF
--- a/scripts/pr_agent_body_notification_probe.py
+++ b/scripts/pr_agent_body_notification_probe.py
@@ -14,5 +14,13 @@ class ProbeRequest:
 
 def fetch_probe(request: ProbeRequest) -> str:
     """执行测试请求并返回输出。"""
-    command = f"curl -sS {request.url}?q={request.query}"
-    return subprocess.check_output(command, shell=True, text=True)
+    command = [
+        "curl",
+        "-sS",
+        "--get",
+        "--data-urlencode",
+        f"q={request.query}",
+        "--",
+        request.url,
+    ]
+    return subprocess.check_output(command, text=True)

--- a/scripts/pr_agent_body_notification_probe.py
+++ b/scripts/pr_agent_body_notification_probe.py
@@ -1,0 +1,18 @@
+"""Temporary probe for validating PR-Agent body updates and notifications."""
+
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class ProbeRequest:
+    """PR-Agent 测试请求，模拟由外部输入拼接出的命令参数。"""
+
+    url: str
+    query: str
+
+
+def fetch_probe(request: ProbeRequest) -> str:
+    """执行测试请求并返回输出。"""
+    command = f"curl -sS {request.url}?q={request.query}"
+    return subprocess.check_output(command, shell=True, text=True)

--- a/scripts/pr_agent_body_notification_probe.py
+++ b/scripts/pr_agent_body_notification_probe.py
@@ -14,9 +14,15 @@ class ProbeRequest:
 
 def fetch_probe(request: ProbeRequest) -> str:
     """执行测试请求并返回输出。"""
+    allowed_url_prefixes = ("https://github.com/", "https://api.github.com/")
+    if not request.url.startswith(allowed_url_prefixes):
+        raise ValueError("unsupported probe target")
+
     command = [
         "curl",
         "-sS",
+        "--proto",
+        "=https",
         "--get",
         "--data-urlencode",
         f"q={request.query}",


### PR DESCRIPTION
## 测试目的
验证 PR-Agent 新工作流输出形态：

- PR Body 保留人工描述，并在下方更新 `PR-Agent 摘要` 占位符。
- 不再生成 `/review` 的 PR Reviewer Guide。
- `/improve` 只生成 inline comments。
- workflow 额外发一条自然语言 `Code Review` comment；没有新增 inline 反馈时也发出自然完成说明。

## 测试内容
新增一个临时 probe，包含刻意的 `shell=True` 风险，用于观察 inline comment 与汇总 comment。

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at 83b3249e55d58c6912bc9f6ca8df1eeb4d5fd99e

- 新增 PR-Agent 通知探针
- 使用 `ProbeRequest` 封装输入
- 限制 GitHub HTTPS 目标
- 依赖网络与本地 `curl`

<!-- pr-agent-summary:end -->