### PR TITLE
ci(pr-agent): harden inline summary recovery

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -506,6 +506,11 @@ jobs:
           patches_path = Path(sys.argv[5])
           marker = os.environ["PR_AGENT_INLINE_MARKER"]
           marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
+          risk_prefixes = ("🔴 **High Risk**:", "🟡 **Medium Risk**:", "🔵 **Low Risk**:")
+
+          def is_pr_agent_inline_body(body: str) -> bool:
+              visible = (body or "").lstrip()
+              return visible.startswith("**Suggestion:**") or visible.startswith(risk_prefixes)
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -528,7 +533,7 @@ jobs:
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_ids
                   and item.get("pull_request_review_id") in new_review_ids
-                  and body.lstrip().startswith("**Suggestion:**")
+                  and is_pr_agent_inline_body(body)
                   and not marker_re.search(body)
               ):
                   patches.append({"id": item["id"], "body": f"{marker}\n{body}"})
@@ -954,7 +959,6 @@ jobs:
       - name: Restore PR-Agent description markers on failure
         if: >-
           always() &&
-          steps.prepare_description.outputs.body_changed == 'true' &&
           steps.pr_language.outputs.skip_pr_agent != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -971,7 +975,7 @@ jobs:
           payload="$(mktemp)"
           etag_file="$(mktemp)"
 
-          if [ ! -s "${body_backup}" ] || [ ! -s "${placeholder_body}" ]; then
+          if [ ! -e "${body_backup}" ] || [ ! -s "${placeholder_body}" ]; then
             echo "No PR body backup found."
             exit 0
           fi
@@ -1042,7 +1046,11 @@ jobs:
               payload_path.write_text(json.dumps({"body": next_body}, ensure_ascii=False))
               raise SystemExit(0)
 
-          restored_section = backup_body[backup_block[0]:backup_block[1]] if backup_block else ""
+          restored_section = ""
+          if backup_block:
+              backup_section = backup_body[backup_block[0]:backup_block[1]]
+              if "pr_agent:summary" not in backup_section:
+                  restored_section = backup_section
           next_body = current_body[:current_block[0]] + restored_section + current_body[current_block[1]:]
           next_body = re.sub(r"\n{4,}", "\n\n\n", next_body).rstrip() + "\n"
           payload_path.write_text(json.dumps({"body": next_body}, ensure_ascii=False))


### PR DESCRIPTION
## 变更说明

- 行内建议补标记同时兼容 PR-Agent 固定 `**Suggestion:**` 包装和风险前缀文本，避免模型或模板输出形态变化导致 summary 漏统计。
- 恢复步骤不再依赖本轮是否改写 PR body；即使已有占位符残留，也能清理 workflow 管理的 summary block。
- 空 PR body 场景下，备份文件允许为 0 字节，避免 PR-Agent 失败后跳过恢复。

## 验证

- YAML 解析通过
- `git diff --check`
- `.githooks/pre-push`

PR-only，无版本、tag 或 release 变更。

本 PR 为 Codex 协作提交
