### PR TITLE
ci(pr-agent): harden review workflow guards

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -17,11 +17,6 @@ on:
       - created
       - edited
 
-concurrency:
-  # 同一 PR 上只保留最新一次 PR-Agent 运行，避免旧 commit 的 review 后完成并覆盖新结果。
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   # 读取仓库内容和 PR diff。
   contents: read
@@ -54,6 +49,9 @@ jobs:
           )
         )
       )
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -76,6 +74,8 @@ jobs:
           pr = json.loads(Path(sys.argv[1]).read_text())
           title = pr.get("title") or ""
           body = pr.get("body") or ""
+          labels = {item.get("name", "") for item in pr.get("labels") or []}
+          skip_pr_agent = "true" if "skip pr-agent" in labels or re.search(r"^(?:\[Auto\]|Auto)", title) else "false"
 
           body = re.sub(
               r"\n*##\s+(PR-Agent\s+摘要|PR-Agent Summary)\s*\n\s*"
@@ -112,16 +112,21 @@ jobs:
           print(f"response_language={response_language}")
           print(f"summary_heading={summary_heading}")
           print(f"summary_language={summary_language}")
+          print(f"skip_pr_agent={skip_pr_agent}")
           PY
 
       - name: Prepare PR-Agent description markers
+        id: prepare_description
         if: >-
-          github.event_name == 'pull_request_target' ||
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
           (
-            github.event_name == 'issue_comment' &&
+            github.event_name == 'pull_request_target' ||
             (
-              github.event.comment.body == '/describe' ||
-              startsWith(github.event.comment.body, '/describe ')
+              github.event_name == 'issue_comment' &&
+              (
+                github.event.comment.body == '/describe' ||
+                startsWith(github.event.comment.body, '/describe ')
+              )
             )
           )
         env:
@@ -134,8 +139,10 @@ jobs:
           current_body="$(mktemp)"
           next_body="$(mktemp)"
           payload="$(mktemp)"
+          body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
 
           gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
+          cp "${current_body}" "${body_backup}"
           python3 - "${current_body}" "${next_body}" <<'PY'
           import os
           import re
@@ -168,6 +175,7 @@ jobs:
           next_path.write_text(next_body)
           PY
 
+          body_changed=false
           if ! cmp -s "${current_body}" "${next_body}"; then
             python3 - "${next_body}" "${payload}" <<'PY'
           import json
@@ -178,17 +186,22 @@ jobs:
           Path(sys.argv[2]).write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY
             gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null
+            body_changed=true
           fi
+          echo "body_changed=${body_changed}" >> "${GITHUB_OUTPUT}"
 
       - name: Snapshot PR-Agent inline comments
         id: inline_state_before
         if: >-
-          github.event_name == 'pull_request_target' ||
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
           (
-            github.event_name == 'issue_comment' &&
+            github.event_name == 'pull_request_target' ||
             (
-              github.event.comment.body == '/improve' ||
-              startsWith(github.event.comment.body, '/improve ')
+              github.event_name == 'issue_comment' &&
+              (
+                github.event.comment.body == '/improve' ||
+                startsWith(github.event.comment.body, '/improve ')
+              )
             )
           )
         env:
@@ -203,12 +216,15 @@ jobs:
 
       - name: Clean previous PR-Agent code review summary
         if: >-
-          github.event_name == 'pull_request_target' ||
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
           (
-            github.event_name == 'issue_comment' &&
+            github.event_name == 'pull_request_target' ||
             (
-              github.event.comment.body == '/improve' ||
-              startsWith(github.event.comment.body, '/improve ')
+              github.event_name == 'issue_comment' &&
+              (
+                github.event.comment.body == '/improve' ||
+                startsWith(github.event.comment.body, '/improve ')
+              )
             )
           )
         env:
@@ -231,6 +247,7 @@ jobs:
 
       - name: Run PR-Agent
         id: pragent
+        if: steps.pr_language.outputs.skip_pr_agent != 'true'
         # 使用版本号加 digest 固定容器构建，避免 tag 被重推后改变运行内容。
         uses: docker://pragent/pr-agent:0.39.0-github_action@sha256:b253845caa8c7ff5ce8be78f32996647982bdd4890826a962b78eff2e385a825
         env:
@@ -305,12 +322,15 @@ jobs:
 
       - name: Publish PR-Agent code review summary
         if: >-
-          github.event_name == 'pull_request_target' ||
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
           (
-            github.event_name == 'issue_comment' &&
+            github.event_name == 'pull_request_target' ||
             (
-              github.event.comment.body == '/improve' ||
-              startsWith(github.event.comment.body, '/improve ')
+              github.event_name == 'issue_comment' &&
+              (
+                github.event.comment.body == '/improve' ||
+                startsWith(github.event.comment.body, '/improve ')
+              )
             )
           )
         env:
@@ -503,3 +523,39 @@ jobs:
           PY
 
           gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" >/dev/null
+
+      - name: Restore PR-Agent description markers on failure
+        if: >-
+          failure() &&
+          steps.prepare_description.outputs.body_changed == 'true' &&
+          steps.pr_language.outputs.skip_pr_agent != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
+          current_body="$(mktemp)"
+          payload="$(mktemp)"
+
+          if [ ! -s "${body_backup}" ]; then
+            echo "No PR body backup found."
+            exit 0
+          fi
+
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
+          if ! grep -q 'pr_agent:summary' "${current_body}"; then
+            echo "No visible PR-Agent summary placeholder to restore."
+            exit 0
+          fi
+
+          python3 - "${body_backup}" "${payload}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          body = Path(sys.argv[1]).read_text()
+          Path(sys.argv[2]).write_text(json.dumps({"body": body}, ensure_ascii=False))
+          PY
+          gh api --method PATCH "repos/${REPO}/pulls/${PR_NUMBER}" --input "${payload}" >/dev/null


### PR DESCRIPTION
## 变更说明

- 将 PR-Agent 并发控制移动到 job 级，避免无效评论触发的 run 取消正在执行的审查。
- 让自定义的 PR Body、行内评论快照、总结清理和总结发布步骤复用 `skip pr-agent` 标签与 `Auto` 标题跳过规则。
- 在准备 `/describe` 占位符前备份 PR Body，运行失败且占位符仍可见时恢复旧描述。

## 验证

- YAML 解析通过
- git diff --check
- .githooks/pre-push

## 交付路径

PR-only：不包含版本升级、tag 或 GitHub Release。

本 PR 为 Codex 协作提交
