### PR TITLE
ci(pr-agent): adapt review language and summary tone

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -57,6 +57,63 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Detect PR review language
+        id: pr_language
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          pr_info="$(mktemp)"
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "${pr_info}"
+          python3 - "${pr_info}" >> "${GITHUB_OUTPUT}" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          pr = json.loads(Path(sys.argv[1]).read_text())
+          title = pr.get("title") or ""
+          body = pr.get("body") or ""
+
+          body = re.sub(
+              r"\n*##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*"
+              r"<!-- pr-agent-summary:start -->.*?<!-- pr-agent-summary:end -->",
+              " ",
+              body,
+              flags=re.IGNORECASE | re.DOTALL,
+          )
+          body = re.sub(
+              r"<!-- pr-agent-summary:start -->.*?<!-- pr-agent-summary:end -->",
+              " ",
+              body,
+              flags=re.DOTALL,
+          )
+          body = re.sub(r"```.*?```", " ", body, flags=re.DOTALL)
+
+          text = f"{title}\n{body}"
+          cjk_count = len(re.findall(r"[\u4e00-\u9fff]", text))
+          latin_words = len(re.findall(r"\b[A-Za-z][A-Za-z]{2,}\b", text))
+
+          if cjk_count >= 4:
+              response_language = "zh-CN"
+              summary_heading = "PR-Agent 摘要"
+              summary_language = "中文"
+          elif latin_words >= 8:
+              response_language = "en-US"
+              summary_heading = "PR-Agent Summary"
+              summary_language = "English"
+          else:
+              response_language = "zh-CN"
+              summary_heading = "PR-Agent 摘要"
+              summary_language = "中文"
+
+          print(f"response_language={response_language}")
+          print(f"summary_heading={summary_heading}")
+          print(f"summary_language={summary_language}")
+          PY
+
       - name: Prepare PR-Agent description markers
         if: >-
           github.event_name == 'pull_request_target' ||
@@ -71,6 +128,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          SUMMARY_HEADING: ${{ steps.pr_language.outputs.summary_heading }}
         run: |
           set -euo pipefail
           current_body="$(mktemp)"
@@ -79,6 +137,8 @@ jobs:
 
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
           python3 - "${current_body}" "${next_body}" <<'PY'
+          import os
+          import re
           import sys
           from pathlib import Path
 
@@ -89,7 +149,13 @@ jobs:
           start = "<!-- pr-agent-summary:start -->"
           end = "<!-- pr-agent-summary:end -->"
           placeholder = "pr_agent:summary"
-          agent_block = f"## PR-Agent 摘要\n\n{start}\n{placeholder}\n{end}\n"
+          summary_heading = os.environ.get("SUMMARY_HEADING") or "PR-Agent 摘要"
+          agent_block = f"## {summary_heading}\n\n{start}\n{placeholder}\n{end}\n"
+          body = re.sub(
+              r"(?im)^##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*(?=<!-- pr-agent-summary:start -->)",
+              f"## {summary_heading}\n\n",
+              body,
+          )
 
           start_index = body.find(start)
           end_index = body.find(end)
@@ -183,7 +249,7 @@ jobs:
           config.fallback_models: '["gpt-5.4"]'
           config.reasoning_effort: "xhigh"
           config.ai_timeout: "900"
-          config.response_language: "zh-CN"
+          config.response_language: ${{ steps.pr_language.outputs.response_language }}
           config.large_patch_policy: "clip"
           config.ignore_pr_title: '["^\\[Auto\\]", "^Auto"]'
           config.ignore_pr_labels: '["skip pr-agent"]'
@@ -216,20 +282,16 @@ jobs:
           pr_description.use_description_markers: "true"
           pr_description.final_update_message: "false"
           pr_description.extra_instructions: |
