### PR TITLE
ci(pr-agent): mark inline review ownership

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   pr-agent:
     name: PR-Agent inline review
+    # PR 事件自动处理；评论命令仅允许指定身份在 PR 下触发，避免任意评论消耗模型配额。
     if: >-
       github.event.sender.type != 'Bot' &&
       (
@@ -50,7 +51,7 @@ jobs:
         )
       )
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name == 'issue_comment' && (github.event.comment.body == '/ask' || startsWith(github.event.comment.body, '/ask ')) && github.event.comment.id || 'write' }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}-${{ github.event_name == 'issue_comment' && github.event.comment.id || 'auto' }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -204,10 +205,12 @@ jobs:
           cp "${next_body}" "${placeholder_body}"
 
           body_changed=false
+          can_describe=true
           if ! cmp -s "${current_body}" "${next_body}"; then
             gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${latest_body}"
             if ! cmp -s "${current_body}" "${latest_body}"; then
               echo "PR body changed while preparing PR-Agent markers; skip placeholder update."
+              can_describe=false
             else
               python3 - "${next_body}" "${payload}" <<'PY'
           import json
@@ -222,6 +225,7 @@ jobs:
             fi
           fi
           echo "body_changed=${body_changed}" >> "${GITHUB_OUTPUT}"
+          echo "can_describe=${can_describe}" >> "${GITHUB_OUTPUT}"
 
       - name: Check PR head before PR-Agent
         id: pragent_head
@@ -255,15 +259,55 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
           EVENT_NAME: ${{ github.event_name }}
+          CAN_DESCRIBE: ${{ steps.prepare_description.outputs.can_describe }}
         run: |
           set -euo pipefail
+          can_describe="${CAN_DESCRIBE:-true}"
           should_improve=true
           push_commands='["/describe", "/improve"]'
+          if [ "${can_describe}" = "false" ]; then
+            push_commands='["/improve"]'
+          fi
           if [ "${EVENT_NAME}" = "pull_request_target" ]; then
             existing_summary_id="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) and (.body | contains(\"/commit/${RUN_HEAD_SHA}\"))) | .id" | tail -n 1)"
-            if [ -n "${existing_summary_id}" ]; then
+            existing_inline_id=""
+            if [ -z "${existing_summary_id}" ]; then
+              comments="$(mktemp)"
+              gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | @json' > "${comments}"
+              existing_inline_id="$(python3 - "${comments}" "${RUN_HEAD_SHA}" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          comments_path = Path(sys.argv[1])
+          head_sha = sys.argv[2]
+          marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
+
+          def is_pr_agent_suggestion(body: str) -> bool:
+              return bool(marker_re.search(body or ""))
+
+          for line in comments_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("commit_id") == head_sha
+                  and is_pr_agent_suggestion(item.get("body") or "")
+              ):
+                  print(item.get("id") or "")
+                  break
+          PY
+              )"
+            fi
+            if [ -n "${existing_summary_id}" ] || [ -n "${existing_inline_id}" ]; then
               should_improve=false
-              push_commands='["/describe"]'
+              if [ "${can_describe}" = "false" ]; then
+                push_commands='[]'
+              else
+                push_commands='["/describe"]'
+              fi
               echo "PR-Agent code review summary already exists for ${RUN_HEAD_SHA}; skip duplicate inline review."
             fi
           fi
@@ -308,7 +352,15 @@ jobs:
         if: >-
           steps.pr_language.outputs.skip_pr_agent != 'true' &&
           steps.run_state.outputs.is_stale != 'true' &&
