### PR TITLE
ci(pr-agent): narrow inline review ownership

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -95,9 +95,8 @@ jobs:
           )
           body = re.sub(r"```.*?```", " ", body, flags=re.DOTALL)
 
-          text = f"{title}\n{body}"
-          cjk_count = len(re.findall(r"[\u4e00-\u9fff]", text))
-          latin_words = len(re.findall(r"\b[A-Za-z][A-Za-z]{2,}\b", text))
+          cjk_count = len(re.findall(r"[\u4e00-\u9fff]", body))
+          latin_words = len(re.findall(r"\b[A-Za-z][A-Za-z]{2,}\b", body))
 
           if cjk_count >= 4:
               response_language = "zh-CN"
@@ -238,6 +237,33 @@ jobs:
           fi
           echo "is_stale=${is_stale}" >> "${GITHUB_OUTPUT}"
 
+      - name: Check existing PR-Agent review summary
+        id: review_history
+        if: >-
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true' &&
+          steps.pragent_head.outputs.is_stale != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          should_improve=true
+          push_commands='["/describe", "/improve"]'
+          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+            existing_summary_id="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) and (.body | contains(\"/commit/${RUN_HEAD_SHA}\"))) | .id" | tail -n 1)"
+            if [ -n "${existing_summary_id}" ]; then
+              should_improve=false
+              push_commands='["/describe"]'
+              echo "PR-Agent code review summary already exists for ${RUN_HEAD_SHA}; skip duplicate inline review."
+            fi
+          fi
+          echo "should_improve=${should_improve}" >> "${GITHUB_OUTPUT}"
+          echo "push_commands=${push_commands}" >> "${GITHUB_OUTPUT}"
+
       - name: Snapshot PR-Agent review state
         id: inline_state_before
         if: >-
