### PR TITLE
ci: tolerate PR-Agent cleanup races

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -478,7 +478,9 @@ jobs:
           fi
           while IFS= read -r comment_id || [ -n "${comment_id}" ]; do
             [ -z "${comment_id}" ] && continue
-            gh api --method DELETE "repos/${REPO}/pulls/comments/${comment_id}" >/dev/null
+            if ! gh api --method DELETE "repos/${REPO}/pulls/comments/${comment_id}" >/dev/null 2>&1; then
+              echo "PR-Agent inline comment ${comment_id} was already removed; continue."
+            fi
           done < "${delete_ids}"
 
       - name: Publish PR-Agent code review summary
@@ -748,7 +750,9 @@ jobs:
 
           while IFS= read -r comment_id; do
             [ -z "${comment_id}" ] && continue
-            gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null
+            if ! gh api --method DELETE "repos/${REPO}/issues/comments/${comment_id}" >/dev/null 2>&1; then
+              echo "PR-Agent summary comment ${comment_id} was already removed; continue."
+            fi
           done <<< "${comment_ids}"
 
       - name: Restore PR-Agent description markers on failure


### PR DESCRIPTION
验证 PR-Agent comment cleanup 并发容错：旧行内评论和 Code Review 总结已被其他 run 删除时继续执行，避免 cleanup 404 让 workflow 失败。本 PR 为 Codex 协作提交