### PR TITLE
ci(pr-agent): serialize review summary publication

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -51,7 +51,7 @@ jobs:
       )
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-      cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -494,6 +494,12 @@ jobs:
           """)
           payload_path.write_text(json.dumps({"body": body}, ensure_ascii=False))
           PY
+
+          latest_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          if [ "${latest_head_sha}" != "${HEAD_SHA}" ]; then
+            echo "PR head changed from ${HEAD_SHA} to ${latest_head_sha}; skip stale code review summary."
+            exit 0
+          fi
 
           new_comment_id="$(gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" --jq '.id')"
           comment_ids="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.id != ${new_comment_id} and .user.login == \"github-actions[bot]\" and ((.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) or (.body | startswith(\"<!-- pr-agent-update-notification -->\")))) | .id")"


### PR DESCRIPTION
## 变更说明

- 保留同一 PR 的并发分组，但不再取消已启动的 PR-Agent 运行，避免运行在写入摘要占位符后被并发取消。
- 在 Code Review 总结真正发布前再次校验 PR head，避免总结生成期间出现新 push 时发布过期总结。

## 验证

- YAML 解析通过
- git diff --check
- .githooks/pre-push

## 交付路径

PR-only：不包含版本升级、tag 或 GitHub Release。

本 PR 为 Codex 协作提交