-          steps.pragent_head.outputs.is_stale != 'true'
+          steps.pragent_head.outputs.is_stale != 'true' &&
+          !(
+            steps.prepare_description.outputs.can_describe == 'false' &&
+            github.event_name == 'issue_comment' &&
+            (
+              github.event.comment.body == '/describe' ||
+              startsWith(github.event.comment.body, '/describe ')
+            )
+          )
         timeout-minutes: 40
         # 使用版本号加 digest 固定容器构建，避免 tag 被重推后改变运行内容。
         uses: docker://pragent/pr-agent:0.39.0-github_action@sha256:b253845caa8c7ff5ce8be78f32996647982bdd4890826a962b78eff2e385a825
@@ -335,7 +387,7 @@ jobs:
 
           # PR 初次进入评审或后续 push 时，更新 PR 摘要并发布 GitHub Review 行内建议。
           github_action_config.auto_review: "false"
-          github_action_config.auto_describe: "true"
+          github_action_config.auto_describe: ${{ steps.prepare_description.outputs.can_describe != 'false' }}
           github_action_config.auto_improve: ${{ steps.review_history.outputs.should_improve }}
 
           # synchronize 由 push_commands 单独处理；每次 push 更新摘要和行内 Review，旧行评由 GitHub 标记 outdated。
@@ -382,6 +434,96 @@ jobs:
           # github_action_config.auto_improve: "true"
           # config.verbosity_level: "1"
 
+      - name: Mark PR-Agent inline comments
+        if: >-
+          always() &&
+          steps.pr_language.outputs.skip_pr_agent != 'true' &&
+          steps.run_state.outputs.is_stale != 'true' &&
+          steps.pragent_head.outputs.is_stale != 'true' &&
+          steps.inline_state_before.outputs.inline_ids_b64 != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
+          BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
+          BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
+          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
+        run: |
+          set -euo pipefail
+          before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
+          before_review_ids="$(printf '%s' "${BEFORE_REVIEW_IDS_B64:-W10=}" | base64 -d)"
+          comments="$(mktemp)"
+          reviews="$(mktemp)"
+          patches="$(mktemp)"
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments?per_page=100" --jq '.[] | @json' > "${comments}"
+          gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
+          python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${patches}" "${RUN_HEAD_SHA}" <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          before_ids = set(json.loads(sys.argv[1] or "[]"))
+          before_review_ids = set(json.loads(sys.argv[2] or "[]"))
+          comments_path = Path(sys.argv[3])
+          reviews_path = Path(sys.argv[4])
+          patches_path = Path(sys.argv[5])
+          head_sha = sys.argv[6]
+          marker = os.environ["PR_AGENT_INLINE_MARKER"]
+          marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
+
+          new_review_ids = set()
+          for line in reviews_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("id") not in before_review_ids
+                  and item.get("commit_id") == head_sha
+              ):
+                  new_review_ids.add(item["id"])
+
+          patches = []
+          for line in comments_path.read_text().splitlines():
+              if not line.strip():
+                  continue
+              item = json.loads(line)
+              body = item.get("body") or ""
+              if (
+                  item.get("user", {}).get("login") == "github-actions[bot]"
+                  and item.get("id") not in before_ids
+                  and item.get("commit_id") == head_sha
+                  and item.get("pull_request_review_id") in new_review_ids
+                  and body.strip()
+                  and not marker_re.search(body)
+              ):
+                  patches.append({"id": item["id"], "body": f"{marker}\n{body}"})
+
+          patches_path.write_text("\n".join(json.dumps(item, ensure_ascii=False) for item in patches))
+          PY
+
+          if [ ! -s "${patches}" ]; then
+            echo "No PR-Agent inline comments to mark."
+            exit 0
+          fi
+          patch_failed=false
+          while IFS= read -r patch || [ -n "${patch}" ]; do
+            [ -z "${patch}" ] && continue
+            comment_id="$(printf '%s' "${patch}" | jq -r '.id')"
+            payload="$(mktemp)"
+            printf '%s' "${patch}" | jq '{body:.body}' > "${payload}"
+            if ! gh api --method PATCH "repos/${REPO}/pulls/comments/${comment_id}" --input "${payload}" >/dev/null 2>&1; then
+              echo "PR-Agent inline comment ${comment_id} could not be marked."
+              patch_failed=true
+            fi
+          done < "${patches}"
+          if [ "${patch_failed}" = "true" ]; then
+            exit 1
+          fi
+
       - name: Clean stale PR-Agent inline comments
         id: post_pragent_state
         if: >-
