### PR TITLE
ci(pr-agent): preserve review summary on failures

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -218,37 +218,6 @@ jobs:
           inline_ids_b64="$(printf '%s' "${inline_ids}" | base64 -w0)"
           echo "inline_ids_b64=${inline_ids_b64}" >> "${GITHUB_OUTPUT}"
 
-      - name: Clean previous PR-Agent code review summary
-        if: >-
-          steps.pr_language.outputs.skip_pr_agent != 'true' &&
-          (
-            github.event_name == 'pull_request_target' ||
-            (
-              github.event_name == 'issue_comment' &&
-              (
-                github.event.comment.body == '/improve' ||
-                startsWith(github.event.comment.body, '/improve ')
-              )
-            )
-          )
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-        run: |
-          set -euo pipefail
-          comment_ids="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq '.[] | select(.user.login == "github-actions[bot]" and ((.body | startswith("<!-- pr-agent-code-review-summary -->")) or (.body | startswith("<!-- pr-agent-update-notification -->")))) | .id')"
-
-          if [ -z "${comment_ids}" ]; then
-            echo "No previous PR-Agent code review summary to clean."
-            exit 0
-          fi
-
-          while IFS= read -r comment_id; do
-            [ -z "${comment_id}" ] && continue
-            gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null
-          done <<< "${comment_ids}"
-
       - name: Run PR-Agent
         id: pragent
         if: steps.pr_language.outputs.skip_pr_agent != 'true'
@@ -526,7 +495,18 @@ jobs:
           payload_path.write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY
 
-          gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" >/dev/null
+          new_comment_id="$(gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" --jq '.id')"
+          comment_ids="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.id != ${new_comment_id} and .user.login == \"github-actions[bot]\" and ((.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) or (.body | startswith(\"<!-- pr-agent-update-notification -->\")))) | .id")"
+
+          if [ -z "${comment_ids}" ]; then
+            echo "No previous PR-Agent code review summary to clean."
+            exit 0
+          fi
+
+          while IFS= read -r comment_id; do
+            [ -z "${comment_id}" ] && continue
+            gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null
+          done <<< "${comment_ids}"
 
       - name: Restore PR-Agent description markers on failure
         if: >-


### PR DESCRIPTION
## 变更说明

- 在新的 Code Review 总结评论成功发布后，再删除上一条 PR-Agent 总结评论。
- 如果 PR-Agent 容器、模型调用或 GitHub API 在发布前失败，上一轮总结会保留，不会提前丢失。

## 验证

- YAML 解析通过
- git diff --check
- .githooks/pre-push

## 交付路径

PR-only：不包含版本升级、tag 或 GitHub Release。

本 PR 为 Codex 协作提交