-            请用中文输出。
-            生成中等详细的 PR 摘要，覆盖变更目标、关键实现、配置或兼容影响、测试与风险提示。
-            小型 PR 可用 2-4 条要点；功能型或多文件 PR 可用 4-8 条要点。
-            不要堆叠低价值文件列表或本地命令。
+            Match the configured response language.
+            Generate a moderately detailed PR summary covering the change goal, key implementation details, configuration or compatibility impact, tests, and notable risks.
+            Use 2-4 bullets for small PRs; use 4-8 bullets for feature or multi-file PRs.
+            Avoid low-value file lists and local command transcripts.
 
           # /improve 以 GitHub 内联建议呈现，便于像正式 review discussion 一样逐条处理。
           pr_code_suggestions.extra_instructions: |
-            请用中文输出。
-            只给出需要维护者处理的实质性问题，避免纯格式、偏好或低价值建议。
-            对需要区分优先级的问题，建议正文开头使用 HTML badge 标识风险级别：
-            <span style="background-color:#d1242f;color:#fff;border-radius:4px;padding:2px 6px;">High Risk</span>
-            <span style="background-color:#bf8700;color:#fff;border-radius:4px;padding:2px 6px;">Medium Risk</span>
-            <span style="background-color:#0969da;color:#fff;border-radius:4px;padding:2px 6px;">Low Risk</span>
-            如果平台过滤样式，退回使用 🔴 **High Risk**:、🟡 **Medium Risk**: 或 🔵 **Low Risk**: 前缀。
+            Match the configured response language.
+            Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
+            For prioritized issues, start the suggestion body with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
           pr_code_suggestions.num_code_suggestions_per_chunk: "2"
@@ -257,6 +319,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          SUMMARY_LANGUAGE: ${{ steps.pr_language.outputs.summary_language }}
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
           SUMMARY_MODEL: gpt-5.5
@@ -337,18 +400,32 @@ jobs:
           payload_path = Path(os.sys.argv[2])
           suggestions = review_data["suggestions"]
           marker = "<!-- pr-agent-code-review-summary -->"
+          summary_language = os.environ.get("SUMMARY_LANGUAGE") or "中文"
+          use_chinese = summary_language != "English"
 
           def fallback_summary() -> str:
               if not suggestions:
-                  return "已审查本次变更，未发现需要进一步反馈或调整的问题。"
-              lines = [f"本轮代码审查新增 {len(suggestions)} 条行内建议，建议优先查看以下位置："]
+                  if use_chinese:
+                      return "已审查本次变更，未发现需要进一步反馈或调整的问题。"
+                  return "Reviewed this change and found no further feedback or required adjustments."
+              if use_chinese:
+                  lines = [f"本轮代码审查新增 {len(suggestions)} 条行内建议，建议优先查看以下位置："]
+              else:
+                  noun = "suggestion" if len(suggestions) == 1 else "suggestions"
+                  lines = [f"This review added {len(suggestions)} inline {noun}. Consider reviewing these locations first:"]
               for item in suggestions[:5]:
                   location = f"{item.get('path')}:{item.get('line')}" if item.get("line") else str(item.get("path"))
                   summary = item.get("summary") or "查看行内建议"
                   url = item.get("url")
-                  lines.append(f"- [{location}]({url})：{summary}" if url else f"- {location}：{summary}")
+                  if use_chinese:
+                      lines.append(f"- [{location}]({url})：{summary}" if url else f"- {location}：{summary}")
+                  else:
+                      lines.append(f"- [{location}]({url}): {summary}" if url else f"- {location}: {summary}")
               if len(suggestions) > 5:
-                  lines.append(f"- 其余 {len(suggestions) - 5} 条请在 Files changed 的行内评论中查看。")
+                  if use_chinese:
+                      lines.append(f"- 其余 {len(suggestions) - 5} 条请在 Files changed 的行内评论中查看。")
+                  else:
+                      lines.append(f"- Review the remaining {len(suggestions) - 5} inline comments in Files changed.")
               return "\n".join(lines)
 
           def llm_summary() -> str | None:
@@ -361,15 +438,36 @@ jobs:
               if not api_base or not api_key:
                   return None
 