@@ -397,6 +539,7 @@ jobs:
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
           BEFORE_INLINE_IDS_B64: ${{ steps.inline_state_before.outputs.inline_ids_b64 }}
           BEFORE_REVIEW_IDS_B64: ${{ steps.inline_state_before.outputs.review_ids_b64 }}
+          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
         run: |
           set -euo pipefail
           current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
@@ -418,7 +561,7 @@ jobs:
           gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | @json' > "${reviews}"
           python3 - "${before_ids}" "${before_review_ids}" "${comments}" "${reviews}" "${delete_ids}" "${RUN_HEAD_SHA}" <<'PY'
           import json
-          import re
+          import os
           import sys
           from pathlib import Path
 
@@ -428,20 +571,10 @@ jobs:
           reviews_path = Path(sys.argv[4])
           delete_path = Path(sys.argv[5])
           head_sha = sys.argv[6]
-          risk_prefix_re = re.compile(
-              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
-              re.IGNORECASE,
-          )
-          marker_re = re.compile(
-              r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*",
-              re.IGNORECASE,
-          )
-
-          def normalize_suggestion_body(body: str) -> str:
-              return marker_re.sub("", body or "", count=1).strip()
+          marker = os.environ["PR_AGENT_INLINE_MARKER"]
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              return bool(risk_prefix_re.search(normalize_suggestion_body(item.get("body") or "")))
+              return (item.get("body") or "").lstrip().startswith(marker)
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -513,6 +646,7 @@ jobs:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
           SUMMARY_MODEL: gpt-5.5
+          PR_AGENT_INLINE_MARKER: "<!-- pr-agent-inline-comment:${{ github.run_id }} -->"
         run: |
           set -euo pipefail
           before_ids="$(printf '%s' "${BEFORE_INLINE_IDS_B64:-W10=}" | base64 -d)"
@@ -553,12 +687,9 @@ jobs:
           pr_url = sys.argv[7]
           commit_url = sys.argv[8]
           short_sha = sys.argv[9]
+          marker = os.environ["PR_AGENT_INLINE_MARKER"]
           marker_re = re.compile(
               r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*",
-              re.IGNORECASE,
-          )
-          risk_prefix_re = re.compile(
-              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
               re.IGNORECASE,
           )
 
@@ -566,8 +697,7 @@ jobs:
               return marker_re.sub("", body or "", count=1).strip()
 
           def is_pr_agent_suggestion(item: dict) -> bool:
-              body = normalize_suggestion_body(item.get("body") or "")
-              return bool(risk_prefix_re.search(body))
+              return (item.get("body") or "").lstrip().startswith(marker)
 
           comments = []
           for line in comments_path.read_text().splitlines():


### PR DESCRIPTION
## 变更说明

- 为 PR-Agent 行内 Review 评论写入隐藏归属标记，后续汇总和 stale cleanup 只识别本 workflow 标记的评论。
- 同一 commit 重跑时，同时检查 Code Review 汇总评论和已标记的行内评论，避免重复发布 inline feedback。
- PR body 占位符准备遇到并发修改时跳过本轮 describe，避免覆盖用户刚编辑的正文。
- 保留个人仓 fork PR 自动触发过滤，同仓 PR 仍可通过手动命令触发。

## 影响范围

- `.github/workflows/pr-agent.yml`

## 验证

- Workflow YAML 解析通过。
- `git diff --check` 通过。
- `.githooks/pre-push` 通过。

## 交付路径

PR-only，不包含版本升级、tag 或 GitHub Release。

本 PR 为 Codex 协作提交
