### PR TITLE
perf(subscribeassistantenhanced): defer site snapshot reads

### DIFF
--- a/plugins.v2/subscribeassistantenhanced/engine/site.py
+++ b/plugins.v2/subscribeassistantenhanced/engine/site.py
@@ -329,7 +329,6 @@ class SiteEpisodesRefreshHandler:
             return
         current_total = data.current_total_episode or 0
         live_total = _safe_int(getattr(subscribe, "total_episode", None)) or 0
-        evidence = self._store.read_snapshot(subscribe)
 
         if applied:
             applied_total = _safe_int(applied.applied_total) or 0
@@ -340,6 +339,7 @@ class SiteEpisodesRefreshHandler:
             if _has_high_confidence_tmdb_completion(data.mediainfo, subscribe, as_of=_as_date(now)):
                 self._store.clear_lease(subscribe)
                 return
+            evidence = self._store.read_snapshot(subscribe)
             if evidence and not evidence.is_expired(now):
                 site_total = evidence.site_candidate_total or 0
                 if evidence.kind == "site_total_ahead" and site_total > applied_total:
@@ -364,6 +364,7 @@ class SiteEpisodesRefreshHandler:
             self._apply_total(data, applied_total, applied.applied_reason)
             return
 
+        evidence = self._store.read_snapshot(subscribe)
         if not evidence:
             return
         if evidence.is_expired(now):


### PR DESCRIPTION
## 变更说明

- 当主程序事件集数已追平租约目标时，在读取站点证据快照前释放租约并返回。
- 当事件携带高置信 TMDB 完结信号时，同样先结束租约，不再读取无用快照。
- 其他租约建立、续用、消费判断和超时语义保持不变。

## 影响范围

- `plugins.v2/subscribeassistantenhanced/engine/site.py`

## 验证

- `tests/run.py -q`：CI 测试 33 passed，v2 全量 2162 passed
- `scripts/plugin_coverage.py --base-ref origin/main`：changed-line 2/2，100%
- `python -m compileall -q plugins.v2/subscribeassistantenhanced`
- `.githooks/pre-push`
- `git diff --check`

## 交付范围

本 PR 为 PR-only 维护，不包含版本升级、tag 或 GitHub Release。

关联主程序 PR：https://github.com/jxxghp/MoviePilot/pull/6102

本 PR 为 Codex 协作提交
