### PR TITLE
ci: 增加 V3 插件依赖真实安装门禁

### DIFF
--- a/.github/workflows/plugin-gate.yml
+++ b/.github/workflows/plugin-gate.yml
@@ -94,6 +94,8 @@ jobs:
           cache-dependency-glob: plugins.v3/*/pyproject.toml
 
       - name: Install V3 plugin dependencies
+        env:
+          PYTHONUTF8: '1'
         run: uv run --no-project --python 3.14 python scripts/check_v3_dependency_install.py --python 3.14
 
   plugin-coverage-gate:

--- a/.github/workflows/plugin-gate.yml
+++ b/.github/workflows/plugin-gate.yml
@@ -63,6 +63,39 @@ jobs:
         working-directory: MoviePilot-Plugins
         run: ../MoviePilot/.venv/bin/python tests/run.py
 
+  plugin-dependency-install-gate:
+    name: V3 dependency install (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            os: ubuntu-latest
+          - name: Linux arm64
+            os: ubuntu-24.04-arm
+          - name: Windows x64
+            os: windows-latest
+          - name: macOS Intel
+            os: macos-15-intel
+          - name: macOS arm64
+            os: macos-15
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout plugin repository
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: '0.12.5'
+          python-version: '3.14'
+          enable-cache: true
+          cache-dependency-glob: plugins.v3/*/pyproject.toml
+
+      - name: Install V3 plugin dependencies
+        run: uv run --no-project --python 3.14 python scripts/check_v3_dependency_install.py --python 3.14
+
   plugin-coverage-gate:
     name: Plugin coverage gate
     runs-on: ubuntu-latest

