### PR TITLE
ci(pr-agent): remove stale review summaries

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -941,6 +941,14 @@ jobs:
           gh api --method POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input "${payload}" > "${new_comment}"
           new_comment_id="$(jq -r '.id' "${new_comment}")"
           new_comment_created_at="$(jq -r '.created_at' "${new_comment}")"
+
+          latest_head_sha="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          if [ "${latest_head_sha}" != "${HEAD_SHA}" ]; then
+            echo "PR head changed from ${HEAD_SHA} to ${latest_head_sha}; remove stale code review summary."
+            gh api --method DELETE "repos/${REPO}/issues/comments/${new_comment_id}" >/dev/null
+            exit 0
+          fi
+
           comment_ids="$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" --jq ".[] | select(.id != ${new_comment_id} and .user.login == \"github-actions[bot]\" and ((.body | startswith(\"<!-- pr-agent-code-review-summary -->\")) or (.body | startswith(\"<!-- pr-agent-update-notification -->\"))) and (.created_at < \"${new_comment_created_at}\" or (.created_at == \"${new_comment_created_at}\" and .id < ${new_comment_id}))) | .id")"
 
           if [ -z "${comment_ids}" ]; then


### PR DESCRIPTION
## 变更说明

- Code Review summary 发布后再次检查 PR head。
- 若 POST 后发现 PR 已推到新 commit，立即删除刚创建的旧 commit summary 并退出，避免 stale summary 长期保留。

## 验证

- YAML 解析通过
- `git diff --check`
- `.githooks/pre-push`

PR-only，无版本、tag 或 release 变更。

本 PR 为 Codex 协作提交
