### PR TITLE
ci(pr-agent): filter inline review markers

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -430,7 +430,8 @@ jobs:
           pr_code_suggestions.extra_instructions: |
             Match the configured response language.
             Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
-            Start every suggestion body with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
+            Start every suggestion body with this hidden ownership marker on its own first line: <!-- pr-agent-inline-comment:${{ github.run_id }} -->
+            Then start the visible suggestion text with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
           pr_code_suggestions.num_code_suggestions_per_chunk: "2"
@@ -481,6 +482,14 @@ jobs:
           head_sha = sys.argv[6]
           marker = os.environ["PR_AGENT_INLINE_MARKER"]
           marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
+          risk_prefix_re = re.compile(
+              r"^(?:(?:🔴\s*)?\*\*High Risk\*\*:|(?:🟡\s*)?\*\*Medium Risk\*\*:|(?:🔵\s*)?\*\*Low Risk\*\*:)",
+              re.IGNORECASE,
+          )
+
+          def looks_like_pr_agent_suggestion(body: str) -> bool:
+              body = marker_re.sub("", body or "", count=1).lstrip()
+              return bool(risk_prefix_re.search(body))
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -507,6 +516,7 @@ jobs:
                   and item.get("pull_request_review_id") in new_review_ids
                   and body.strip()
                   and not marker_re.search(body)
+                  and looks_like_pr_agent_suggestion(body)
               ):
                   patches.append({"id": item["id"], "body": f"{marker}\n{body}"})
 
@@ -633,7 +643,10 @@ jobs:
           (
             (
               github.event_name == 'pull_request_target' &&
-              steps.review_history.outputs.should_improve == 'true'
+              (
+                steps.review_history.outputs.should_improve == 'true' ||
+                steps.review_history.outputs.should_publish_existing_summary == 'true'
+              )
             ) ||
             (
               github.event_name == 'issue_comment' &&


### PR DESCRIPTION
## 变更说明

- 要求 PR-Agent 行内建议在正文首行携带隐藏 run marker，后续汇总可直接按本轮 marker 归属。
- 对未携带 marker 的新增行评，只在正文符合 PR-Agent 风险前缀时才补写 marker，避免误标其他 workflow 的行评。
- 修复已有行评 marker 但缺少 Code Review 总结时的补发条件，确保恢复路径能真正发布 summary。

## 影响范围

- `.github/workflows/pr-agent.yml`

## 验证

- Workflow YAML 解析通过。
- `git diff --check` 通过。
- `.githooks/pre-push` 通过。

## 交付路径

PR-only，不包含版本升级、tag 或 GitHub Release。

本 PR 为 Codex 协作提交
