### PR TITLE
test: strengthen plugin runtime isolation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -13,9 +13,5 @@ markers =
 # 仅忽略主程序依赖链或三方库在 Python 3.12 下的已知弃用告警；插件仓自身告警应直接修复
 filterwarnings =
     ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning
-    ignore:websockets.legacy is deprecated:DeprecationWarning
-    ignore:websockets.InvalidStatusCode is deprecated:DeprecationWarning
-    ignore:pkg_resources is deprecated as an API:DeprecationWarning
-    ignore:Deprecated call to .pkg_resources.declare_namespace:DeprecationWarning
     ignore:'crypt' is deprecated:DeprecationWarning
     ignore:'audioop' is deprecated:DeprecationWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 # 相对导入本仓薄壳，先定位同级 MoviePilot 后端并加入 ``sys.path``，再复用主程序共享引导。
@@ -43,3 +44,30 @@ def pytest_configure(config) -> None:
         prepare_v2_backend()
     else:
         prepare_v1_backend()
+
+
+def _report_session_cleanup_error(session, name: str, err: Exception) -> None:
+    """记录收尾错误；原测试绿色时将会话标记为失败。"""
+    sys.stderr.write(f"\npytest session cleanup failed: {name}: {err!r}\n")
+    if session.exitstatus == 0:
+        session.exitstatus = 1
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:
+    """释放测试过程中创建的消息队列与日志后台线程"""
+    if _selected_generation(session.config) == "ci":
+        return
+
+    try:
+        from app.helper.message import stop_message
+
+        stop_message()
+    except Exception as err:
+        _report_session_cleanup_error(session, "message service", err)
+
+    try:
+        from app.log import LoggerManager
+
+        LoggerManager.shutdown()
+    except Exception as err:
+        _report_session_cleanup_error(session, "logger manager", err)

--- a/tests/v2/subscribeassistantenhanced/test_plugin_integration.py
+++ b/tests/v2/subscribeassistantenhanced/test_plugin_integration.py
@@ -1123,6 +1123,7 @@ def test_run_meta_check_keeps_airing_gap_when_current_check_is_inconclusive():
         first_air_date=None,
     ))
     plugin._tmdb_episodes = MagicMock(return_value=[])
+    plugin._tmdb_chain.tmdb_episodes = MagicMock(return_value=[])
 
     pause_manager = plugin._modules["pause_manager"]
     next_air_date = (date.today() + timedelta(days=7)).isoformat()
@@ -1987,6 +1988,7 @@ def test_external_plugin_data_reset_restores_p_but_keeps_s_untouched():
     plugin._task_manager._save = plugin.save_data
     plugin._subscribe_oper = MagicMock()
     plugin._subscribe_oper.list.side_effect = lambda **kwargs: [pending] if kwargs.get("state") == "P" else [paused]
+    plugin._recognize_mediainfo = MagicMock(return_value=None)
     plugin._modules["pending_state"]._subscribe_oper = plugin._subscribe_oper
 
     plugin.run_pending_state_reconcile()


### PR DESCRIPTION
## 变更说明

- 为插件测试会话增加消息服务与 Logger 清理，避免 pytest 退出时遗留后台线程。
- 清理四条当前测试不再产生的 warning 过滤规则，保留三条精确的第三方弃用过滤。
- 补齐 SubscribeAssistantEnhanced 两条测试路径的外部媒体信息 mock，确保全量测试零真实出站。

## 影响范围

- `tests/conftest.py`、`pytest.ini`：共享测试脚手架与 warning 策略。
- `tests/v2/subscribeassistantenhanced/test_plugin_integration.py`：测试外部依赖隔离。

## 联动说明

- 主程序资源清理语义同步见 https://github.com/jxxghp/MoviePilot/pull/6116 。
- 本 PR 为 PR-only 测试维护，不包含插件版本升级、tag 或 GitHub Release。

## 验证

- `tests/run.py -q`：33 个 CI 测试及 2163 个 v2 测试通过。
- 插件版本门禁通过。
- `git diff --check`：通过。

本 PR 为 Codex 协作提交
