### PR TITLE
chore(ci): 跟随稳定工具链版本

### DIFF
--- a/.github/workflows/plugin-gate.yml
+++ b/.github/workflows/plugin-gate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -32,21 +32,20 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout plugin repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: MoviePilot-Plugins
 
       - name: Checkout MoviePilot V3 backend
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: jxxghp/MoviePilot
           ref: v3
           path: MoviePilot
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: '0.12.5'
           python-version: '3.14'
           enable-cache: true
           cache-dependency-glob: |
@@ -69,7 +68,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout plugin repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: MoviePilot-Plugins
           fetch-depth: 0
@@ -124,7 +123,7 @@ jobs:
 
       - name: Checkout MoviePilot backend
         if: steps.coverage-scope.outputs.run == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: jxxghp/MoviePilot
           ref: v3
@@ -132,9 +131,8 @@ jobs:
 
       - name: Set up uv
         if: steps.coverage-scope.outputs.run == 'true'
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@v10.0.1
         with:
-          version: '0.12.5'
           python-version: '3.14'
           enable-cache: true
           cache-dependency-glob: |
@@ -156,7 +154,7 @@ jobs:
 
       - name: Upload plugin coverage reports
         if: always() && steps.coverage-scope.outputs.run == 'true'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: plugin-coverage-reports
           path: MoviePilot-Plugins/coverage-reports/

--- a/.github/workflows/plugin-gate.yml
+++ b/.github/workflows/plugin-gate.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
+          version-file: MoviePilot/pyproject.toml
           python-version: '3.14'
           enable-cache: true
           cache-dependency-glob: |
@@ -133,6 +134,7 @@ jobs:
         if: steps.coverage-scope.outputs.run == 'true'
         uses: astral-sh/setup-uv@v10.0.1
         with:
+          version-file: MoviePilot/pyproject.toml
           python-version: '3.14'
           enable-cache: true
           cache-dependency-glob: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/tests/ci/test_plugin_coverage_gate.py
+++ b/tests/ci/test_plugin_coverage_gate.py
@@ -162,7 +162,8 @@ def test_pr_workflow_runs_plugin_coverage_gate() -> None:
     assert "Determine whether coverage gate is required" in workflow
     assert "steps.coverage-scope.outputs.run == 'true'" in workflow
     assert "astral-sh/setup-uv" in workflow
-    assert "version: '0.12.5'" in workflow
+    assert "uses: astral-sh/setup-uv@v10.0.1" in workflow
+    assert "version: '0.12.5'" not in workflow
     assert "MoviePilot/uv.lock" in workflow
     assert "uv sync --locked" in workflow
     assert "../MoviePilot/.venv/bin/python scripts/plugin_coverage.py" in workflow

--- a/tests/ci/test_plugin_coverage_gate.py
+++ b/tests/ci/test_plugin_coverage_gate.py
@@ -163,6 +163,7 @@ def test_pr_workflow_runs_plugin_coverage_gate() -> None:
     assert "steps.coverage-scope.outputs.run == 'true'" in workflow
     assert "astral-sh/setup-uv" in workflow
     assert "uses: astral-sh/setup-uv@v10.0.1" in workflow
+    assert "version-file: MoviePilot/pyproject.toml" in workflow
     assert "version: '0.12.5'" not in workflow
     assert "MoviePilot/uv.lock" in workflow
     assert "uv sync --locked" in workflow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,14 +62,13 @@ def configure_plugin_test_services(request):
         ChainRuntimeContext,
         configure_chain_runtime_context_provider,
     )
-    from app.application.chain.data import ChainDataPorts
+    from app.application.chain.data import configure_chain_data_ports
     from app.application.configuration import SystemConfigService, configure_system_config
     from app.db.oper.systemconfig import SystemConfigOper
 
     port_names = (
         "site",
         "subscribe",
-        "workflow",
         "download_history",
         "transfer_history",
         "transfer_pending",
@@ -78,7 +77,7 @@ def configure_plugin_test_services(request):
         "download_failure",
         "user",
     )
-    data_ports = ChainDataPorts(**{name: MagicMock for name in port_names})
+    configure_chain_data_ports(**{name: MagicMock for name in port_names})
     context = ChainRuntimeContext(
         module_manager=MagicMock(),
         plugin_manager=MagicMock(),
@@ -89,7 +88,6 @@ def configure_plugin_test_services(request):
         async_file_cache=MagicMock(),
         message_queue_factory=lambda _callback: MagicMock(),
         module_dispatcher_factory=lambda **_kwargs: MagicMock(),
-        data_ports=data_ports,
     )
     configure_system_config(SystemConfigService(repository=SystemConfigOper()))
     configure_chain_runtime_context_provider(lambda: context)


### PR DESCRIPTION
## 背景

插件 CI 同时固定 Action SHA 和 uv 精确 patch，工具链无法自然获得稳定版本的兼容性与性能改进。

## 调整

- `actions/checkout`、`actions/upload-artifact` 跟随当前稳定大版本。
- `setup-uv` 使用稳定 `v10.0.1` Action，不再在插件仓固定 uv `0.12.5`；测试环境从已 checkout 的 MoviePilot `pyproject.toml` 读取兼容版本，主仓策略调整前后均可独立通过。
- 同步 coverage workflow 契约测试，并修正测试夹具对当前后端 Chain 契约的构造。
- 不修改插件源码、版本或 Release 内容。

## 验证

- CI focused：`11 passed`
- V1 全量：`56 passed`
- V3 全量：`1405 passed`
- V2 全量：`81 passed`
- Coverage：`1357 passed`，行覆盖率 `93.24%`，方法覆盖率 `98.02%`
- actionlint：通过
- 插件版本门禁：通过
- GitHub Actions：Plugin release/test/coverage gate 全部通过
- `git diff --check`：通过
