### PR TITLE
ci(pr-agent): handle final stale comment id

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -463,7 +463,7 @@ jobs:
             echo "No stale PR-Agent inline comments to clean."
             exit 0
           fi
-          while IFS= read -r comment_id; do
+          while IFS= read -r comment_id || [ -n "${comment_id}" ]; do
             [ -z "${comment_id}" ] && continue
             gh api --method DELETE "repos/${REPO}/pulls/comments/${comment_id}" >/dev/null
           done < "${delete_ids}"


### PR DESCRIPTION
## Summary

- Ensure stale inline comment cleanup handles a final comment id even when the generated id file has no trailing newline.

## Verification

- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-agent.yml"); puts "yaml ok"'
- git diff --check
- .githooks/pre-push
- shell read-loop simulation for a no-trailing-newline id file

本 PR 为 Codex 协作提交