+              if use_chinese:
+                  task = (
+                      "你是独立的代码审查摘要助手。只基于本轮已经发布的行内审查意见做简短汇总，"
+                      "不新增审查结论，不替维护者判断 PR 是否可以合并。请用中文 Markdown 输出："
+                      "第一段说明本轮审查已完成，并已在行内留下需要关注的建议；如有建议，"
+                      "概括 1-3 个主要关注点，使用“建议关注”“可能影响”“可优先查看”等中立表述。"
+                      "不要输出表格，不要复述所有文件，不要使用“可以合并”“不建议合并”“阻塞合并”"
+                      "“先处理后再合入”等合并裁决措辞。"
+                  )
+                  system_prompt = "你是严谨、中立的代码审查摘要助手。输出中文 Markdown，简洁自然。"
+              else:
+                  task = (
+                      "You are an independent code review summarizer. Summarize only the inline review comments "
+                      "already posted in this run; do not add new review conclusions or decide whether the PR should merge. "
+                      "Write concise Markdown in English. Start by noting that review completed and inline suggestions "
+                      "were left; then summarize 1-3 main points using neutral phrasing such as \"consider\", "
+                      "\"may affect\", or \"worth reviewing\". Do not output tables, list every file, or use merge-gate "
+                      "wording such as \"ready to merge\", \"do not merge\", \"blocks merging\", or \"must be fixed before merge\"."
+                  )
+                  system_prompt = "You are a rigorous, neutral code review summarizer. Write concise English Markdown."
+
               user_content = {
-                  "task": "请基于本轮新增的行内审查意见，写一条中文 Code Review 总结。语气自然，像维护者刚完成审查后的简短反馈；先概括整体结论，再点出最重要的 1-3 个风险。不要输出表格，不要复述所有文件。",
+                  "task": task,
                   "suggestions": suggestions[:10],
               }
 
               request_body = {
                   "model": model,
                   "messages": [
-                      {"role": "system", "content": "你是严谨的代码审查助手。输出中文 Markdown，简洁自然。"},
+                      {"role": "system", "content": system_prompt},
                       {"role": "user", "content": json.dumps(user_content, ensure_ascii=False)},
                   ],
                   "temperature": 0.2,
@@ -392,13 +490,14 @@ jobs:
                   return None
 
           summary = llm_summary() or fallback_summary()
+          commit_label = "审查提交：" if use_chinese else "Reviewed commit:"
           body = textwrap.dedent(f"""\
           {marker}
           ## Code Review
 
           {summary}
 
-          审查提交：[{review_data["short_sha"]}]({review_data["commit_url"]})
+          {commit_label} [{review_data["short_sha"]}]({review_data["commit_url"]})
           """)
           payload_path.write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY


### PR DESCRIPTION
## 变更说明

- 根据 PR title/body 检测输出语言：中文 PR 使用中文，英文 PR 使用英文，识别不到时回退中文。
- PR-Agent 摘要区标题随语言切换为 `PR-Agent 摘要` 或 `PR-Agent Summary`。
- 移除 `/improve` 风险提示里的 HTML badge，直接使用稳定的 Markdown 前缀：`🔴 **High Risk**:`、`🟡 **Medium Risk**:`、`🔵 **Low Risk**:`。
- 调整 Code Review 汇总提示词为第三方中立摘要，只总结已发布的 inline comments，不替维护者判断是否可以合并。
- 无新增 inline comments 时继续跳过总结模型，直接输出对应语言的固定无反馈文案。

## 影响范围

- 仅影响 `.github/workflows/pr-agent.yml`。
- 不启用 `/review`，不恢复 PR Reviewer Guide 表格。
- 不改变插件版本、package 索引或发布流程。

## 验证

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-agent.yml"); puts "yaml ok"'`
- `git diff --check`
- `.githooks/pre-push`

本 PR 为 Codex 协作提交

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at fd4523d9b5e9091ede73cf8658a7529b370c5b14

- 新增 PR 语言自动识别
- 动态切换摘要标题与输出语言
- 审查汇总支持中英文回退
- 风险前缀改用稳定 Markdown

<!-- pr-agent-summary:end -->