@@ -245,7 +271,10 @@ jobs:
           steps.run_state.outputs.is_stale != 'true' &&
           steps.pragent_head.outputs.is_stale != 'true' &&
           (
-            github.event_name == 'pull_request_target' ||
+            (
+              github.event_name == 'pull_request_target' &&
+              steps.review_history.outputs.should_improve == 'true'
+            ) ||
             (
               github.event_name == 'issue_comment' &&
               (
@@ -300,12 +329,12 @@ jobs:
           # PR 初次进入评审或后续 push 时，更新 PR 摘要并发布 GitHub Review 行内建议。
           github_action_config.auto_review: "false"
           github_action_config.auto_describe: "true"
-          github_action_config.auto_improve: "true"
+          github_action_config.auto_improve: ${{ steps.review_history.outputs.should_improve }}
 
           # synchronize 由 push_commands 单独处理；每次 push 更新摘要和行内 Review，旧行评由 GitHub 标记 outdated。
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "review_requested"]'
           github_action_config.handle_push_trigger: "true"
-          github_action_config.push_commands: '["/describe", "/improve"]'
+          github_action_config.push_commands: ${{ steps.review_history.outputs.push_commands }}
 
           # 保留 action outputs，便于后续 workflow 编排或排查。
           github_action_config.enable_output: "true"
@@ -382,6 +411,7 @@ jobs:
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
           import json
+          import re
           import sys
           from pathlib import Path
 
@@ -391,6 +421,14 @@ jobs:
           reviews_path = Path(sys.argv[4])
           delete_path = Path(sys.argv[5])
           head_sha = sys.argv[6]
+          risk_prefix_re = re.compile(
+              r"^\s*(?:<!-- pr-agent-inline-comment -->\s*)?"
+              r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
+
+          def is_pr_agent_suggestion(item: dict) -> bool:
+              return bool(risk_prefix_re.search(item.get("body") or ""))
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -414,6 +452,7 @@ jobs:
                   and item.get("id") not in before_ids
                   and item.get("commit_id") == head_sha
                   and item.get("pull_request_review_id") in new_review_ids
+                  and is_pr_agent_suggestion(item)
               ):
                   delete_ids.append(str(item["id"]))
 
@@ -436,7 +475,10 @@ jobs:
           steps.pragent_head.outputs.is_stale != 'true' &&
           steps.post_pragent_state.outputs.is_stale != 'true' &&
           (
-            github.event_name == 'pull_request_target' ||
+            (
+              github.event_name == 'pull_request_target' &&
+              steps.review_history.outputs.should_improve == 'true'
+            ) ||
             (
               github.event_name == 'issue_comment' &&
               (
@@ -482,6 +524,7 @@ jobs:
 
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${review_data}" "${HEAD_SHA}" "${pr_url}" "${commit_url}" "${short_sha}" <<'PY'
           import json
+          import re
           import sys
           from pathlib import Path
 
@@ -494,6 +537,17 @@ jobs:
           pr_url = sys.argv[7]
           commit_url = sys.argv[8]
           short_sha = sys.argv[9]
+          risk_prefix_re = re.compile(
+              r"^\s*(?:<!-- pr-agent-inline-comment -->\s*)?"
+              r"(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
+
+          def normalize_suggestion_body(body: str) -> str:
+              return re.sub(r"^\s*<!-- pr-agent-inline-comment -->\s*", "", body or "").strip()
+
+          def is_pr_agent_suggestion(item: dict) -> bool:
+              return bool(risk_prefix_re.search(item.get("body") or ""))
 
           comments = []
           for line in comments_path.read_text().splitlines():
@@ -518,10 +572,11 @@ jobs:
               and item.get("id") not in before_ids
               and item.get("commit_id") == head_sha
               and item.get("pull_request_review_id") in new_review_ids
+              and is_pr_agent_suggestion(item)
           ]
           suggestions = []
           for item in new_comments:
-              body = (item.get("body") or "").strip()
+              body = normalize_suggestion_body(item.get("body") or "")
               first_line = next((line.strip() for line in body.splitlines() if line.strip()), "")
               suggestions.append({
                   "path": item.get("path"),
@@ -636,7 +691,7 @@ jobs:
                       data = json.loads(response.read().decode("utf-8"))
                   content = data["choices"][0]["message"]["content"].strip()
                   return content or None
-              except (KeyError, TimeoutError, urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError):
+              except (KeyError, IndexError, TypeError, TimeoutError, urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError):
                   return None
 
           summary = llm_summary() or fallback_summary()

--- a/docs/pr-agent.md
+++ b/docs/pr-agent.md
@@ -34,7 +34,7 @@ workflow 会在 `/improve` 后发布一条普通 PR 评论：
 - 评论标题为 `## Code Review`。
 - 如果本轮有新增行内建议，会基于这些建议生成自然语言总结。
 - 如果本轮没有新增行内建议，直接发布无更多反馈的简短总结。
-- 下一次运行前会删除上一条 PR-Agent Code Review 总结评论，避免评论堆叠，同时保留新的通知事件。
+- 发布新总结后会删除上一条 PR-Agent Code Review 总结评论，避免评论堆叠，同时保留新的通知事件。
 
 ## 常用评论命令
 
@@ -58,7 +58,7 @@ workflow 会在 `/improve` 后发布一条普通 PR 评论：
 
 PR-Agent 配置集中在 `.github/workflows/pr-agent.yml` 中维护。公开说明只描述用户可见行为：
 
-- 根据 PR 标题和用户原始描述自动选择中文或英文；无法识别时默认中文。
+- 根据用户原始 PR 描述自动选择中文或英文；无法识别时默认中文。
 - 保留用户原始 PR 描述，只更新 PR Body 中的 PR-Agent 标记区域。
 - 不使用 PR-Agent 的 Reviewer Guide 输出。
 - 不输出 PR Type、额外标签、图表或 describe 评论。


### PR DESCRIPTION
## Summary

- Avoid summarizing or deleting unrelated GitHub Actions review comments by requiring the PR-Agent risk-prefix format before treating a new inline comment as PR-Agent output.
- Skip duplicate automatic /improve runs when a Code Review summary already exists for the same head commit, while still allowing manual /improve.
- Align PR-Agent language detection and docs with PR body based language selection.

## Verification

- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-agent.yml"); puts "yaml ok"'
- git diff --check
- .githooks/pre-push

本 PR 为 Codex 协作提交
