### PR TITLE
ci(pr-agent): keep body reads consistent

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -160,6 +160,7 @@ jobs:
           RUN_HEAD_SHA: ${{ steps.pr_language.outputs.head_sha }}
         run: |
           set -euo pipefail
+          current_response="$(mktemp)"
           current_body="$(mktemp)"
           latest_body="$(mktemp)"
           latest_response="$(mktemp)"
@@ -169,7 +170,14 @@ jobs:
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
           placeholder_body="${RUNNER_TEMP}/pr-agent-body-with-placeholder.md"
 
-          gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "${current_response}"
+          python3 - "${current_response}" "${current_body}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          Path(sys.argv[2]).write_text(json.loads(Path(sys.argv[1]).read_text()).get("body") or "")
+          PY
           cp "${current_body}" "${body_backup}"
           python3 - "${current_body}" "${next_body}" <<'PY'
           import os
@@ -464,7 +472,7 @@ jobs:
           pr_code_suggestions.extra_instructions: |
             Match the configured response language.
             Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
-            Start every suggestion with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
+            Use one of these Markdown risk labels near the beginning of each visible suggestion when applicable: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
           pr_code_suggestions.suggestions_score_threshold: "8"
           pr_code_suggestions.num_code_suggestions_per_chunk: "2"
@@ -513,11 +521,6 @@ jobs:
           patches_path = Path(sys.argv[5])
           marker = os.environ["PR_AGENT_INLINE_MARKER"]
           marker_re = re.compile(r"^\s*<!--\s*pr-agent-inline-comment(?::[^>]*)?\s*-->\s*", re.IGNORECASE)
-          risk_prefixes = ("🔴 **High Risk**:", "🟡 **Medium Risk**:", "🔵 **Low Risk**:")
-
-          def is_pr_agent_inline_body(body: str) -> bool:
-              visible = (body or "").lstrip()
-              return visible.startswith("**Suggestion:**") or visible.startswith(risk_prefixes)
 
           new_review_ids = set()
           for line in reviews_path.read_text().splitlines():
@@ -540,7 +543,7 @@ jobs:
                   item.get("user", {}).get("login") == "github-actions[bot]"
                   and item.get("id") not in before_ids
                   and item.get("pull_request_review_id") in new_review_ids
-                  and is_pr_agent_inline_body(body)
+                  and body.lstrip().startswith("**Suggestion:**")
                   and not marker_re.search(body)
               ):
                   patches.append({"id": item["id"], "body": f"{marker}\n{body}"})
@@ -976,6 +979,7 @@ jobs:
           set -euo pipefail
           body_backup="${RUNNER_TEMP}/pr-agent-body-before-describe.md"
           placeholder_body="${RUNNER_TEMP}/pr-agent-body-with-placeholder.md"
+          current_response="$(mktemp)"
           current_body="$(mktemp)"
           latest_body="$(mktemp)"
           latest_response="$(mktemp)"
@@ -987,7 +991,14 @@ jobs:
             exit 0
           fi
 
-          gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${current_body}"
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}" > "${current_response}"
+          python3 - "${current_response}" "${current_body}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          Path(sys.argv[2]).write_text(json.loads(Path(sys.argv[1]).read_text()).get("body") or "")
+          PY
           current_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
           run_head_sha="${RUN_HEAD_SHA:-}"
           is_stale=false


### PR DESCRIPTION
## 变更说明

- PR body 的初始读取和并发校验读取统一走 JSON 解析，避免 `--jq` 自动追加终止换行导致误判 body 已变化。
- 行内建议来源识别收窄为 PR-Agent 固定 `**Suggestion:**` 包装，风险标签改为可见建议文本中的提示，不再把裸风险前缀作为归属判据。
- 保持 PR body 条件写入和恢复逻辑不变。

## 验证

- YAML 解析通过
- `git diff --check`
- `.githooks/pre-push`

PR-only，无版本、tag 或 release 变更。

本 PR 为 Codex 协作提交
