### PR TITLE
ci(pr-agent): tune suggestion sensitivity

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -283,8 +283,8 @@ jobs:
             Only provide substantive issues that maintainers should address; avoid style-only, preference-only, or low-value suggestions.
             For prioritized issues, start the suggestion body with one of these Markdown prefixes: 🔴 **High Risk**:, 🟡 **Medium Risk**:, or 🔵 **Low Risk**:.
           pr_code_suggestions.focus_only_on_problems: "true"
-          pr_code_suggestions.suggestions_score_threshold: "8"
-          pr_code_suggestions.num_code_suggestions_per_chunk: "2"
+          pr_code_suggestions.suggestions_score_threshold: "3"
+          pr_code_suggestions.num_code_suggestions_per_chunk: "3"
           pr_code_suggestions.commitable_code_suggestions: "true"
           pr_code_suggestions.publish_output_no_suggestions: "false"
           pr_questions.use_conversation_history: "true"


### PR DESCRIPTION
## 变更说明

- 将 PR-Agent 行内建议分数阈值从 `8` 调整为 `3`，降低过滤强度。
- 将每个 diff chunk 的建议数量从 `2` 调整为 `3`，与官方仓库配置保持一致。

## 验证

- YAML 解析通过
- `git diff --check`
- `.githooks/pre-push`

## 交付边界

- PR-only，不包含版本升级、tag 或 GitHub Release。

本 PR 为 Codex 协作提交
