### PR TITLE
fix(test): 补齐 V3 Chain 数据端口测试契约

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,7 @@ def configure_plugin_test_services(request):
         "download_history",
         "transfer_history",
         "transfer_pending",
+        "transfer_execution",
         "media_server",
         "download_failure",
         "user",


### PR DESCRIPTION
## 背景

MoviePilot V3 的 `ChainDataPorts` 新增必填 `transfer_execution` 端口后，插件仓测试运行上下文仍使用旧端口集合，导致全部 V3 插件用例在 fixture 初始化阶段失败。

## 调整

在共享测试替身中显式补齐 `transfer_execution`，保持测试上下文与当前 V3 后端端口契约一致。

## 验证

- CI 脚手架：59 passed
- V3 插件测试：1405 passed
- 兼容 V2 插件测试：81 passed
- `.githooks/pre-push`：通过
- `git diff --check`：通过
