### PR TITLE
fix(SmartRename): 修正默认替换规则的转义告警

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -327,11 +327,12 @@
         "name": "智能重命名",
         "description": "自定义适配多场景重命名。",
         "labels": "刮削",
-        "version": "1.5",
+        "version": "1.5.1",
         "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/smartrename.png",
         "author": "InfinityPacer",
         "level": 1,
         "history": {
+            "v1.5.1": "修正默认词替换规则在新版 Python 中触发的转义告警",
             "v1.5": "支持与其它重命名插件链式协作，词替换可叠加在上游已渲染结果上",
             "v1.4": "支持根据TMDB或二级分类自定义重命名模板规则",
             "v1.3": "支持自定义替换词及修改自定义占位符分隔符",

--- a/plugins.v2/smartrename/__init__.py
+++ b/plugins.v2/smartrename/__init__.py
@@ -24,7 +24,7 @@ class SmartRename(_PluginBase):
     # 插件图标
     plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/smartrename.png"
     # 插件版本
-    plugin_version = "1.5"
+    plugin_version = "1.5.1"
     # 插件作者
     plugin_author = "InfinityPacer"
     # 作者主页
@@ -319,7 +319,7 @@ class SmartRename(_PluginBase):
             "separator_types": ["audioCodec", "videoCodec", "videoFormat", "edition", "effect",
                                 "resourceType"],
             "custom_separator": "@",
-            "word_replacements": """(?i)(?<=[\W_])BluRay.REMUX(?=[\W_]) => REMUX
+            "word_replacements": r"""(?i)(?<=[\W_])BluRay.REMUX(?=[\W_]) => REMUX
 (?i)(?<=[\W_])HDR.DV(?=[\W_]) => DoVi.HDR
 (?i)(?<=[\W_])DV(?=[\W_]) => DoVi
 (?i)(?<=[\W_])H264(?=[\W_]) => x264


### PR DESCRIPTION
SmartRename 的默认词替换配置使用普通多行字符串，在新版 Python 中会因 `\W`、`\.` 触发 `SyntaxWarning`。

将默认配置改为原始字符串，保持传入正则引擎的运行时内容和现有替换行为不变；同步发布版本 `1.5.1` 及插件市场更新记录。

验证：

- 严格模式编译通过（将 `SyntaxWarning` 视为错误）
- AST 对比确认修改前后的默认规则字符串一致
- 插件版本门禁通过
- 插件仓全量测试通过：`46 passed, 1 skipped`、`1376 passed`、`81 passed`
