### PR TITLE
refactor(plexlocalization): improve full scan performance

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -175,11 +175,12 @@
         "name": "Plex中文本地化",
         "description": "实现拼音排序、搜索及类型标签中文本地化功能。",
         "labels": "Plex",
-        "version": "1.9",
+        "version": "2.0",
         "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/plexlocalization.png",
         "author": "InfinityPacer",
         "level": 1,
         "history": {
+            "v2.0": "重构插件执行逻辑，提升全量处理性能和稳定性",
             "v1.9": "修复标题排序写入端点，避免日志显示成功但 Plex 未实际更新",
             "v1.8": "优化执行周期输入，需要MoviePilot v2.2.1+",
             "v1.7": "MoviePilot V2 版本Plex中文本地化插件"

--- a/plugins.v2/plexlocalization/__init__.py
+++ b/plugins.v2/plexlocalization/__init__.py
@@ -6,6 +6,7 @@ import time
 from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
 
 import plexapi.utils
 import pypinyin
@@ -38,7 +39,7 @@ class PlexLocalization(_PluginBase):
     # 插件图标
     plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/plexlocalization.png"
     # 插件版本
-    plugin_version = "1.9"
+    plugin_version = "2.0"
     # 插件作者
     plugin_author = "InfinityPacer"
     # 作者主页
@@ -74,6 +75,10 @@ class PlexLocalization(_PluginBase):
     _batch_size = None
     # timeout
     _timeout = 10
+    # Plex 列表分页大小
+    _page_size = 500
+    # ratingKey 批量读取和验证的安全分块大小
+    _metadata_chunk_size = 100
     # tags_json
     _tags_json = None
     # tags
@@ -86,6 +91,15 @@ class PlexLocalization(_PluginBase):
     _event = threading.Event()
 
     # endregion
+
+    @staticmethod
+    def __positive_int(value: Any, default: int) -> int:
+        """读取正整数配置，非法值回退默认值。"""
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
 
     def init_plugin(self, config: dict = None):
         self.mediaserver_helper = MediaServerHelper()
@@ -100,18 +114,12 @@ class PlexLocalization(_PluginBase):
         self._execute_transfer = config.get("execute_transfer")
         self._tags_json = config.get("tags_json")
         self._tags = self.__get_tags()
-        try:
-            self._thread_count = int(config.get("thread_count", 5))
-        except ValueError:
-            self._thread_count = 5
+        self._thread_count = self.__positive_int(config.get("thread_count", 3), default=3)
         try:
             self._delay = int(config.get("delay", 300))
         except ValueError:
             self._delay = 300
-        try:
-            self._batch_size = int(config.get("batch_size", 100))
-        except ValueError:
-            self._batch_size = 100
+        self._batch_size = self.__positive_int(config.get("batch_size", 100), default=100)
 
         # 如果开启了入库后运行一次，延迟时间又不填，默认为300s
         if self._execute_transfer and not self._delay:
@@ -382,7 +390,7 @@ class PlexLocalization(_PluginBase):
                                         'props': {
                                             'model': 'thread_count',
                                             'label': '运行线程数',
-                                            'hint': '执行任务时使用的线程数量',
+                                            'hint': '执行任务时使用的线程数量，普通用户建议设置为 2 至 4',
                                             'persistent-hint': True
                                         },
                                     }
@@ -400,7 +408,7 @@ class PlexLocalization(_PluginBase):
                                         'props': {
                                             'model': 'batch_size',
                                             'label': '每批次处理数',
-                                            'hint': '每次处理的最大元数据条数',
+                                            'hint': '每次处理的最大元数据条数，数值越大会占用更多单任务内存',
                                             'persistent-hint': True
                                         },
                                     }
@@ -676,7 +684,7 @@ class PlexLocalization(_PluginBase):
             "cron": "0 1 * * *",
             "lock": False,
             "tags_json": self.__get_preset_tags_json(),
-            "thread_count": 5,
+            "thread_count": 3,
             "execute_transfer": False,
             "delay": 300,
             "batch_size": 100
@@ -710,13 +718,12 @@ class PlexLocalization(_PluginBase):
         """
         退出插件
         """
+        self._event.set()
         try:
             if self._scheduler:
                 self._scheduler.remove_all_jobs()
                 if self._scheduler.running:
-                    self._event.set()
                     self._scheduler.shutdown()
-                    self._event.clear()
                 self._scheduler = None
         except Exception as e:
             logger.info(str(e))
@@ -859,6 +866,7 @@ class PlexLocalization(_PluginBase):
     def localization(self, added_time: Optional[int] = None):
         """本地化服务"""
         with lock:
+            self._event.clear()
             logger.info(f"正在准备执行本地化服务")
             service_libraries = self.__get_service_libraries()
             if not service_libraries:
@@ -956,10 +964,10 @@ class PlexLocalization(_PluginBase):
     def __list_rating_keys(self, plex: Plex, library: LibrarySection, type_id: int, is_collection: bool = False,
                            added_time: Optional[int] = None):
         """
-        获取所有媒体项目
+        分页获取媒体项目。返回 ratingKey 列表及 complete/failed/stopped 状态。
         """
         if not library:
-            return []
+            return [], "complete"
 
         if is_collection:
             endpoint = f"/library/sections/{library.key}/collections"
@@ -968,18 +976,91 @@ class PlexLocalization(_PluginBase):
             if added_time:
                 endpoint += f"&addedAt>={added_time}"
 
-        response = plex.get_data(endpoint=endpoint, timeout=self._timeout)
-        datas = (response
-                 .json()
-                 .get("MediaContainer", {})
-                 .get("Metadata", []))
-        rating_keys = [data.get("ratingKey") for data in datas]
+        rating_keys = []
+        offset = 0
+        previous_page = None
+        while True:
+            if self._event.is_set():
+                return rating_keys, "stopped"
+
+            response = plex.get_data(
+                endpoint=endpoint,
+                headers={
+                    "X-Plex-Container-Start": str(offset),
+                    "X-Plex-Container-Size": str(self._page_size)
+                },
+                timeout=self._timeout
+            )
+            if self._event.is_set():
+                return rating_keys, "stopped"
+            if response is None or response.status_code >= 400:
+                logger.warning(f"分页读取媒体项目失败，媒体库：{library.title}，offset={offset}")
+                return rating_keys, "failed"
+
+            try:
+                payload = response.json()
+                if not isinstance(payload, dict):
+                    raise ValueError("响应体不是对象")
+                if "MediaContainer" not in payload:
+                    raise ValueError("缺少 MediaContainer")
+                container = payload["MediaContainer"]
+                if not isinstance(container, dict):
+                    raise ValueError("MediaContainer 不是对象")
+                page_items = container.get("Metadata", [])
+                if not isinstance(page_items, list) \
+                        or any(not isinstance(data, dict) for data in page_items):
+                    raise ValueError("Metadata 不是对象列表")
+                total_size_value = container.get("totalSize")
+                total_size = int(total_size_value) if total_size_value is not None else None
+                if total_size is not None and total_size < 0:
+                    raise ValueError("totalSize 不能为负数")
+            except (AttributeError, TypeError, ValueError) as e:
+                logger.warning(f"分页响应解析失败，媒体库：{library.title}，offset={offset}，错误：{e}")
+                return rating_keys, "failed"
+
+            response_offset = container.get("offset")
+            if response_offset is not None:
+                try:
+                    if int(response_offset) != offset:
+                        logger.warning(f"分页响应位置不匹配，媒体库：{library.title}，"
+                                       f"请求 offset={offset}，响应 offset={response_offset}")
+                        return rating_keys, "failed"
+                except (TypeError, ValueError):
+                    logger.warning(f"分页响应位置无效，媒体库：{library.title}，offset={response_offset}")
+                    return rating_keys, "failed"
+
+            page_keys = [
+                str(data.get("ratingKey"))
+                for data in page_items
+                if data.get("ratingKey") is not None
+            ]
+            if offset and page_items and page_items == previous_page:
+                logger.warning(f"分页响应未推进，媒体库：{library.title}，offset={offset}")
+                return rating_keys, "failed"
+
+            rating_keys.extend(page_keys)
+            logger.debug(f"媒体库 {library.title} 分页读取完成：offset={offset}，"
+                         f"本页 {len(page_keys)} 条，累计 {len(rating_keys)} 条")
+
+            next_offset = offset + len(page_items)
+            if total_size is not None:
+                if next_offset >= total_size:
+                    break
+                if not page_items:
+                    logger.warning(f"分页响应提前结束，媒体库：{library.title}，offset={offset}，"
+                                   f"totalSize={total_size}")
+                    return rating_keys, "failed"
+            elif not page_items or len(page_items) < self._page_size:
+                break
+
+            previous_page = page_items
+            offset = next_offset
 
         if len(rating_keys):
             logger.info(f"<{library.title} {plexapi.utils.reverseSearchType(libtype=type_id)}> "
                         f"类型共计 {len(rating_keys)} 个{'合集' if is_collection else ''}")
 
-        return rating_keys
+        return rating_keys, "complete"
 
     def __fetch_item(self, plex: Plex, rating_key):
         """
@@ -987,6 +1068,8 @@ class PlexLocalization(_PluginBase):
         """
         endpoint = f"/library/metadata/{rating_key}"
         response = plex.get_data(endpoint=endpoint, timeout=self._timeout)
