### PR TITLE
ci: narrow PR-Agent inline suggestion detection

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -418,6 +418,7 @@ jobs:
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
           import json
+          import re
           import sys
           from pathlib import Path
 
@@ -427,9 +428,13 @@ jobs:
           reviews_path = Path(sys.argv[4])
           delete_path = Path(sys.argv[5])
           head_sha = sys.argv[6]
+          risk_prefix_re = re.compile(
+              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              return bool((item.get("body") or "").strip())
+              return bool(risk_prefix_re.search((item.get("body") or "").lstrip()))
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -545,12 +550,17 @@ jobs:
               r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*",
               re.IGNORECASE,
           )
+          risk_prefix_re = re.compile(
+              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
 
           def normalize_suggestion_body(body: str) -> str:
               return marker_re.sub("", body or "", count=1).strip()
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              return bool((item.get("body") or "").strip())
+              body = normalize_suggestion_body(item.get("body") or "")
+              return bool(risk_prefix_re.search(body))
 
           comments = []
           for line in comments_path.read_text().splitlines():


### PR DESCRIPTION
验证 PR-Agent 行内建议识别收窄：基于风险前缀识别本轮建议，避免把其他 github-actions[bot] 行评当成 PR-Agent 输出。本 PR 为 Codex 协作提交