### PR TITLE
ci(pr-agent): skip same-repo automatic runs

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -33,12 +33,12 @@ permissions:
 jobs:
   pr-agent:
     name: PR-Agent inline review
-    # 所有非 Bot PR 自动处理；手动命令仍限制在可信贡献者的 PR 评论中。
     if: >-
       github.event.sender.type != 'Bot' &&
       (
         (
-          github.event_name == 'pull_request_target'
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository
         ) ||
         (
           github.event_name == 'issue_comment' &&


### PR DESCRIPTION
## 变更说明

- 调整 PR-Agent 自动触发条件：仅 fork PR 自动运行。
- 同仓 PR 不再默认消耗 PR-Agent；需要时仍可通过 PR 评论手动执行 /describe、/improve、/ask。

## 验证

- YAML 解析通过
- git diff --check
- .githooks/pre-push

## 交付路径

PR-only，不涉及版本升级、tag 或 GitHub Release。

本 PR 为 Codex 协作提交

## PR-Agent 摘要

<!-- pr-agent-summary:start -->
### 🤖 Generated by PR Agent at cd3718c5d4f8f1f403f83377483fa8f06aa9a347

- 限制 fork PR 自动运行
- 比较 `head.repo.full_name` 来源
- 同仓改用评论手动触发
- 未新增测试，影响限 CI

<!-- pr-agent-summary:end -->