### PR TITLE
chore(subscribeassistantenhanced): add frontend watch workflow

### DIFF
--- a/plugins.v2/subscribeassistantenhanced/docs/architecture.md
+++ b/plugins.v2/subscribeassistantenhanced/docs/architecture.md
@@ -57,6 +57,8 @@ flowchart TD
 
 前端在 `frontend/` 目录执行 `yarn build`，构建会清空并重建 `frontend/dist/`。Python `get_form()` 继续提供初始配置模型，Vue 草稿按同一稳定配置键生成完整保存 payload，最终仍由主程序插件配置接口持久化并触发插件重新初始化。
 
+本地开发可改用 `yarn dev` 持续构建。通过 `PLUGIN_LOCAL_REPO_PATHS` 开发插件并启用 `DEV` 或 `PLUGIN_AUTO_RELOAD` 时，MoviePilot 会同步新的构建产物；刷新页面即可查看修改。
+
 ## 入口层
 
 入口层包含：

--- a/plugins.v2/subscribeassistantenhanced/frontend/package.json
+++ b/plugins.v2/subscribeassistantenhanced/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
+    "dev": "vite build --watch",
     "test": "vitest run --root ../../.. ../../../tests/v2/subscribeassistantenhanced/frontend",
     "typecheck": "vue-tsc --noEmit"
   },

--- a/tests/v2/subscribeassistantenhanced/test_vue_config_contract.py
+++ b/tests/v2/subscribeassistantenhanced/test_vue_config_contract.py
@@ -19,6 +19,7 @@ from subscribeassistantenhanced.shared.config import PluginConfig
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 README_PATH = REPO_ROOT / "plugins.v2/subscribeassistantenhanced/README.md"
+FRONTEND_PACKAGE_PATH = REPO_ROOT / "plugins.v2/subscribeassistantenhanced/frontend/package.json"
 DEFAULTS_PATH = REPO_ROOT / "plugins.v2/subscribeassistantenhanced/frontend/src/config/defaults.ts"
 FIELDS_PATH = REPO_ROOT / "plugins.v2/subscribeassistantenhanced/frontend/src/config/fields.ts"
 
@@ -169,6 +170,12 @@ def test_render_mode_uses_vue_assets():
     plugin = SubscribeAssistantEnhanced()
 
     assert plugin.get_render_mode() == ("vue", "frontend/dist/assets")
+
+
+def test_frontend_package_exposes_watch_build_script():
+    package = json.loads(FRONTEND_PACKAGE_PATH.read_text(encoding="utf-8"))
+
+    assert package.get("scripts", {}).get("dev") == "vite build --watch"
 
 
 def test_summary_api_uses_bear_auth_and_coarse_payload_shape():


### PR DESCRIPTION
## 变更说明

- 为订阅助手增强版前端增加 `yarn dev` 监听构建命令。
- 在架构文档中补充本地插件仓的前端构建与同步方式。
- 增加脚本契约测试，防止开发命令意外回退。

## 影响路径

- `plugins.v2/subscribeassistantenhanced/frontend/package.json`
- `plugins.v2/subscribeassistantenhanced/docs/architecture.md`
- `tests/v2/subscribeassistantenhanced/test_vue_config_contract.py`

## 验证

- 插件仓全量测试：2149 passed
- SAE 前端测试：59 passed
- SAE 前端 typecheck、build、watch 构建和生成 JavaScript 语法检查通过
- `Plugin release gate`
- `git diff --check`

## 交付范围

本 PR 为 PR-only，不包含版本升级、tag 或 GitHub Release。

本 PR 为 Codex 协作提交