--- a/scripts/check_v3_dependency_install.py
+++ b/scripts/check_v3_dependency_install.py
@@ -1,0 +1,109 @@
+"""在隔离环境中真实安装每份 V3 插件依赖清单。"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+V3_ROOT = REPO_ROOT / "plugins.v3"
+
+
+def discover_manifests(root: Path = V3_ROOT) -> list[Path]:
+    """返回仓库中全部 V3 modern manifest。"""
+    return sorted(root.glob("*/pyproject.toml"))
+
+
+def venv_python(environment: Path, *, windows: bool | None = None) -> Path:
+    """返回目标虚拟环境的解释器路径。"""
+    is_windows = os.name == "nt" if windows is None else windows
+    if is_windows:
+        return environment / "Scripts" / "python.exe"
+    return environment / "bin" / "python"
+
+
+def installation_commands(
+    *,
+    uv_bin: str,
+    python_spec: str,
+    environment: Path,
+    manifest: Path,
+    windows: bool | None = None,
+) -> tuple[list[str], list[str], list[str]]:
+    """构造与宿主插件安装语义一致的隔离安装和健康检查命令。"""
+    python_bin = venv_python(environment, windows=windows)
+    return (
+        [uv_bin, "venv", "--python", python_spec, str(environment)],
+        [
+            uv_bin,
+            "pip",
+            "install",
+            "--python",
+            str(python_bin),
+            "-r",
+            str(manifest),
+        ],
+        [uv_bin, "pip", "check", "--python", str(python_bin)],
+    )
+
+
+def verify_manifest(*, uv_bin: str, python_spec: str, manifest: Path) -> None:
+    """在一次性虚拟环境中安装并检查指定清单。"""
+    prefix = f"moviepilot-{manifest.parent.name}-"
+    with tempfile.TemporaryDirectory(prefix=prefix) as temp_dir:
+        environment = Path(temp_dir) / ".venv"
+        for command in installation_commands(
+            uv_bin=uv_bin,
+            python_spec=python_spec,
+            environment=environment,
+            manifest=manifest,
+        ):
+            subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+def parse_args() -> argparse.Namespace:
+    """解析命令行参数。"""
+    parser = argparse.ArgumentParser(
+        description="Install every V3 plugin manifest in an isolated environment.",
+    )
+    parser.add_argument("--python", default="3.14", help="目标 Python 解释器")
+    parser.add_argument("--uv", default="uv", help="uv 可执行文件")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """执行全部 V3 插件依赖的真实安装门禁。"""
+    args = parse_args()
+    uv_bin = shutil.which(args.uv)
+    if not uv_bin:
+        print(f"未找到 uv 可执行文件：{args.uv}")
+        return 1
+
+    manifests = discover_manifests()
+    if not manifests:
+        print("未发现 V3 插件 pyproject.toml，拒绝空门禁")
+        return 1
+
+    for manifest in manifests:
+        relative_manifest = manifest.relative_to(REPO_ROOT)
+        print(f"真实安装 {relative_manifest}", flush=True)
+        try:
+            verify_manifest(
+                uv_bin=uv_bin,
+                python_spec=args.python,
+                manifest=manifest,
+            )
+        except subprocess.CalledProcessError as err:
+            print(f"{relative_manifest} 安装门禁失败，退出码：{err.returncode}")
+            return err.returncode or 1
+
+    print(f"V3 插件依赖真实安装门禁通过：{len(manifests)} 份清单")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,6 +68,14 @@ autouse 网络守卫等引导逻辑统一在主程序 `app/testing`（`bootstrap
 - 插件不提交 `uv.lock`；MoviePilot 不为每个插件创建独立环境，会在共享环境中统一解析和安装。
 - V1/V2 历史插件继续使用 `requirements.txt`。
 
+PR 门禁会自动发现全部 V3 `pyproject.toml`，在 Python 3.14 的 Linux x64/arm64、Windows x64、
+macOS Intel/ARM runner 中分别创建隔离环境，按宿主的 `uv pip install -r pyproject.toml` 语义真实安装
+并执行 `uv pip check`。本地可执行同一入口：
+
+```bash
+uv run --no-project --python 3.14 python scripts/check_v3_dependency_install.py --python 3.14
+```
+
 ## 覆盖率门禁
 
 插件覆盖率按插件独立统计，不使用全仓聚合覆盖率。历史兼容实现数量多且维护等级不同，

--- a/tests/ci/test_v3_dependency_install_gate.py
+++ b/tests/ci/test_v3_dependency_install_gate.py
@@ -1,0 +1,93 @@
+"""V3 插件依赖真实安装门禁测试。"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / "scripts/check_v3_dependency_install.py"
+PR_WORKFLOW = REPO_ROOT / ".github/workflows/plugin-gate.yml"
+
+
+def _load_install_module():
+    """按文件路径导入安装门禁脚本。"""
+    spec = importlib.util.spec_from_file_location(
+        "check_v3_dependency_install",
+        INSTALL_SCRIPT,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_manifest_discovery_covers_every_v3_pyproject() -> None:
+    """门禁必须自动覆盖全部 V3 modern manifest 并拒绝静态白名单。"""
+    module = _load_install_module()
+    expected = sorted((REPO_ROOT / "plugins.v3").glob("*/pyproject.toml"))
+
+    assert expected
+    assert module.discover_manifests() == expected
+
+
+def test_installation_uses_fresh_environment_and_host_manifest_semantics(
+    tmp_path: Path,
+) -> None:
+    """安装命令必须面向隔离解释器并通过 -r 消费原始 pyproject。"""
+    module = _load_install_module()
+    environment = tmp_path / ".venv"
+    manifest = REPO_ROOT / "plugins.v3/plexpersonmeta/pyproject.toml"
+
+    create, install, healthcheck = module.installation_commands(
+        uv_bin="uv",
+        python_spec="3.14",
+        environment=environment,
+        manifest=manifest,
+        windows=False,
+    )
+
+    python_bin = environment / "bin/python"
+    assert create == ["uv", "venv", "--python", "3.14", str(environment)]
+    assert install == [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        str(python_bin),
+        "-r",
+        str(manifest),
+    ]
+    assert healthcheck == ["uv", "pip", "check", "--python", str(python_bin)]
+
+
+def test_windows_environment_uses_scripts_python(tmp_path: Path) -> None:
+    """Windows runner 必须把依赖安装到目标 venv，而不是 runner 全局环境。"""
+    module = _load_install_module()
+
+    assert module.venv_python(tmp_path / ".venv", windows=True) == (
+        tmp_path / ".venv/Scripts/python.exe"
+    )
+
+
+def test_workflow_runs_five_platform_install_matrix() -> None:
+    """PR 门禁应覆盖 V3 声明支持的五个平台并执行真实安装脚本。"""
+    workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+    job_start = workflow.index("  plugin-dependency-install-gate:")
+    job_end = workflow.index("\n  plugin-coverage-gate:", job_start)
+    install_job = workflow[job_start:job_end]
+
+    for runner in (
+        "ubuntu-latest",
+        "ubuntu-24.04-arm",
+        "windows-latest",
+        "macos-15-intel",
+        "macos-15",
+    ):
+        assert f"os: {runner}" in install_job
+    assert "name: V3 dependency install (${{ matrix.name }})" in install_job
+    assert "runs-on: ${{ matrix.os }}" in install_job
+    assert "scripts/check_v3_dependency_install.py --python 3.14" in install_job
+    assert "fail-fast: false" in install_job


### PR DESCRIPTION
V3 插件已迁移到 modern manifest，但现有门禁只检查声明结构，无法证明这些依赖能在干净的 Python 3.14 环境中真实安装。

本 PR 增加 V3 依赖安装门禁：

- 自动发现 `package.v3.json` 发布范围内的 modern manifest；
- 在 Linux x64/arm64、Windows x64、macOS Intel/ARM CI 矩阵中创建隔离环境；
- 复用宿主的 `uv pip install -r pyproject.toml` 安装语义；
- 安装后执行 `uv pip check`，阻止缺失依赖、版本冲突和平台制品缺口进入主分支；
- 不依赖已安装的 MoviePilot 环境，也不改变插件运行时行为。

验证：

- `pytest tests/ci -q`：59 passed
- 插件版本门禁通过
- macOS ARM64 对当前两份 V3 modern manifest 完成真实隔离安装并通过 `uv pip check`
- `git diff --check` 通过
