### PR TITLE
fix(plexpersonmeta): 适配 Python 3.14t 文本转换

### DIFF
--- a/package.v3.json
+++ b/package.v3.json
@@ -45,13 +45,13 @@
         "name": "Plex演职人员刮削",
         "description": "实现刮削演职人员中文名称及角色。",
         "labels": "Plex,刮削",
-        "version": "2.5",
+        "version": "2.6",
         "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/plexpersonmeta.png",
         "author": "InfinityPacer",
         "level": 1,
         "system_version": ">=3.0.0",
         "history": {
-            "v2.5": "适配 V3 SDK 导入规范，迁移至 app.sdk 体系"
+            "v2.6": "中文转换改用 MoviePilot 文本 SDK，兼容 Python 3.14t。"
         },
         "release": true
     },

--- a/plugins.v3/plexpersonmeta/__init__.py
+++ b/plugins.v3/plexpersonmeta/__init__.py
@@ -29,7 +29,7 @@ class PlexPersonMeta(_PluginBase):
     # 插件图标
     plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/plexpersonmeta.png"
     # 插件版本
-    plugin_version = "2.5"
+    plugin_version = "2.6"
     # 插件作者
     plugin_author = "InfinityPacer"
     # 作者主页

--- a/plugins.v3/plexpersonmeta/scrape.py
+++ b/plugins.v3/plexpersonmeta/scrape.py
@@ -8,13 +8,12 @@ import plexapi
 import plexapi.utils
 import pypinyin
 from plexapi.library import LibrarySection
-from zhconv_rs import zhconv as zhconv_convert
 
 from app.chain.mediaserver import MediaServerChain
 from app.chain.tmdb import TmdbChain
 from app.sdk.logging import logger
 from app.sdk.media import MediaInfo
-from app.sdk.utilities import StringUtils
+from app.sdk.utilities import StringUtils, convert
 from app.plugins import PluginChian
 from .helper import RatingInfo, cache_backend, cache_with_logging
 from app.schemas import MediaPerson, ServiceInfo
@@ -660,7 +659,7 @@ class ScrapeHelper:
             if also_known_as:
                 for name in also_known_as:
                     if name and StringUtils.is_chinese(name):
-                        return zhconv_convert(name, "zh-hans")
+                        return convert(name, "zh-hans")
         except Exception as err:
             logger.error(f"获取人物中文名失败：{err}")
         return None

--- a/tests/v3/plexpersonmeta/test_v3_migration.py
+++ b/tests/v3/plexpersonmeta/test_v3_migration.py
@@ -5,6 +5,7 @@ from types import ModuleType
 from unittest.mock import MagicMock
 
 from app.schemas.types import MediaSource, MediaType
+from app.sdk.utilities import convert
 from app.testing import stub_modules
 
 
@@ -31,6 +32,11 @@ def test_v3_plugin_uses_stable_sdk_imports():
     assert _plugin.get_command() == []
     assert plugin.get_api() == []
     assert plugin.get_page() == []
+
+
+def test_text_conversion_uses_host_sdk():
+    """人物别名转换应由宿主 SDK 选择兼容当前解释器的实现。"""
+    assert _scrape.convert is convert
 
 
 def test_tmdb_media_uses_unified_source_identity():


### PR DESCRIPTION
## 背景

PlexPersonMeta 直接依赖 `zhconv_rs`，在不安装该扩展的 Python 3.14t 环境中会导入失败。

## 调整

- 中文转换改用 `app.sdk.utilities.convert`，由 MoviePilot 宿主统一提供兼容实现。
- 插件版本升级至 2.6，并同步插件索引发布记录。

## 验证

- PlexPersonMeta focused tests：13 passed。
- 插件版本一致性、JSON、Python 编译和 diff 检查通过。