+        if response is None or response.status_code >= 400:
+            return None
         datas = (response
                  .json()
                  .get("MediaContainer", {})
@@ -999,53 +1082,57 @@ class PlexLocalization(_PluginBase):
         """
         endpoint = f"/library/metadata/{','.join(rating_keys)}"
         response = plex.get_data(endpoint=endpoint, timeout=self._timeout)
+        if response is None or response.status_code >= 400:
+            return None
         items = (response
                  .json()
                  .get("MediaContainer", {})
                  .get("Metadata", []))
         return items
 
-    def __put_title_sort(self, plex: Plex, rating_key: str, library_id: int, type_id: int, sort_title: str) -> bool:
-        """
-        更新标题排序，并通过重新读取元数据确认 Plex 已真实写入。
-        """
+    def __put_item_metadata(self, plex: Plex, rating_key: str, library_id: int, params: dict,
+                            expected_sort_title: Optional[str], expected_tags: Dict[str, List[str]]) -> bool:
+        """一次提交同一条目的全部元数据变更。最终状态由批次统一回读。"""
         response = plex.put_data(
-            endpoint=f"library/sections/{library_id}/all",
-            params={
-                "type": type_id,
-                "id": rating_key,
-                "includeExternalMedia": 1,
-                "titleSort.value": sort_title,
-                "titleSort.locked": 1 if self._lock else 0
-            },
+            endpoint=f"/library/sections/{library_id}/all",
+            params=params,
             timeout=self._timeout)
-        if not response or response.status_code >= 400:
-            logger.warning(f"更新标题排序失败，ratingKey={rating_key}，状态码："
-                           f"{response.status_code if response else '无响应'}")
-            return False
-
-        item = self.__fetch_item(plex=plex, rating_key=rating_key)
-        actual_sort_title = item.get("titleSort", "") if item else ""
-        if actual_sort_title != sort_title:
-            logger.warning(f"更新标题排序未生效，ratingKey={rating_key}，期望：{sort_title}，实际：{actual_sort_title}")
+        if response is None or response.status_code >= 400:
+            logger.warning(f"更新元数据失败，ratingKey={rating_key}，状态码："
+                           f"{response.status_code if response is not None else '无响应'}")
             return False
         return True
 
-    def __put_tag(self, plex: Plex, rating_key: str, library_id: int, type_id: str, tag, new_tag, tag_type):
-        """
-        更新标签
-        """
-        endpoint = f"/library/sections/{library_id}/all"
-        plex.put_data(
-            endpoint=endpoint,
-            params={
-                "type": type_id,
-                "id": rating_key,
-                f"{tag_type}.locked": 1 if self._lock else 0,
-                f"{tag_type}[0].tag.tag": new_tag,
-                f"{tag_type}[].tag.tag-": tag
-            },
-            timeout=self._timeout)
+    @staticmethod
+    def __metadata_differences(item: Optional[dict], expected_sort_title: Optional[str],
+                               expected_tags: Dict[str, List[str]]) -> List[str]:
+        """比较 Plex 最终元数据与本次写入期望，返回差异说明。"""
+        if not item:
+            return ["无法读取最终状态"]
+
+        differences = []
+        if expected_sort_title is not None:
+            actual_sort_title = item.get("titleSort")
+            if actual_sort_title != expected_sort_title:
+                differences.append(f"标题排序期望：{expected_sort_title}，实际：{actual_sort_title or ''}")
+
+        for tag_type, target_tags in expected_tags.items():
+            field_name = tag_type.capitalize()
+            actual_tags = [tag.get("tag") for tag in item.get(field_name, []) if tag.get("tag")]
+            if set(actual_tags) != set(target_tags):
+                differences.append(f"{tag_type}标签期望：{target_tags}，实际：{actual_tags}")
+        return differences
+
+    @staticmethod
+    def __empty_result_counts() -> Dict[str, int]:
+        """创建批次统计，确保停止路径也参与守恒。"""
+        return {"updated": 0, "failed": 0, "skipped": 0, "unprocessed": 0}
+
+    @staticmethod
+    def __merge_result_counts(target: Dict[str, int], source: Dict[str, int]):
+        """把子块统计合并到业务批次。"""
+        for key in target:
+            target[key] += source[key]
 
     def __process_rating_key(self, plex: Plex, rating_key: str):
         """
@@ -1060,16 +1147,147 @@ class PlexLocalization(_PluginBase):
 
     def __process_items_batch(self, plex: Plex, rating_keys):
         """
-        获取并处理一批评级键对应的条目
+        按固定 HTTP 子块处理业务批次，返回更新、失败、跳过和未处理数量。
         """
-        items = self.__fetch_all_items(plex=plex, rating_keys=rating_keys)
-        for item in items:
-            self.__process_item(plex=plex, item=item)
+        result_counts = self.__empty_result_counts()
+        for offset in range(0, len(rating_keys), self._metadata_chunk_size):
+            chunk_keys = rating_keys[offset:offset + self._metadata_chunk_size]
+            if self._event.is_set():
+                result_counts["unprocessed"] += len(rating_keys) - offset
+                break
 
-    def __process_item(self, plex: Plex, item: dict):
+            try:
+                chunk_result = self.__process_items_chunk(plex=plex, rating_keys=chunk_keys)
+            except Exception as e:
+                logger.error(f"处理元数据子块失败，首个 ratingKey={chunk_keys[0] if chunk_keys else ''}: {e}",
+                             exc_info=True)
+                chunk_result = self.__empty_result_counts()
+                chunk_result["failed"] = len(chunk_keys)
+            self.__merge_result_counts(result_counts, chunk_result)
+        return result_counts
+
+    def __process_items_chunk(self, plex: Plex, rating_keys: List[str]) -> Dict[str, int]:
+        """读取并处理一个不超过安全上限的 HTTP 子块。"""
+        items = self.__fetch_all_items(plex=plex, rating_keys=rating_keys)
+        if items is None:
+            result_counts = self.__empty_result_counts()
+            result_counts["failed"] = len(rating_keys)
+            return result_counts
+        return self.__process_loaded_items(plex=plex, rating_keys=rating_keys, items=items)
+
+    def __process_loaded_items(self, plex: Plex, rating_keys: List[str], items: List[dict]) -> Dict[str, int]:
+        """对已读取元数据执行逐条 PUT，并统一回读成功写入。"""
+        result_counts = self.__empty_result_counts()
+        items_by_rating_key = {
+            str(item.get("ratingKey")): item
+            for item in items
+            if item and item.get("ratingKey") is not None
+        }
+        pending_verification = []
+
+        for index, rating_key in enumerate(rating_keys):
+            if self._event.is_set():
+                result_counts["unprocessed"] += len(rating_keys) - index
+                break
+
+            item = items_by_rating_key.get(str(rating_key))
+            if not item:
+                result_counts["failed"] += 1
+                logger.warning(f"批量读取条目缺失，ratingKey={rating_key}")
+                continue
+
+            try:
+                edit_plan = self.__prepare_item_edit(item=item)
+            except Exception as e:
+                result_counts["failed"] += 1
+                logger.error(f"处理条目失败，ratingKey={rating_key}: {e}", exc_info=True)
+                continue
+
+            if edit_plan is None:
+                result_counts["skipped"] += 1
+                continue
+
+            if self._event.is_set():
+                result_counts["unprocessed"] += len(rating_keys) - index
+                break
+
+            try:
+                updated = self.__put_item_metadata(
+                    plex=plex,
+                    rating_key=edit_plan["rating_key"],
+                    library_id=edit_plan["library_id"],
+                    params=edit_plan["params"],
+                    expected_sort_title=edit_plan["expected_sort_title"],
+                    expected_tags=edit_plan["expected_tags"]
+                )
+            except Exception as e:
+                result_counts["failed"] += 1
+                logger.error(f"更新元数据异常，ratingKey={rating_key}: {e}", exc_info=True)
+                continue
+            if not updated:
+                result_counts["failed"] += 1
+                continue
+            pending_verification.append(edit_plan)
+
+        if not pending_verification:
+            return result_counts
+
+        if self._event.is_set():
+            result_counts["failed"] += len(pending_verification)
+            return result_counts
+
+        verification_keys = [plan["rating_key"] for plan in pending_verification]
+        final_items = self.__fetch_all_items(plex=plex, rating_keys=verification_keys)
+        if final_items is None:
+            result_counts["failed"] += len(pending_verification)
+            return result_counts
+
+        final_items_by_key = {
+            str(item.get("ratingKey")): item
+            for item in final_items
+            if item and item.get("ratingKey") is not None
+        }
+        for plan in pending_verification:
+            rating_key = plan["rating_key"]
+            try:
+                differences = self.__metadata_differences(
+                    item=final_items_by_key.get(rating_key),
+                    expected_sort_title=plan["expected_sort_title"],
+                    expected_tags=plan["expected_tags"]
+                )
+            except Exception as e:
+                result_counts["failed"] += 1
+                logger.error(f"验证元数据异常，ratingKey={rating_key}: {e}", exc_info=True)
+                continue
+            if differences:
+                result_counts["failed"] += 1
+                logger.warning(f"更新元数据未完全生效，ratingKey={rating_key}，{'；'.join(differences)}")
+                continue
+
+            result_counts["updated"] += 1
+            for message in plan["success_logs"]:
+                logger.info(message)
+        return result_counts
+
+    def __process_item(self, plex: Plex, item: dict) -> Optional[bool]:
         """
-        处理元数据
+        处理元数据。返回 True 表示更新成功，False 表示更新失败，None 表示无需处理。
         """
+        if not item or item.get("ratingKey") is None:
+            return None
+        result = self.__process_loaded_items(
+            plex=plex,
+            rating_keys=[str(item.get("ratingKey"))],
+            items=[item]
+        )
+        if result["updated"]:
+            return True
+        if result["failed"]:
+            return False
+        return None
+
+    def __prepare_item_edit(self, item: dict) -> Optional[dict]:
+        """计算单条元数据的原子编辑计划，不执行网络请求。"""
         if not item:
             return
 
@@ -1085,20 +1303,30 @@ class PlexLocalization(_PluginBase):
         type_id = plexapi.utils.searchType(libtype=item_type)
         title = item.get("title", "")
         locked_fields = [field["name"] for field in item.get("Field") or [] if field.get("locked")]
+        edit_params = {
+            "type": type_id,
+            "id": rating_key,
+            "includeExternalMedia": 1
+        }
+        expected_sort_title = None
+        sort_title_changed = False
+        expected_tags = {}
+        tag_updates = []
+        current_sort_title = item.get("titleSort")
+
         # 如果标题排序没有锁定，尝试更新标题排序
         if "titleSort" in locked_fields:
             logger.debug(f"{title}: titleSort is locked, skip")
         else:
-            title_sort = item.get("titleSort", "")
-            if StringUtils.is_chinese(title_sort) or title_sort == "":
-                title_sort = self.__convert_to_pinyin(title)
-                updated = self.__put_title_sort(plex=plex,
-                                                rating_key=rating_key,
-                                                library_id=library_id,
-                                                type_id=type_id,
-                                                sort_title=title_sort)
-                if updated:
-                    logger.info(f"{title} < {title_sort} >")
+            if not current_sort_title or StringUtils.is_chinese(current_sort_title):
+                generated_sort_title = self.__convert_to_pinyin(title)
+                if generated_sort_title != title:
+                    expected_sort_title = generated_sort_title
+                    sort_title_changed = True
+                    edit_params.update({
+                        "titleSort.value": expected_sort_title,
+                        "titleSort.locked": 1 if self._lock else 0
+                    })
 
         tags: dict[str, list] = {
             "genre": [genre.get("tag") for genre in item.get("Genre", {})],  # 流派
@@ -1113,17 +1341,53 @@ class PlexLocalization(_PluginBase):
                 if tag_type in locked_fields:
                     logger.debug(f"{title}: {tag_type} is locked, skip")
                 else:
+                    target_tags = []
+                    source_tags_to_remove = []
                     for tag in tag_list:
                         new_tag = self._tags.get(tag)
                         if new_tag:
-                            self.__put_tag(plex=plex,
-                                           rating_key=rating_key,
-                                           library_id=library_id,
-                                           type_id=type_id,
-                                           tag=tag,
-                                           new_tag=new_tag,
-                                           tag_type=tag_type)
-                            logger.info(f"{title}: {tag} → {new_tag}")
+                            tag_updates.append((tag, new_tag))
+                            source_tags_to_remove.append(tag)
+                        target_tag = new_tag or tag
+                        if target_tag not in target_tags:
+                            target_tags.append(target_tag)
+
+                    if source_tags_to_remove:
+                        expected_tags[tag_type] = target_tags
+                        edit_params[f"{tag_type}.locked"] = 1 if self._lock else 0
+                        for index, target_tag in enumerate(target_tags):
+                            edit_params[f"{tag_type}[{index}].tag.tag"] = target_tag
+                        # Plex 的 tag- 协议使用逗号分隔值；逐项预编码可保留标签内的特殊字符。
+                        edit_params[f"{tag_type}[].tag.tag-"] = ",".join(
+                            quote(str(tag)) for tag in source_tags_to_remove
+                        )
+
+        # Plex 会重置同一编辑请求中未携带的未锁定字段；标签变更时必须显式保持已有排序标题。
+        if expected_tags and expected_sort_title is None \
+                and current_sort_title and "titleSort" not in locked_fields:
+            expected_sort_title = current_sort_title
+            edit_params.update({
+                "titleSort.value": current_sort_title,
+                "titleSort.locked": 1 if self._lock else 0
+            })
+
+        if expected_sort_title is None and not expected_tags:
+            logger.debug(f"{title}（ratingKey={rating_key}）无需更新，跳过")
+            return None
+
+        success_logs = []
+        if sort_title_changed:
+            success_logs.append(f"{title} < {expected_sort_title} >")
+        for tag, new_tag in tag_updates:
+            success_logs.append(f"{title}: {tag} → {new_tag}")
+        return {
+            "rating_key": str(rating_key),
+            "library_id": library_id,
+            "params": edit_params,
+            "expected_sort_title": expected_sort_title,
+            "expected_tags": expected_tags,
+            "success_logs": success_logs
+        }
 
     def __loop_all(self, service_libraries: Dict[str, Dict[int, Any]], thread_count: int = None,
                    added_time: Optional[int] = None):
@@ -1136,36 +1400,61 @@ class PlexLocalization(_PluginBase):
 
         logger.info(f"当前标签本地化配置为：{self._tags}")
         overall_start_time = time.time()
-        thread_count = thread_count or 5
+        thread_count = thread_count or 3
         logger.info(f"正在运行中文本地化，线程数：{thread_count}，锁定元数据：{self._lock}")
 
+        overall_results = {"updated": 0, "failed": 0, "skipped": 0, "unprocessed": 0}
+        completed_services = 0
+        discovered_items = 0
+        failed_services = 0
+        stopped = False
+
         for service_name, libraries in service_libraries.items():
+            if self._event.is_set():
+                stopped = True
+                break
+
             service = self.service_info(name=service_name)
             if not service or not service.instance:
-                logger.info(f"获取媒体服务器 {service.name} 实例失败，跳过处理")
+                failed_services += 1
+                logger.warning(f"获取媒体服务器 {service_name} 实例失败，跳过处理")
                 continue
 
             service_start_time = time.time()
             logger.info(f"开始处理媒体服务器 {service.name}")
 
             # 生成所有需要处理的rating keys
-            if added_time:
-                rating_keys = self.__generate_all_rating_keys(plex=service.instance,
-                                                              libraries=libraries,
-                                                              with_collection=False,
-                                                              added_time=added_time)
-            else:
-                rating_keys = self.__generate_all_rating_keys(plex=service.instance,
-                                                              libraries=libraries,
-                                                              with_collection=True)
+            rating_keys, scan_status = self.__generate_all_rating_keys(
+                plex=service.instance,
+                libraries=libraries,
+                with_collection=added_time is None,
+                added_time=added_time
+            )
+            if scan_status == "stopped":
+                stopped = True
+                break
+            if scan_status != "complete":
+                failed_services += 1
+                logger.warning(f"媒体服务器 {service.name} 枚举不完整，跳过本次处理")
+                continue
+            discovered_items += len(rating_keys)
 
             # 分批处理rating keys
-            self.__process_rating_keys_in_batches(plex=service.instance,
-                                                  rating_keys=rating_keys,
-                                                  thread_count=thread_count,
-                                                  batch_size=self._batch_size)
+            service_results = self.__process_rating_keys_in_batches(
+                plex=service.instance,
+                rating_keys=rating_keys,
+                thread_count=thread_count,
+                batch_size=self._batch_size
+            )
+            for key in overall_results:
+                overall_results[key] += service_results[key]
 
             service_elapsed_time = time.time() - service_start_time
+            if self._event.is_set():
+                stopped = True
+                logger.warning(f"媒体服务器 {service.name} 处理已停止，耗时 {service_elapsed_time:.2f} 秒")
+                break
+            completed_services += 1
             logger.info(f"媒体服务器 {service.name} 处理完成，耗时 {service_elapsed_time:.2f} 秒")
 
         overall_elapsed_time = time.time() - overall_start_time
@@ -1175,60 +1464,124 @@ class PlexLocalization(_PluginBase):
         else:
             message_text = f"Plex本地化完成，用时 {overall_elapsed_time :.2f} 秒"
 
-        self.__send_message(title="【Plex中文本地化】", text=message_text)
-
-        logger.info(message_text)
+        result_text = (f"完整服务 {completed_services}，失败服务 {failed_services}，发现 {discovered_items}，"
+                       f"更新 {overall_results['updated']}，失败 {overall_results['failed']}，"
+                       f"跳过 {overall_results['skipped']}，未处理 {overall_results['unprocessed']}")
+        if stopped:
+            logger.warning(f"Plex本地化已停止，{result_text}，用时 {overall_elapsed_time:.2f} 秒")
+        elif failed_services:
+            logger.warning(f"Plex本地化未完整完成，{result_text}，"
+                           f"用时 {overall_elapsed_time:.2f} 秒")
+        else:
+            self.__send_message(title="【Plex中文本地化】", text=message_text)
+            logger.info(f"{message_text}，{result_text}")
 
     def __generate_all_rating_keys(self, plex: Plex, libraries, with_collection: bool = True,
                                    added_time: Optional[int] = None):
         """
-        生成所有库中项目的rating keys列表
+        生成所有库中唯一且保持首次发现顺序的 ratingKey 列表。
         """
-        # 使用集合来自动去除重复的rating keys
-        rating_keys_set = set()
+        rating_keys = []
+        seen_keys = set()
+
+        def append_unique(keys):
+            """保留跨类型和合集首次出现的 ratingKey。"""
+            for rating_key in keys:
+                if rating_key not in seen_keys:
+                    seen_keys.add(rating_key)
+                    rating_keys.append(rating_key)
+
         for library in libraries.values():
             library_types = TYPES.get(library.type, [])
             for type_id in library_types:
-                if with_collection:
-                    rating_keys_set.update(self.__list_rating_keys(plex=plex, library=library, type_id=type_id))
-                    rating_keys_set.update(
-                        self.__list_rating_keys(plex=plex, library=library, type_id=type_id, is_collection=True))
-                else:
-                    rating_keys_set.update(
-                        self.__list_rating_keys(plex=plex, library=library, type_id=type_id, added_time=added_time))
-        return list(rating_keys_set)
+                keys, status = self.__list_rating_keys(
+                    plex=plex,
+                    library=library,
+                    type_id=type_id,
+                    added_time=added_time
+                )
+                if status != "complete":
+                    return [], status
+                append_unique(keys)
+
+            if with_collection and library_types:
+                keys, status = self.__list_rating_keys(
+                    plex=plex,
+                    library=library,
+                    type_id=library_types[0],
+                    is_collection=True
+                )
+                if status != "complete":
+                    return [], status
+                append_unique(keys)
+
+        return rating_keys, "complete"
 
     def __process_rating_keys_in_batches(self, plex: Plex, rating_keys, thread_count, batch_size=100):
         """
-        分批处理rating keys列表
+        有界提交批次并汇总所有 ratingKey 的终态。
         """
         total_keys_count = len(rating_keys)
         total_batches = (total_keys_count + batch_size - 1) // batch_size
 
         logger.info(f"总条目：{total_keys_count}，每批处理条数：{batch_size}，总批次数：{total_batches}，准备开始执行")
 
-        futures = {}
-        successful_batches = 0  # 成功处理的批次数
+        pending = {}
+        completed_batches = 0
+        failed_batches = 0
+        total_results = {"updated": 0, "failed": 0, "skipped": 0, "unprocessed": 0}
+        next_start = 0
+        max_pending = thread_count * 2
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=thread_count) as executor:
-            # 提交所有批次处理任务
-            for i in range(0, total_keys_count, batch_size):
-                batch_keys = rating_keys[i:i + batch_size]
-                future = executor.submit(self.__process_items_batch, plex, batch_keys)
-                futures[future] = i // batch_size
-
-            # 实时处理每个future的完成
-            for future in concurrent.futures.as_completed(futures):
-                batch_index = futures[future]
+        def collect_done(done_futures):
+            """汇总已终结 Future，异常批次按失败处理。"""
+            nonlocal completed_batches, failed_batches
+            for future in done_futures:
+                batch_index, batch_keys = pending.pop(future)
                 try:
-                    future.result()
-                    logger.debug(f"第{batch_index + 1}批次处理成功")
-                    successful_batches += 1
+                    batch_results = future.result()
+                    logger.debug(f"第{batch_index + 1}批次处理完成："
+                                 f"更新 {batch_results['updated']}，失败 {batch_results['failed']}，"
+                                 f"跳过 {batch_results['skipped']}，未处理 {batch_results['unprocessed']}")
+                    completed_batches += 1
+                    for key in total_results:
+                        total_results[key] += batch_results[key]
                 except Exception as e:
+                    failed_batches += 1
+                    total_results["failed"] += len(batch_keys)
                     logger.error(f"第{batch_index + 1}批次处理过程中发生错误: {e}", exc_info=True)
 
-        # 打印处理完毕后的结果
-        logger.info(f"处理完毕，成功批次数：{successful_batches}")
+        with concurrent.futures.ThreadPoolExecutor(max_workers=thread_count) as executor:
+            while next_start < total_keys_count or pending:
+                while next_start < total_keys_count and len(pending) < max_pending \
+                        and not self._event.is_set():
+                    batch_keys = rating_keys[next_start:next_start + batch_size]
+                    future = executor.submit(self.__process_items_batch, plex, batch_keys)
+                    pending[future] = (next_start // batch_size, batch_keys)
+                    next_start += len(batch_keys)
+
+                if self._event.is_set():
+                    for future, (_, batch_keys) in list(pending.items()):
+                        if future.cancel():
+                            pending.pop(future)
+                            total_results["unprocessed"] += len(batch_keys)
+
+                if not pending:
+                    break
+
+                done, _ = concurrent.futures.wait(
+                    pending,
+                    return_when=concurrent.futures.FIRST_COMPLETED
+                )
+                collect_done(done)
+
+            if next_start < total_keys_count:
+                total_results["unprocessed"] += total_keys_count - next_start
+
+        logger.info(f"处理完毕，完成批次数：{completed_batches}，异常批次数：{failed_batches}，"
+                    f"更新条目：{total_results['updated']}，失败条目：{total_results['failed']}，"
+                    f"跳过条目：{total_results['skipped']}，未处理条目：{total_results['unprocessed']}")
+        return total_results
 
     @staticmethod
     def __extract_tags(datas: Any, attribute_name: str) -> list:

--- a/tests/v2/plexlocalization/conftest.py
+++ b/tests/v2/plexlocalization/conftest.py
@@ -1,0 +1,17 @@
+"""Plex 中文本地化测试隔离。"""
+
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_stop_event():
+    """避免类级停止事件在测试模块和用例之间传播。"""
+    module = sys.modules.get("plexlocalization")
+    if module:
+        module.PlexLocalization._event.clear()
+    yield
+    module = sys.modules.get("plexlocalization")
+    if module:
+        module.PlexLocalization._event.clear()

--- a/tests/v2/plexlocalization/test_full_scan_pipeline.py
+++ b/tests/v2/plexlocalization/test_full_scan_pipeline.py
@@ -1,0 +1,828 @@
+"""Plex 中文本地化全量扫描管线测试。"""
+
+import concurrent.futures
+import threading
+import time
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from app.testing import stub_modules
+
+
+_pypinyin = ModuleType("pypinyin")
+_pypinyin.Style = SimpleNamespace(FIRST_LETTER="first_letter")
+_pypinyin.lazy_pinyin = lambda *args, **kwargs: []
+
+with stub_modules({"pypinyin": _pypinyin}):
+    from plexlocalization import PlexLocalization
+
+
+class _Response:
+    """提供分页 API 所需的最小响应。"""
+
+    def __init__(self, container, status_code=200):
+        self.status_code = status_code
+        self._container = container
+
+    def json(self):
+        """返回 Plex JSON 包装结构。"""
+        return {"MediaContainer": self._container}
+
+
+class _MalformedResponse(_Response):
+    """模拟状态码成功但响应体无法解析。"""
+
+    def __init__(self):
+        super().__init__({})
+
+    def json(self):
+        """模拟 Plex 返回非 JSON 响应。"""
+        raise ValueError("invalid json")
+
+
+class _MissingContainerResponse(_Response):
+    """模拟缺失 Plex 顶层包装字段的响应。"""
+
+    def __init__(self):
+        super().__init__({})
+
+    def json(self):
+        """返回缺失 MediaContainer 的对象。"""
+        return {}
+
+
+class _PagingPlex:
+    """按 endpoint 和 offset 返回测试页并记录请求。"""
+
+    def __init__(self, handler):
+        self._handler = handler
+        self.calls = []
+
+    @property
+    def starts(self):
+        """返回所有分页请求的起始位置。"""
+        return [call[1] for call in self.calls]
+
+    def get_data(self, *, endpoint, headers=None, timeout):
+        """调用页处理器，None 表示请求失败。"""
+        headers = headers or {}
+        start = int(headers.get("X-Plex-Container-Start", 0))
+        size = int(headers.get("X-Plex-Container-Size", 0))
+        self.calls.append((endpoint, start, size, timeout))
+        result = self._handler(endpoint, start)
+        if result is None:
+            return None
+        if isinstance(result, _Response):
+            return result
+        return _Response(result)
+
+
+class _MetadataPlex:
+    """模拟详情读取、原子 PUT 和批量验证。"""
+
+    def __init__(self, source_items, final_items=None):
+        self.source_items = source_items
+        self.final_items = final_items or source_items
+        self.put_calls = []
+        self.written_keys = set()
+        self.detail_request_sizes = []
+        self.verify_request_sizes = []
+        self.fail_verification = False
+        self.raise_on_detail_call = None
+        self.raise_on_put_key = None
+        self.on_first_put = None
+
+    def get_data(self, *, endpoint, timeout):
+        """写入前返回源状态，写入后返回最终状态。"""
+        keys = endpoint.rsplit("/", 1)[-1].split(",")
+        is_verification = bool(keys) and all(key in self.written_keys for key in keys)
+        if is_verification:
+            self.verify_request_sizes.append(len(keys))
+            if self.fail_verification:
+                return None
+            items = [self.final_items[key] for key in keys if key in self.final_items]
+        else:
+            self.detail_request_sizes.append(len(keys))
+            if self.raise_on_detail_call == len(self.detail_request_sizes):
+                raise RuntimeError("detail request failed")
+            items = [self.source_items[key] for key in keys if key in self.source_items]
+        return _Response({"Metadata": items})
+
+    def put_data(self, *, endpoint, params, timeout):
+        """记录单条写入并允许测试在首个 PUT 后触发停止。"""
+        if str(params["id"]) == self.raise_on_put_key:
+            raise RuntimeError("put failed")
+        self.put_calls.append({"endpoint": endpoint, "params": params, "timeout": timeout})
+        self.written_keys.add(str(params["id"]))
+        if len(self.put_calls) == 1 and self.on_first_put:
+            self.on_first_put()
+        return _Response({}, status_code=200)
+
+
+class _ConcurrentPlex:
+    """通过 barrier 记录真实同时请求数。"""
+
+    def __init__(self, worker_count):
+        self._barrier = threading.Barrier(worker_count)
+        self._lock = threading.Lock()
+        self.active_requests = 0
+        self.max_active_requests = 0
+
+    def get_data(self, *, endpoint, timeout):
+        """让首轮详情请求同时进入，验证线程上限。"""
+        keys = endpoint.rsplit("/", 1)[-1].split(",")
+        with self._lock:
+            self.active_requests += 1
+            self.max_active_requests = max(self.max_active_requests, self.active_requests)
+        try:
+            self._barrier.wait(timeout=2)
+            time.sleep(0.01)
+            items = [_media_item(key) for key in keys]
+            return _Response({"Metadata": items})
+        finally:
+            with self._lock:
+                self.active_requests -= 1
+
+
+def _plugin():
+    plugin = object.__new__(PlexLocalization)
+    plugin._timeout = 10
+    plugin._event.clear()
+    return plugin
+
+
+def _edit_plugin():
+    plugin = _plugin()
+    plugin._lock = False
+    plugin._tags = {"Action": "动作"}
+    plugin._PlexLocalization__convert_to_pinyin = lambda _title: "PX"
+    return plugin
+
+
+def _library(*, key=1, title="Movies", library_type="movie"):
+    return SimpleNamespace(key=key, title=title, type=library_type)
+
+
+def _metadata(start, count):
+    return [{"ratingKey": str(index)} for index in range(start, start + count)]
+
+
+def _media_item(rating_key, *, needs_update=False, final=False):
+    title = f"标题{rating_key}"
+    return {
+        "ratingKey": str(rating_key),
+        "librarySectionID": 1,
+        "type": "movie",
+        "title": title,
+        "titleSort": "PX" if final or not needs_update else title,
+        "Field": [],
+        "Genre": [],
+        "Style": [],
+        "Mood": [],
+    }
+
+
+def test_list_rating_keys_pages_until_total_size():
+    """完整库应按 500 条分页直到 totalSize。"""
+    def handler(_endpoint, start):
+        count = 500 if start == 0 else 2
+        return {
+            "offset": start,
+            "totalSize": 502,
+            "Metadata": _metadata(start, count),
+        }
+
+    plugin = _plugin()
+    plex = _PagingPlex(handler)
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "complete"
+    assert len(keys) == 502
+    assert plex.starts == [0, 500]
+    assert all(call[2] == 500 for call in plex.calls)
+
+
+def test_list_rating_keys_without_total_size_stops_on_short_page():
+    """缺少 totalSize 时短页应作为结束条件。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, start: {
+        "offset": start,
+        "Metadata": _metadata(start, 2),
+    })
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "complete"
+    assert keys == ["0", "1"]
+    assert plex.starts == [0]
+
+
+def test_list_rating_keys_without_total_size_stops_on_empty_page():
+    """缺少 totalSize 时完整页后的空页应结束枚举。"""
+    def handler(_endpoint, start):
+        return {
+            "offset": start,
+            "Metadata": _metadata(0, 500) if start == 0 else [],
+        }
+
+    plugin = _plugin()
+    plex = _PagingPlex(handler)
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "complete"
+    assert len(keys) == 500
+    assert plex.starts == [0, 500]
+
+
+def test_list_rating_keys_with_total_size_continues_after_short_page():
+    """totalSize 尚未达到时，短页不能被误判为完整枚举。"""
+    def handler(_endpoint, start):
+        count = 400 if start == 0 else 200
+        return {
+            "offset": start,
+            "totalSize": 600,
+            "Metadata": _metadata(start, count),
+        }
+
+    plugin = _plugin()
+    plex = _PagingPlex(handler)
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "complete"
+    assert len(keys) == 600
+    assert plex.starts == [0, 400]
+
+
+def test_list_rating_keys_advances_by_raw_metadata_count():
+    """缺少 ratingKey 的条目仍占用 Plex 分页位置。"""
+    def handler(_endpoint, start):
+        if start == 0:
+            metadata = _metadata(0, 500)
+            metadata[10] = {"title": "missing key"}
+        else:
+            metadata = [{"ratingKey": "last"}]
+        return {
+            "offset": start,
+            "totalSize": 501,
+            "Metadata": metadata,
+        }
+
+    plugin = _plugin()
+    plex = _PagingPlex(handler)
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "complete"
+    assert len(keys) == 500
+    assert keys[-1] == "last"
+    assert plex.starts == [0, 500]
+
+
+def test_list_rating_keys_fails_when_total_size_has_unexpected_empty_page():
+    """totalSize 尚未达到却返回空页时，枚举结果不可信。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, start: {
+        "offset": start,
+        "totalSize": 600,
+        "Metadata": _metadata(0, 500) if start == 0 else [],
+    })
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+    assert plex.starts == [0, 500]
+
+
+def test_list_rating_keys_rejects_mismatched_response_offset():
+    """响应 offset 与请求不一致时不能继续产生不可信结果。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, _start: {
+        "offset": 7,
+        "totalSize": 1,
+        "Metadata": _metadata(0, 1),
+    })
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+
+
+def test_list_rating_keys_rejects_repeated_nonempty_page():
+    """Plex 忽略分页起点并重复首个完整页时应停止。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, start: {
+        "offset": start,
+        "Metadata": _metadata(0, 500),
+    })
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+    assert plex.starts == [0, 500]
+
+
+def test_list_rating_keys_returns_failed_when_second_page_fails():
+    """第二页失败时不得把首个页面当成完整媒体库。"""
+    def handler(_endpoint, start):
+        if start == 500:
+            return None
+        return {"offset": 0, "totalSize": 600, "Metadata": _metadata(0, 500)}
+
+    plugin = _plugin()
+    plex = _PagingPlex(handler)
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+
+
+def test_list_rating_keys_returns_failed_for_malformed_payload():
+    """状态码成功但响应体结构异常时应转为服务级失败。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, _start: {"Metadata": None})
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+
+
+def test_list_rating_keys_returns_failed_without_media_container():
+    """缺失 MediaContainer 不能被误判为空库。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, _start: _MissingContainerResponse())
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+
+
+def test_generate_keys_fetches_collections_once_for_artist_library():
+    """artist 的三个 type 不应重复请求同一个合集端点。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda endpoint, start: {
+        "offset": start,
+        "Metadata": [{"ratingKey": endpoint.split("type=")[-1]}]
+        if "type=" in endpoint else [{"ratingKey": "collection"}],
+    })
+
+    keys, status = plugin._PlexLocalization__generate_all_rating_keys(
+        plex=plex,
+        libraries={7: _library(key=7, title="Music", library_type="artist")},
+        with_collection=True,
+    )
+
+    collection_calls = [call for call in plex.calls if call[0].endswith("/collections")]
+    assert status == "complete"
+    assert keys == ["8", "9", "10", "collection"]
+    assert len(collection_calls) == 1
+
+
+def test_generate_keys_deduplicates_across_types_and_collections():
+    """同一 ratingKey 跨普通端点和合集出现时只处理一次。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda endpoint, start: {
+        "offset": start,
+        "Metadata": [{"ratingKey": "same"}, {"ratingKey": "unique"}]
+        if "type=" in endpoint else [{"ratingKey": "same"}],
+    })
+
+    keys, status = plugin._PlexLocalization__generate_all_rating_keys(
+        plex=plex,
+        libraries={1: _library()},
+        with_collection=True,
+    )
+
+    assert status == "complete"
+    assert keys == ["same", "unique"]
+
+
+def test_list_rating_keys_stops_before_request_when_event_is_set():
+    """主程序停止插件后不应发起新的分页请求。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, _start: {"Metadata": []})
+    plugin._event.set()
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert keys == []
+    assert status == "stopped"
+    assert plex.calls == []
+
+
+def test_batch_size_250_uses_100_100_50_detail_chunks():
+    """业务批次增大时 HTTP 详情读取仍应限制为 100 个 key。"""
+    source_items = {str(index): _media_item(index) for index in range(250)}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source_items)
+
+    result = plugin._PlexLocalization__process_items_batch(
+        plex=plex, rating_keys=list(source_items)
+    )
+
+    assert plex.detail_request_sizes == [100, 100, 50]
+    assert result == {"updated": 0, "failed": 0, "skipped": 250, "unprocessed": 0}
+
+
+def test_successful_puts_use_one_bulk_verification_get():
+    """同一子块中的成功 PUT 应合并回读。"""
+    source_items = {str(index): _media_item(index, needs_update=True) for index in range(3)}
+    final_items = {str(index): _media_item(index, needs_update=True, final=True) for index in range(3)}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source_items, final_items)
+
+    result = plugin._PlexLocalization__process_items_batch(
+        plex=plex, rating_keys=list(source_items)
+    )
+
+    assert len(plex.put_calls) == 3
+    assert plex.verify_request_sizes == [3]
+    assert result == {"updated": 3, "failed": 0, "skipped": 0, "unprocessed": 0}
+
+
+def test_201_successful_puts_use_100_100_1_verification_gets():
+    """跨多个子块的验证请求不得超过 100 个 key。"""
+    source_items = {str(index): _media_item(index, needs_update=True) for index in range(201)}
+    final_items = {
+        str(index): _media_item(index, needs_update=True, final=True)
+        for index in range(201)
+    }
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source_items, final_items)
+
+    result = plugin._PlexLocalization__process_items_batch(
+        plex=plex, rating_keys=list(source_items)
+    )
+
+    assert plex.verify_request_sizes == [100, 100, 1]
+    assert result["updated"] == 201
+
+
+def test_bulk_verification_marks_mismatched_item_failed():
+    """回读字段不一致的条目不能计为更新成功。"""
+    source = {"1": _media_item("1", needs_update=True)}
+    final = {"1": {**_media_item("1", needs_update=True, final=True), "titleSort": "wrong"}}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final)
+
+    result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1"])
+
+    assert result == {"updated": 0, "failed": 1, "skipped": 0, "unprocessed": 0}
+
+
+def test_bulk_verification_marks_missing_item_failed():
+    """Plex 批量回读缺失的条目应计失败。"""
+    source = {"1": _media_item("1", needs_update=True)}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final_items={})
+    plex.final_items = {}
+
+    result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1"])
+
+    assert result == {"updated": 0, "failed": 1, "skipped": 0, "unprocessed": 0}
+
+
+def test_bulk_verification_request_failure_marks_pending_items_failed():
+    """整次验证读取失败时所有待验证写入均应计失败。"""
+    source = {"1": _media_item("1", needs_update=True), "2": _media_item("2", needs_update=True)}
+    final = {key: _media_item(key, needs_update=True, final=True) for key in source}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final)
+    plex.fail_verification = True
+
+    result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1", "2"])
+
+    assert result == {"updated": 0, "failed": 2, "skipped": 0, "unprocessed": 0}
+
+
+def test_put_exception_only_fails_current_item():
+    """单条 PUT 异常不得覆盖同一子块内其他条目的结果。"""
+    source = {str(index): _media_item(index, needs_update=True) for index in range(1, 4)}
+    final = {
+        key: _media_item(key, needs_update=True, final=True)
+        for key in source
+    }
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final)
+    plex.raise_on_put_key = "2"
+
+    result = plugin._PlexLocalization__process_items_batch(
+        plex=plex, rating_keys=["1", "2", "3"]
+    )
+
+    assert plex.verify_request_sizes == [2]
+    assert result == {"updated": 2, "failed": 1, "skipped": 0, "unprocessed": 0}
+
+
+def test_verification_exception_only_fails_current_item():
+    """单条差异比较异常不得覆盖同一子块内其他条目的结果。"""
+    source = {str(index): _media_item(index, needs_update=True) for index in range(1, 4)}
+    final = {
+        key: _media_item(key, needs_update=True, final=True)
+        for key in source
+    }
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final)
+
+    def differences(item, expected_sort_title, expected_tags):
+        if item["ratingKey"] == "2":
+            raise RuntimeError("verification failed")
+        return []
+
+    with patch.object(
+        plugin,
+        "_PlexLocalization__metadata_differences",
+        side_effect=differences,
+    ):
+        result = plugin._PlexLocalization__process_items_batch(
+            plex=plex, rating_keys=["1", "2", "3"]
+        )
+
+    assert result == {"updated": 2, "failed": 1, "skipped": 0, "unprocessed": 0}
+
+
+def test_second_chunk_exception_keeps_first_chunk_results():
+    """后一子块异常不得覆盖前一子块已终结结果。"""
+    source_items = {str(index): _media_item(index) for index in range(150)}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source_items)
+    plex.raise_on_detail_call = 2
+
+    result = plugin._PlexLocalization__process_items_batch(
+        plex=plex, rating_keys=list(source_items)
+    )
+
+    assert result == {"updated": 0, "failed": 50, "skipped": 100, "unprocessed": 0}
+
+
+def test_stop_after_put_marks_unverified_write_failed():
+    """停止发生在 PUT 后时不得继续验证或误报成功。"""
+    source = {"1": _media_item("1", needs_update=True), "2": _media_item("2", needs_update=True)}
+    final = {key: _media_item(key, needs_update=True, final=True) for key in source}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final)
+    plex.on_first_put = plugin._event.set
+
+    result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1", "2"])
+
+    assert result == {"updated": 0, "failed": 1, "skipped": 0, "unprocessed": 1}
+    assert plex.verify_request_sizes == []
+
+
+def test_pending_futures_never_exceed_twice_thread_count():
+    """数万级条目不能让 Future 数随总批次数增长。"""
+    plugin = _edit_plugin()
+    plex = SimpleNamespace()
+    observed_pending = []
+    real_wait = concurrent.futures.wait
+
+    def recording_wait(futures, *args, **kwargs):
+        observed_pending.append(len(futures))
+        return real_wait(futures, *args, **kwargs)
+
+    def skip_batch(_plex, batch_keys):
+        return {
+            "updated": 0,
+            "failed": 0,
+            "skipped": len(batch_keys),
+            "unprocessed": 0,
+        }
+
+    with patch("plexlocalization.concurrent.futures.wait", side_effect=recording_wait), \
+            patch.object(plugin, "_PlexLocalization__process_items_batch", side_effect=skip_batch):
+        result = plugin._PlexLocalization__process_rating_keys_in_batches(
+            plex=plex,
+            rating_keys=[str(index) for index in range(10_000)],
+            thread_count=3,
+            batch_size=100,
+        )
+
+    assert observed_pending
+    assert max(observed_pending) <= 6
+    assert result == {"updated": 0, "failed": 0, "skipped": 10_000, "unprocessed": 0}
+
+
+def test_second_page_failure_skips_all_puts_and_continues_next_service():
+    """一个服务枚举失败不应写入，也不应阻止独立服务继续。"""
+    plugin = _edit_plugin()
+    plugin._batch_size = 100
+    plugin._notify = False
+    first_plex = SimpleNamespace(put_calls=[])
+    second_plex = SimpleNamespace(put_calls=[])
+    services = {
+        "first": SimpleNamespace(name="First Plex", instance=first_plex),
+        "second": SimpleNamespace(name="Second Plex", instance=second_plex),
+    }
+    library = _library()
+    completed = {"updated": 0, "failed": 0, "skipped": 1, "unprocessed": 0}
+
+    with patch.object(plugin, "service_info", side_effect=lambda name: services[name]), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__generate_all_rating_keys",
+                side_effect=[([], "failed"), (["1"], "complete")],
+            ), patch.object(
+                plugin,
+                "_PlexLocalization__process_rating_keys_in_batches",
+                return_value=completed,
+            ) as process_batches, patch("plexlocalization.logger.warning") as warning:
+        plugin._PlexLocalization__loop_all(
+            service_libraries={"first": {1: library}, "second": {1: library}},
+            thread_count=3,
+        )
+
+    assert first_plex.put_calls == []
+    assert process_batches.call_count == 1
+    assert process_batches.call_args.kwargs["plex"] is second_plex
+    assert any("枚举不完整" in str(call.args[0]) for call in warning.call_args_list)
+
+
+def test_malformed_page_skips_service_and_continues_next_service():
+    """单个服务解析失败不得终止后续独立 Plex 服务。"""
+    plugin = _edit_plugin()
+    plugin._batch_size = 100
+    plugin._notify = False
+    first_plex = _PagingPlex(lambda _endpoint, _start: _MalformedResponse())
+    second_plex = _PagingPlex(lambda endpoint, start: {
+        "offset": start,
+        "Metadata": [] if endpoint.endswith("/collections") else [{"ratingKey": "1"}],
+    })
+    services = {
+        "first": SimpleNamespace(name="First Plex", instance=first_plex),
+        "second": SimpleNamespace(name="Second Plex", instance=second_plex),
+    }
+    completed = {"updated": 0, "failed": 0, "skipped": 1, "unprocessed": 0}
+
+    with patch.object(plugin, "service_info", side_effect=lambda name: services[name]), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__process_rating_keys_in_batches",
+                return_value=completed,
+            ) as process_batches:
+        plugin._PlexLocalization__loop_all(
+            service_libraries={"first": {1: _library()}, "second": {1: _library()}},
+            thread_count=3,
+        )
+
+    assert process_batches.call_count == 1
+    assert process_batches.call_args.kwargs["plex"] is second_plex
+
+
+def test_loop_defaults_to_three_threads():
+    """内部调用未显式传线程数时也应使用新默认值。"""
+    plugin = _edit_plugin()
+    plugin._batch_size = 100
+    plugin._notify = False
+    plex = SimpleNamespace()
+    service = SimpleNamespace(name="Plex", instance=plex)
+    library = _library()
+
+    with patch.object(plugin, "service_info", return_value=service), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__generate_all_rating_keys",
+                return_value=(["1"], "complete"),
+            ), patch.object(
+                plugin,
+                "_PlexLocalization__process_rating_keys_in_batches",
+                return_value={"updated": 0, "failed": 0, "skipped": 1, "unprocessed": 0},
+            ) as process_batches:
+        plugin._PlexLocalization__loop_all(
+            service_libraries={"plex": {1: library}}, thread_count=None
+        )
+
+    assert process_batches.call_args.kwargs["thread_count"] == 3
+
+
+def test_loop_final_log_includes_service_and_discovered_counts():
+    """最终日志应能核对完整服务的发现数与四项处理统计。"""
+    plugin = _edit_plugin()
+    plugin._batch_size = 100
+    plugin._notify = False
+    services = {
+        "first": SimpleNamespace(name="First Plex", instance=SimpleNamespace()),
+        "second": SimpleNamespace(name="Second Plex", instance=SimpleNamespace()),
+    }
+
+    def process_batches(*, rating_keys, **_kwargs):
+        return {"updated": 0, "failed": 0, "skipped": len(rating_keys), "unprocessed": 0}
+
+    with patch.object(plugin, "service_info", side_effect=lambda name: services[name]), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__generate_all_rating_keys",
+                side_effect=[(["1", "2"], "complete"), (["3"], "complete")],
+            ), patch.object(
+                plugin,
+                "_PlexLocalization__process_rating_keys_in_batches",
+                side_effect=process_batches,
+            ), patch("plexlocalization.logger.info") as info:
+        plugin._PlexLocalization__loop_all(
+            service_libraries={"first": {1: _library()}, "second": {1: _library()}},
+            thread_count=3,
+        )
+
+    final_log = str(info.call_args_list[-1].args[0])
+    assert "完整服务 2" in final_log
+    assert "发现 3" in final_log
+    assert "跳过 3" in final_log
+
+
+def test_stopped_log_preserves_previous_failed_service_count():
+    """先失败后停止时，最终日志仍应保留失败服务数。"""
+    plugin = _edit_plugin()
+    plugin._batch_size = 100
+    plugin._notify = False
+    services = {
+        "first": SimpleNamespace(name="First Plex", instance=SimpleNamespace()),
+        "second": SimpleNamespace(name="Second Plex", instance=SimpleNamespace()),
+    }
+
+    with patch.object(plugin, "service_info", side_effect=lambda name: services[name]), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__generate_all_rating_keys",
+                side_effect=[([], "failed"), ([], "stopped")],
+            ), patch("plexlocalization.logger.warning") as warning:
+        plugin._PlexLocalization__loop_all(
+            service_libraries={"first": {1: _library()}, "second": {1: _library()}},
+            thread_count=3,
+        )
+
+    final_log = str(warning.call_args_list[-1].args[0])
+    assert "失败服务 1" in final_log
+
+
+def test_stop_cancels_pending_batches_and_counts_unprocessed():
+    """停止后未运行的批次必须进入未处理统计。"""
+    plugin = _edit_plugin()
+    plex = SimpleNamespace()
+    total_keys = 1_000
+
+    def stop_after_first_batch(_plex, batch_keys):
+        plugin._event.set()
+        return {
+            "updated": 0,
+            "failed": 0,
+            "skipped": len(batch_keys),
+            "unprocessed": 0,
+        }
+
+    with patch.object(
+        plugin,
+        "_PlexLocalization__process_items_batch",
+        side_effect=stop_after_first_batch,
+    ):
+        result = plugin._PlexLocalization__process_rating_keys_in_batches(
+            plex=plex,
+            rating_keys=[str(index) for index in range(total_keys)],
+            thread_count=3,
+            batch_size=100,
+        )
+
+    assert sum(result.values()) == total_keys
+    assert result["unprocessed"] > 0
+
+
+def test_processing_http_concurrency_respects_configured_thread_count():
+    """实际详情请求并发应由用户线程配置控制。"""
+    for thread_count in (3, 2):
+        plugin = _edit_plugin()
+        plex = _ConcurrentPlex(worker_count=thread_count)
+        item_count = thread_count * 100
+
+        result = plugin._PlexLocalization__process_rating_keys_in_batches(
+            plex=plex,
+            rating_keys=[str(index) for index in range(item_count)],
+            thread_count=thread_count,
+            batch_size=100,
+        )
+
+        assert plex.max_active_requests == thread_count
+        assert result["skipped"] == item_count

--- a/tests/v2/plexlocalization/test_metadata_edits.py
+++ b/tests/v2/plexlocalization/test_metadata_edits.py
@@ -1,0 +1,348 @@
+"""Plex 中文本地化元数据原子编辑测试。"""
+
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from app.testing import stub_modules
+
+
+_pypinyin = ModuleType("pypinyin")
+_pypinyin.Style = SimpleNamespace(FIRST_LETTER="first_letter")
+_pypinyin.lazy_pinyin = lambda *args, **kwargs: []
+
+with stub_modules({"pypinyin": _pypinyin}):
+    from plexlocalization import PlexLocalization
+
+
+class _Response:
+    """提供插件 HTTP 调用所需的最小响应契约。"""
+
+    def __init__(self, *, status_code=200, metadata=None):
+        self.status_code = status_code
+        self._metadata = metadata or []
+
+    def json(self):
+        """返回 Plex JSON API 的元数据包装结构。"""
+        return {"MediaContainer": {"Metadata": self._metadata}}
+
+    def __bool__(self):
+        """模拟 requests.Response 对错误状态码的布尔语义。"""
+        return self.status_code < 400
+
+
+class _FakePlex:
+    """记录 Plex 写入请求，并为最终回读提供指定元数据。"""
+
+    def __init__(self, final_item, status_code=200):
+        self.final_item = final_item
+        self.status_code = status_code
+        self.put_calls = []
+        self.get_calls = []
+
+    def put_data(self, *, endpoint, params, timeout):
+        """记录一次元数据编辑请求。"""
+        self.put_calls.append({"endpoint": endpoint, "params": params, "timeout": timeout})
+        return _Response(status_code=self.status_code)
+
+    def get_data(self, *, endpoint, timeout):
+        """返回写入完成后的条目状态。"""
+        self.get_calls.append({"endpoint": endpoint, "timeout": timeout})
+        return _Response(metadata=[self.final_item])
+
+
+def _plugin(sort_title="TSXK"):
+    plugin = object.__new__(PlexLocalization)
+    plugin._lock = False
+    plugin._timeout = 10
+    plugin._tags = {
+        "Action": "动作",
+        "Adventure": "冒险",
+        "Sci-Fi & Fantasy": "科幻与奇幻",
+    }
+    plugin._PlexLocalization__convert_to_pinyin = lambda title: sort_title
+    return plugin
+
+
+def _source_item():
+    return {
+        "ratingKey": "98824",
+        "librarySectionID": 42,
+        "type": "show",
+        "title": "吞噬星空",
+        "titleSort": "吞噬星空",
+        "Field": [],
+        "Genre": [
+            {"tag": "Action"},
+            {"tag": "Adventure"},
+            {"tag": "Sci-Fi & Fantasy"},
+            {"tag": "Unmapped"},
+        ],
+        "Style": [],
+        "Mood": [],
+    }
+
+
+def _final_item(title_sort="TSXK"):
+    return {
+        **_source_item(),
+        "titleSort": title_sort,
+        "Genre": [
+            {"tag": "动作"},
+            {"tag": "冒险"},
+            {"tag": "科幻与奇幻"},
+            {"tag": "Unmapped"},
+        ],
+    }
+
+
+def test_process_item_submits_sort_title_and_all_tags_in_one_request():
+    """同一条目的排序标题与标签应通过一次 PUT 原子提交。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item())
+
+    result = plugin._PlexLocalization__process_item(plex=plex, item=_source_item())
+
+    assert result is True
+    assert len(plex.put_calls) == 1
+    assert len(plex.get_calls) == 1
+    call = plex.put_calls[0]
+    assert call["endpoint"] == "/library/sections/42/all"
+    assert call["params"] == {
+        "type": 2,
+        "id": "98824",
+        "includeExternalMedia": 1,
+        "titleSort.value": "TSXK",
+        "titleSort.locked": 0,
+        "genre.locked": 0,
+        "genre[0].tag.tag": "动作",
+        "genre[1].tag.tag": "冒险",
+        "genre[2].tag.tag": "科幻与奇幻",
+        "genre[3].tag.tag": "Unmapped",
+        "genre[].tag.tag-": "Action,Adventure,Sci-Fi%20%26%20Fantasy",
+    }
+
+
+def test_process_item_reports_failure_when_final_sort_title_differs():
+    """最终回读不一致时不得把中间写入状态记录为成功。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item(title_sort=None))
+
+    with patch("plexlocalization.logger.info") as info, patch("plexlocalization.logger.warning") as warning:
+        result = plugin._PlexLocalization__process_item(plex=plex, item=_source_item())
+
+    assert result is False
+    assert len(plex.put_calls) == 1
+    assert len(plex.get_calls) == 1
+    assert any("更新元数据未完全生效" in str(call.args[0]) for call in warning.call_args_list)
+    assert not any("吞噬星空 < TSXK >" in str(call.args[0]) for call in info.call_args_list)
+
+
+def test_process_item_treats_null_sort_title_as_unset():
+    """Plex 返回 null 排序标题时仍应生成并写入拼音。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item())
+    item = {
+        **_source_item(),
+        "titleSort": None,
+        "Genre": [],
+    }
+
+    result = plugin._PlexLocalization__process_item(plex=plex, item=item)
+
+    assert result is True
+    assert len(plex.put_calls) == 1
+    assert plex.put_calls[0]["params"]["titleSort.value"] == "TSXK"
+
+
+def test_process_item_skips_write_when_relevant_fields_are_locked():
+    """排序标题和标签均已锁定时不应发送编辑请求。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item())
+    item = {
+        **_source_item(),
+        "Field": [
+            {"name": "titleSort", "locked": True},
+            {"name": "genre", "locked": True},
+        ],
+    }
+
+    result = plugin._PlexLocalization__process_item(plex=plex, item=item)
+
+    assert result is None
+    assert plex.put_calls == []
+    assert plex.get_calls == []
+
+
+def test_process_item_preserves_existing_sort_title_during_tag_only_update():
+    """仅更新标签时应携带并校验已有的未锁定排序标题。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item())
+    item = {
+        **_source_item(),
+        "titleSort": "TSXK",
+    }
+
+    result = plugin._PlexLocalization__process_item(plex=plex, item=item)
+
+    assert result is True
+    assert plex.put_calls[0]["params"]["titleSort.value"] == "TSXK"
+    assert plex.put_calls[0]["params"]["titleSort.locked"] == 0
+
+
+def test_process_item_skips_redundant_sort_title_equal_to_title():
+    """生成排序与原标题一致时无需写入 Plex。"""
+    plugin = _plugin(sort_title="2012")
+    plex = _FakePlex(final_item={})
+    item = {
+        **_source_item(),
+        "title": "2012",
+        "titleSort": None,
+        "Genre": [],
+    }
+
+    result = plugin._PlexLocalization__process_item(plex=plex, item=item)
+
+    assert result is None
+    assert plex.put_calls == []
+    assert plex.get_calls == []
+
+
+def test_process_item_logs_noop_skip_at_debug_level():
+    """无需更新的有效条目应在 debug 日志中标明标题和 ratingKey。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item={})
+    item = {
+        **_source_item(),
+        "titleSort": "TSXK",
+        "Genre": [{"tag": "动画"}],
+    }
+
+    with patch("plexlocalization.logger.debug") as debug:
+        result = plugin._PlexLocalization__process_item(plex=plex, item=item)
+
+    assert result is None
+    assert plex.put_calls == []
+    assert any(
+        "吞噬星空（ratingKey=98824）无需更新，跳过" in str(call.args[0])
+        for call in debug.call_args_list
+    )
+
+
+def test_process_item_logs_http_error_status_code():
+    """Plex 返回错误响应时日志应保留真实 HTTP 状态码。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item(), status_code=500)
+
+    with patch("plexlocalization.logger.warning") as warning:
+        result = plugin._PlexLocalization__process_item(plex=plex, item=_source_item())
+
+    assert result is False
+    assert plex.get_calls == []
+    assert any("状态码：500" in str(call.args[0]) for call in warning.call_args_list)
+
+
+def test_positive_int_config_falls_back_only_for_invalid_values():
+    """线程数与批大小保持可配置，但零、负数和非法值应回退默认值。"""
+    parse = PlexLocalization._PlexLocalization__positive_int
+
+    assert parse("8", default=5) == 8
+    assert parse(0, default=5) == 5
+    assert parse(-2, default=100) == 100
+    assert parse(None, default=5) == 5
+    assert parse("invalid", default=100) == 100
+
+
+def test_positive_int_config_supports_new_thread_default():
+    """线程配置缺失时应使用新的安全默认值。"""
+    parse = PlexLocalization._PlexLocalization__positive_int
+
+    assert parse(None, default=3) == 3
+    assert parse("8", default=3) == 8
+
+
+def test_form_defaults_to_three_threads():
+    """表单默认线程数应限制 Plex 的初始并发压力。"""
+    plugin = object.__new__(PlexLocalization)
+
+    with patch.object(plugin, "_PlexLocalization__get_service_library_options", return_value=[]):
+        _, defaults = plugin.get_form()
+
+    assert defaults["thread_count"] == 3
+
+
+def test_init_plugin_defaults_thread_count_to_three():
+    """缺省配置初始化时应实际写入三线程默认值。"""
+    plugin = object.__new__(PlexLocalization)
+    plugin._scheduler = None
+
+    with patch("plexlocalization.MediaServerHelper"), \
+            patch.object(plugin, "_PlexLocalization__get_tags", return_value={"Action": "动作"}), \
+            patch.object(plugin, "stop_service"), \
+            patch("plexlocalization.BackgroundScheduler"), \
+            patch.object(plugin, "update_config"):
+        plugin.init_plugin({"tags_json": "{}"})
+
+    assert plugin._thread_count == 3
+
+
+def test_stop_service_sets_event_without_private_scheduler():
+    """主程序停止插件时不应依赖入库任务的私有 scheduler。"""
+    plugin = _plugin()
+    plugin._scheduler = None
+    plugin._event.clear()
+
+    plugin.stop_service()
+
+    assert plugin._event.is_set()
+
+
+def test_process_items_batch_aggregates_chunk_outcomes():
+    """业务批次应合并多个 HTTP 子块的四项结果。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item={})
+    rating_keys = [str(index) for index in range(150)]
+    with patch.object(
+        plugin,
+        "_PlexLocalization__process_items_chunk",
+        side_effect=[
+            {"updated": 10, "failed": 20, "skipped": 70, "unprocessed": 0},
+            {"updated": 5, "failed": 5, "skipped": 30, "unprocessed": 10},
+        ],
+    ):
+        result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=rating_keys)
+
+    assert result == {"updated": 15, "failed": 25, "skipped": 100, "unprocessed": 10}
+
+
+def test_process_items_batch_isolates_item_exceptions():
+    """单条异常应计为失败并继续处理同批后续条目。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item={})
+    items = [{"ratingKey": "1"}, {"ratingKey": "2"}, {"ratingKey": "3"}]
+
+    with patch.object(plugin, "_PlexLocalization__fetch_all_items", return_value=items), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__prepare_item_edit",
+                side_effect=[None, RuntimeError("broken item"), None]
+            ) as prepare_item, patch("plexlocalization.logger.error") as error:
+        result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1", "2", "3"])
+
+    assert result == {"updated": 0, "failed": 1, "skipped": 2, "unprocessed": 0}
+    assert prepare_item.call_count == 3
+    assert any("ratingKey=2" in str(call.args[0]) for call in error.call_args_list)
+
+
+def test_process_items_batch_counts_missing_response_items_as_failed():
+    """批量读取缺失的请求条目应进入失败统计并保留其余结果。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item={})
+    items = [{"ratingKey": "1"}, {"ratingKey": "3"}]
+
+    with patch.object(plugin, "_PlexLocalization__fetch_all_items", return_value=items), \
+            patch.object(plugin, "_PlexLocalization__prepare_item_edit", return_value=None), \
+            patch("plexlocalization.logger.warning") as warning:
+        result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1", "2", "3"])
+
+    assert result == {"updated": 0, "failed": 1, "skipped": 2, "unprocessed": 0}
+    assert any("ratingKey=2" in str(call.args[0]) for call in warning.call_args_list)


### PR DESCRIPTION
## 变更说明

- 重构全量扫描流程，分页枚举媒体条目并限制待处理批次数量，降低大媒体库运行时开销。
- 合并同一媒体的排序标题与标签写入，通过 Plex API 批量回读确认最终状态。
- 完善停止、分页异常、服务隔离和处理统计，避免枚举不完整时写入元数据。
- 新增 Plex 中文本地化插件单元测试。

## 版本事实

- `PlexLocalization.plugin_version`：`2.0`
- `package.v2.json`：`2.0`
- 更新 `v2.0` 版本说明。

## 验证

- 插件聚焦测试：48 passed
- 插件仓 CI 测试：33 passed
- 插件仓 v2 全量测试：2170 passed
- 版本门禁、JSON 解析、Python 编译和差异检查通过
- 完成一次真实 Plex 全量扫描及 API 回读验证

Fixes #327

本 PR 为 Codex 协作提交
