### PR TITLE
fix: 对齐 SAE 最新宿主订阅合同

### DIFF
--- a/plugins.v3/subscribeassistantenhanced/__init__.py
+++ b/plugins.v3/subscribeassistantenhanced/__init__.py
@@ -29,6 +29,7 @@ from app.chain.tmdb import TmdbChain
 from app.chain.torrents import TorrentsChain
 from app.db.oper.downloadhistory import DownloadHistoryOper
 from app.db.oper.subscribe import SubscribeOper
+from app.db.oper.subscribehistory import SubscribeHistoryOper
 from app.db.oper.transferhistory import TransferHistoryOper
 
 from .engine.types import CompletionSignal, SeasonScope
@@ -130,6 +131,7 @@ class SubscribeAssistantEnhanced(_PluginBase):
         self._onlyonce = False
         # DB oper / chain 在 init_plugin 实例化后注入各业务域模块。
         self._subscribe_oper: Optional[SubscribeOper] = None
+        self._subscribe_history_oper: Optional[SubscribeHistoryOper] = None
         self._subscribe_chain: Optional[SubscribeChain] = None
         self._tmdb_chain: Optional[TmdbChain] = None
         self._storage_chain: Optional[StorageChain] = None
@@ -146,6 +148,7 @@ class SubscribeAssistantEnhanced(_PluginBase):
 
         # 依赖注入：构造即可用且不触发外部网络，供洗版、下载、补搜等业务域写库与查询。
         self._subscribe_oper = SubscribeOper()
+        self._subscribe_history_oper = SubscribeHistoryOper()
         self._subscribe_chain = SubscribeChain()
         self._tmdb_chain = TmdbChain()
         self._storage_chain = StorageChain()
@@ -274,8 +277,8 @@ class SubscribeAssistantEnhanced(_PluginBase):
         )
         converter = BestVersionConverter(
             subscribe_oper=self._subscribe_oper,
+            subscribe_history_oper=self._subscribe_history_oper,
             clear_tasks_fn=self._task_manager.clear_tasks,
-            send_event_fn=eventmanager.send_event,
             notify_fn=self._notify_subscribe,
             restore_fn=self._restore_subscribe_from_snapshot,
             snapshot_fn=verifier.snapshot,
@@ -441,8 +444,6 @@ class SubscribeAssistantEnhanced(_PluginBase):
 
         orchestrator = BestVersionOrchestrator(
             priority_manager=priority_manager,
-            subscribe_oper=self._subscribe_oper,
-            send_subscribe_added_fn=self._send_subscribe_added,
             notify_fn=self._notify_subscribe,
             related_downloads_fn=self._related_download_histories,
             best_version_type=cfg.best_version_type,
@@ -1192,7 +1193,7 @@ class SubscribeAssistantEnhanced(_PluginBase):
         """无下载处理巡检：上映后超期且无下载的订阅按策略暂停、完成或删除。"""
         policy = self._modules.get("no_download_policy")
         lifecycle = self._modules.get("lifecycle")
-        if not policy or not lifecycle or not self._subscribe_oper:
+        if not policy or not lifecycle or not self._subscribe_oper or not self._subscribe_history_oper:
             return
 
         detail("无下载处理巡检：开始")
@@ -1223,7 +1224,7 @@ class SubscribeAssistantEnhanced(_PluginBase):
                     f"原因={decision.reason}，处理=写入完成历史并删除订阅"
                 )
                 payload = subscribe.to_dict()
-                self._subscribe_oper.add_history(**payload)
+                self._subscribe_history_oper.add(payload)
                 self._subscribe_oper.delete(subscribe_id)
             elif action == "delete":
                 logger.info(

--- a/plugins.v3/subscribeassistantenhanced/best_version/converter.py
+++ b/plugins.v3/subscribeassistantenhanced/best_version/converter.py
@@ -2,7 +2,6 @@
 
 from app.application.subscription.write import add_subscribe as add_subscribe_command
 from app.sdk.logging import logger
-from app.schemas.types import EventType
 
 
 DROP_REBUILT_FIELDS = {
@@ -18,14 +17,16 @@ class BestVersionConverter:
     需要随 payload 保留，避免绝对季或剧集组范围在转换时丢失。
     """
 
-    def __init__(self, subscribe_oper=None, clear_tasks_fn=None, send_event_fn=None,
+    def __init__(self, subscribe_oper=None, clear_tasks_fn=None,
                  notify_fn=None, restore_fn=None, snapshot_fn=None, format_desc_fn=None,
                  notification_image_fn=None,
-                 plugin_name: str = "订阅助手（增强版）"):
-        """注入订阅写库、任务清理、事件、通知、完成快照和失败恢复依赖。"""
+                 plugin_name: str = "订阅助手（增强版）",
+                 subscribe_history_oper=None, subscribe_writer=None):
+        """注入活动订阅、历史归档、新增订阅及转换副作用依赖。"""
         self._subscribe_oper = subscribe_oper
+        self._subscribe_history_oper = subscribe_history_oper
+        self._subscribe_writer = subscribe_writer
         self._clear_tasks = clear_tasks_fn
-        self._send_event = send_event_fn
         self._notify = notify_fn
         self._restore = restore_fn
         self._snapshot = snapshot_fn
@@ -36,7 +37,7 @@ class BestVersionConverter:
     def convert_to_full(self, subscribe, mediainfo=None, current_priority=None) -> bool:
         """按指定全集准入基线替换为全集洗版订阅；失败时尽量恢复分集订阅。"""
         sid = subscribe.id
-        if not sid or not self._subscribe_oper or not mediainfo:
+        if not sid or not self._subscribe_oper or not self._subscribe_history_oper or not mediainfo:
             return False
 
         subscribe_dict = subscribe.to_dict()
@@ -52,7 +53,7 @@ class BestVersionConverter:
             return False
 
         try:
-            self._subscribe_oper.add_history(**subscribe_dict)
+            self._subscribe_history_oper.add(subscribe_dict)
         except Exception as err:
             logger.error(f"{subscribe_desc} 原因=写入订阅历史失败，处理=停止转全集处理，错误={err}")
             self._notify_failure(subscribe, subscribe_desc, str(err), mediainfo=mediainfo)
@@ -72,10 +73,10 @@ class BestVersionConverter:
                 logger.warning(f"{subscribe_desc} 清理旧订阅任务失败，继续创建全集洗版订阅，错误={err}")
 
         try:
-            # V3 Oper 只接收已翻译的 identity/payload；媒体对象写入统一经过订阅应用服务。
+            # 新增订阅由 Application writer 负责，活动订阅 Oper 不承担跨事务写入。
             new_sid, err_msg = add_subscribe_command(
                 mediainfo=mediainfo,
-                subscribe_oper=self._subscribe_oper,
+                subscribe_oper=self._subscribe_writer,
                 **full_payload,
             )
         except Exception as err:
@@ -83,7 +84,6 @@ class BestVersionConverter:
 
         if new_sid:
             logger.info(f"{subscribe_desc} 原因=分集洗版集数已符合目标集数，处理=已转为全集洗版订阅 (ID: {new_sid})")
-            self._send_subscribe_added(new_sid, mediainfo)
             self._notify_success(subscribe, subscribe_desc, mediainfo)
             return True
 
@@ -116,17 +116,6 @@ class BestVersionConverter:
             return self._format_desc(subscribe, mediainfo)
         season = f" S{subscribe.season}" if subscribe.season is not None else ""
         return f"{subscribe.name}{season}"
-
-    def _send_subscribe_added(self, sid, mediainfo):
-        """全集洗版订阅创建成功后发 SubscribeAdded 事件。"""
-        if not self._send_event:
-            return
-        media_payload = mediainfo.to_dict()
-        self._send_event(EventType.SubscribeAdded, {
-            "subscribe_id": sid,
-            "username": self._plugin_name,
-            "mediainfo": media_payload,
-        })
 
     def _notify_success(self, subscribe, subscribe_desc: str, mediainfo):
         """发送转全集成功通知。"""

--- a/plugins.v3/subscribeassistantenhanced/best_version/orchestrator.py
+++ b/plugins.v3/subscribeassistantenhanced/best_version/orchestrator.py
@@ -18,17 +18,15 @@ class BestVersionOrchestrator:
     """洗版全流程编排器，负责按配置创建洗版订阅。"""
 
     def __init__(self, priority_manager: PriorityManager,
-                 subscribe_oper=None,
-                 send_subscribe_added_fn: Optional[Callable] = None,
                  notify_fn: Optional[Callable] = None,
                  related_downloads_fn: Optional[Callable] = None,
                  best_version_type: str = "no",
                  notification_image_fn: Optional[Callable] = None,
-                 plugin_name: str = "订阅助手（增强版）"):
+                 plugin_name: str = "订阅助手（增强版）",
+                 subscribe_writer=None):
         """注入洗版编排依赖与自动洗版范围。"""
         self._priority = priority_manager
-        self._subscribe_oper = subscribe_oper
-        self._send_subscribe_added = send_subscribe_added_fn
+        self._subscribe_writer = subscribe_writer
         self._notify = notify_fn
         self._related_downloads = related_downloads_fn
         self._best_version_type = best_version_type
@@ -58,7 +56,7 @@ class BestVersionOrchestrator:
 
         分集下载洗版只在历史上存在多次分集下载时创建，避免单次全集包完成后误进入洗版。
         """
-        if not self._subscribe_oper or not mediainfo:
+        if not mediainfo:
             return None
         if subscribe.best_version:
             return None
@@ -104,10 +102,10 @@ class BestVersionOrchestrator:
         payload = {key: value for key, value in payload.items() if value is not None}
         # 插件创建的订阅始终重新跟随 TMDB 总集数，不继承已完成订阅的手动锁定状态。
         payload["manual_total_episode"] = 0
-        # V3 Oper 只接收已翻译的 identity/payload；媒体对象写入统一经过订阅应用服务。
+        # 新增订阅由 Application writer 负责，不复用查询 Oper 作为事务入口。
         sid, err_msg = add_subscribe_command(
             mediainfo=mediainfo,
-            subscribe_oper=self._subscribe_oper,
+            subscribe_oper=self._subscribe_writer,
             **payload,
         )
         if sid:
@@ -116,8 +114,6 @@ class BestVersionOrchestrator:
                 f"洗版编排：{format_subscribe_desc(subscribe)} "
                 f"原因=订阅完成，处理=已创建{mode_label}订阅（id={sid}）"
             )
-            if self._send_subscribe_added:
-                self._send_subscribe_added(sid, mediainfo, username=self._plugin_name)
             if self._notify:
                 self._notify(
                     f"{format_subscribe_desc(subscribe)} 已添加{mode_label}订阅",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,22 +62,9 @@ def configure_plugin_test_services(request):
         ChainRuntimeContext,
         configure_chain_runtime_context_provider,
     )
-    from app.application.chain.data import configure_chain_data_ports
     from app.application.configuration import SystemConfigService, configure_system_config
     from app.db.oper.systemconfig import SystemConfigOper
 
-    port_names = (
-        "site",
-        "subscribe",
-        "download_history",
-        "transfer_history",
-        "transfer_pending",
-        "transfer_execution",
-        "media_server",
-        "download_failure",
-        "user",
-    )
-    configure_chain_data_ports(**{name: MagicMock for name in port_names})
     context = ChainRuntimeContext(
         module_manager=MagicMock(),
         plugin_manager=MagicMock(),
@@ -88,6 +75,15 @@ def configure_plugin_test_services(request):
         async_file_cache=MagicMock(),
         message_queue_factory=lambda _callback: MagicMock(),
         module_dispatcher_factory=lambda **_kwargs: MagicMock(),
+        site_repository=MagicMock(),
+        subscription_repository=MagicMock(),
+        download_history_repository=MagicMock(),
+        transfer_history_repository=MagicMock(),
+        transfer_admission_repository=MagicMock(),
+        transfer_execution_repository=MagicMock(),
+        media_server_repository=MagicMock(),
+        download_failure_repository=MagicMock(),
+        user_repository=MagicMock(),
     )
     configure_system_config(SystemConfigService(repository=SystemConfigOper()))
     configure_chain_runtime_context_provider(lambda: context)

--- a/tests/v3/subscribeassistantenhanced/test_converter.py
+++ b/tests/v3/subscribeassistantenhanced/test_converter.py
@@ -2,7 +2,13 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, create_autospec
 
+from app.application.subscription.contract import (
+    SubscriptionIdentity,
+    SubscriptionPatch,
+    SubscriptionWritePort,
+)
 from app.db.oper.subscribe import SubscribeOper
+from app.db.oper.subscribehistory import SubscribeHistoryOper
 from app.plugins.subscribeassistantenhanced.best_version.converter import BestVersionConverter
 
 
@@ -32,22 +38,30 @@ def _mediainfo():
     )
 
 
+def _writer(result=(9, "")):
+    """构造符合正式订阅新增端口的测试替身。"""
+    writer = create_autospec(SubscriptionWritePort, instance=True)
+    writer.add.return_value = result
+    return writer
+
+
 class TestConvertToFull:
 
     def test_success(self):
         """分集转全集应归档、删除分集订阅、创建全集洗版并通知。"""
         oper = MagicMock()
-        oper.add.return_value = (9, "")
+        history_oper = MagicMock(spec=SubscribeHistoryOper)
+        writer = _writer()
         clear_tasks = MagicMock()
-        send_event = MagicMock()
         notify = MagicMock()
         call_order = []
         snapshot = MagicMock(side_effect=lambda **_kwargs: call_order.append("snapshot"))
         oper.delete.side_effect = lambda **_kwargs: call_order.append("delete")
         conv = BestVersionConverter(
             subscribe_oper=oper,
+            subscribe_history_oper=history_oper,
+            subscribe_writer=writer,
             clear_tasks_fn=clear_tasks,
-            send_event_fn=send_event,
             notify_fn=notify,
             snapshot_fn=snapshot,
             format_desc_fn=lambda subscribe, mediainfo: f"{subscribe.name} S{subscribe.season}",
@@ -70,11 +84,16 @@ class TestConvertToFull:
 
         assert conv.convert_to_full(sub, media, current_priority=0) is True
 
-        oper.add_history.assert_called_once_with(**sub.to_dict())
+        history_oper.add.assert_called_once_with(sub.to_dict())
         oper.delete.assert_called_once_with(sid=1)
         clear_tasks.assert_called_once_with(1)
-        oper.add.assert_called_once()
-        add_payload = oper.add.call_args.kwargs["payload"]
+        writer.add.assert_called_once()
+        add_identity = writer.add.call_args.kwargs["identity"]
+        add_patch = writer.add.call_args.kwargs["payload"]
+        assert isinstance(add_identity, SubscriptionIdentity)
+        assert add_identity.media_id == "100"
+        assert isinstance(add_patch, SubscriptionPatch)
+        add_payload = add_patch.to_payload()
         assert add_payload["best_version"] == 1
         assert add_payload["best_version_full"] == 1
         assert add_payload["episode_group"] == "eg-1"
@@ -87,47 +106,52 @@ class TestConvertToFull:
         assert "id" not in add_payload
         snapshot.assert_called_once_with(subscribe=sub, mediainfo=media, scope=None)
         assert call_order == ["snapshot", "delete"]
-        send_event.assert_called_once()
-        assert send_event.call_args.args[1]["subscribe_id"] == 9
         notify.assert_called_once()
         assert notify.call_args.args[0] == "测试剧 S1 分集洗版集数已符合目标集数，已从分集洗版转为全集洗版订阅"
         assert "user" not in notify.call_args.kwargs
         assert "reason" not in notify.call_args.kwargs
 
-    def test_uses_v3_subscribe_oper_signature(self):
-        """分集转全集应通过 V3 订阅应用服务适配 canonical Oper 写入签名。"""
+    def test_uses_subscription_writer_contract(self):
+        """分集转全集应通过正式 writer 传递明确身份和字段补丁。"""
         oper = create_autospec(SubscribeOper, instance=True)
-        oper.add.return_value = (9, "")
+        history_oper = create_autospec(SubscribeHistoryOper, instance=True)
+        writer = _writer()
         conv = BestVersionConverter(
             subscribe_oper=oper,
+            subscribe_history_oper=history_oper,
+            subscribe_writer=writer,
             clear_tasks_fn=MagicMock(),
-            send_event_fn=MagicMock(),
             notify_fn=MagicMock(),
         )
         sub = _SubscribeSnapshot(id=1, name="测试剧", season=1)
 
         assert conv.convert_to_full(sub, _mediainfo()) is True
 
-        oper.add.assert_called_once()
-        _args, kwargs = oper.add.call_args
+        writer.add.assert_called_once()
+        _args, kwargs = writer.add.call_args
         assert set(kwargs) >= {"identity", "payload", "username"}
-        assert "mediainfo" not in kwargs
+        assert isinstance(kwargs["identity"], SubscriptionIdentity)
+        assert isinstance(kwargs["payload"], SubscriptionPatch)
 
     def test_failure_keeps_original(self):
         """删除分集订阅失败时保留活动订阅和已写历史，不做不精确回滚。"""
         oper = MagicMock()
+        history_oper = MagicMock(spec=SubscribeHistoryOper)
+        writer = _writer()
         oper.delete.side_effect = RuntimeError("DB error")
         oper.remove_history = MagicMock()
         notify = MagicMock()
         conv = BestVersionConverter(
             subscribe_oper=oper,
+            subscribe_history_oper=history_oper,
+            subscribe_writer=writer,
             clear_tasks_fn=MagicMock(),
             notify_fn=notify,
             format_desc_fn=lambda subscribe, mediainfo: "测试剧 S1",
         )
         sub = _SubscribeSnapshot(id=1, name="测试剧", season=1)
         assert conv.convert_to_full(sub, _mediainfo()) is False
-        oper.add.assert_not_called()
+        writer.add.assert_not_called()
         oper.remove_history.assert_not_called()
         notify.assert_called_once()
         assert notify.call_args.args[0] == "测试剧 S1 转为全集洗版订阅失败"
@@ -135,24 +159,33 @@ class TestConvertToFull:
     def test_history_failure_stops_before_deleting_active_subscribe(self):
         """历史写入失败时不得删除仍在运行的分集洗版订阅。"""
         oper = MagicMock()
-        oper.add_history.side_effect = RuntimeError("history failed")
-        conv = BestVersionConverter(subscribe_oper=oper, notify_fn=MagicMock())
+        history_oper = MagicMock(spec=SubscribeHistoryOper)
+        history_oper.add.side_effect = RuntimeError("history failed")
+        writer = _writer()
+        conv = BestVersionConverter(
+            subscribe_oper=oper,
+            subscribe_history_oper=history_oper,
+            subscribe_writer=writer,
+            notify_fn=MagicMock(),
+        )
         sub = _SubscribeSnapshot(id=1, name="测试剧", season=1)
 
         assert conv.convert_to_full(sub, _mediainfo()) is False
 
         oper.delete.assert_not_called()
-        oper.add.assert_not_called()
+        writer.add.assert_not_called()
 
     def test_task_cleanup_failure_does_not_interrupt_rebuild(self):
         """插件任务清理属于尽力操作，失败时仍继续创建全集洗版订阅。"""
         oper = MagicMock()
-        oper.add.return_value = (9, "")
+        history_oper = MagicMock(spec=SubscribeHistoryOper)
+        writer = _writer()
         clear_tasks = MagicMock(side_effect=RuntimeError("cleanup failed"))
         conv = BestVersionConverter(
             subscribe_oper=oper,
+            subscribe_history_oper=history_oper,
+            subscribe_writer=writer,
             clear_tasks_fn=clear_tasks,
-            send_event_fn=MagicMock(),
             notify_fn=MagicMock(),
         )
         sub = _SubscribeSnapshot(id=1, name="测试剧", season=1)
@@ -160,15 +193,19 @@ class TestConvertToFull:
         assert conv.convert_to_full(sub, _mediainfo()) is True
 
         oper.delete.assert_called_once_with(sid=1)
-        oper.add.assert_called_once()
+        writer.add.assert_called_once()
 
     def test_snapshot_failure_stops_before_subscription_replacement(self):
         """完成快照写入失败时不得删除分集订阅，避免转换后失去增集基线。"""
         oper = MagicMock()
+        history_oper = MagicMock(spec=SubscribeHistoryOper)
+        writer = _writer()
         notify = MagicMock()
         snapshot = MagicMock(side_effect=RuntimeError("snapshot failed"))
         conv = BestVersionConverter(
             subscribe_oper=oper,
+            subscribe_history_oper=history_oper,
+            subscribe_writer=writer,
             snapshot_fn=snapshot,
             notify_fn=notify,
             format_desc_fn=lambda subscribe, mediainfo: "测试剧 S1",
@@ -177,9 +214,9 @@ class TestConvertToFull:
 
         assert conv.convert_to_full(sub, _mediainfo()) is False
 
-        oper.add_history.assert_not_called()
+        history_oper.add.assert_not_called()
         oper.delete.assert_not_called()
-        oper.add.assert_not_called()
+        writer.add.assert_not_called()
         assert notify.call_args.args[0] == "测试剧 S1 转为全集洗版订阅失败"
 
     def test_no_oper_returns_false(self):
@@ -195,11 +232,14 @@ class TestConvertToFull:
     def test_add_failure_restores_old_subscribe_and_notifies(self):
         """创建全集洗版失败时应尝试重建分集订阅并通知人工检查。"""
         oper = MagicMock()
-        oper.add.return_value = (None, "订阅创建失败")
+        history_oper = MagicMock(spec=SubscribeHistoryOper)
+        writer = _writer((None, "订阅创建失败"))
         restore = MagicMock(return_value=True)
         notify = MagicMock()
         conv = BestVersionConverter(
             subscribe_oper=oper,
+            subscribe_history_oper=history_oper,
+            subscribe_writer=writer,
             clear_tasks_fn=MagicMock(),
             restore_fn=restore,
             notify_fn=notify,
@@ -222,11 +262,15 @@ class TestConvertToFull:
     def test_add_exception_reports_restore_failure(self):
         """全集订阅创建抛错且恢复失败时，通知应明确要求人工检查。"""
         oper = MagicMock()
-        oper.add.side_effect = RuntimeError("boom")
+        history_oper = MagicMock(spec=SubscribeHistoryOper)
+        writer = _writer()
+        writer.add.side_effect = RuntimeError("boom")
         restore = MagicMock(return_value=False)
         notify = MagicMock()
         conv = BestVersionConverter(
             subscribe_oper=oper,
+            subscribe_history_oper=history_oper,
+            subscribe_writer=writer,
             restore_fn=restore,
             notify_fn=notify,
         )
@@ -241,12 +285,17 @@ class TestConvertToFull:
     def test_default_description_and_optional_callbacks(self):
         """未注入格式化、事件和通知回调时仍应完成转换并使用默认订阅描述。"""
         oper = MagicMock()
-        oper.add.return_value = (8, "")
-        conv = BestVersionConverter(subscribe_oper=oper)
+        history_oper = MagicMock(spec=SubscribeHistoryOper)
+        writer = _writer((8, ""))
+        conv = BestVersionConverter(
+            subscribe_oper=oper,
+            subscribe_history_oper=history_oper,
+            subscribe_writer=writer,
+        )
         sub = _SubscribeSnapshot(id=1, name="测试剧", season=2)
 
         assert conv.convert_to_full(sub, _mediainfo()) is True
 
-        payload = oper.add.call_args.kwargs["payload"]
+        payload = writer.add.call_args.kwargs["payload"].to_payload()
         assert payload["best_version_full"] == 1
         assert payload["username"] == "订阅助手（增强版）"

--- a/tests/v3/subscribeassistantenhanced/test_orchestrator.py
+++ b/tests/v3/subscribeassistantenhanced/test_orchestrator.py
@@ -2,7 +2,11 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, create_autospec
 
-from app.db.oper.subscribe import SubscribeOper
+from app.application.subscription.contract import (
+    SubscriptionIdentity,
+    SubscriptionPatch,
+    SubscriptionWritePort,
+)
 from app.schemas.types import MediaType
 
 from app.plugins.subscribeassistantenhanced.best_version.orchestrator import BestVersionOrchestrator
@@ -38,6 +42,13 @@ def _sub(ep_priority=None, episode_group=None, **kwargs):
     )
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
+
+
+def _writer(result=(5, "")):
+    """构造符合正式订阅新增端口的测试替身。"""
+    writer = create_autospec(SubscriptionWritePort, instance=True)
+    writer.add.return_value = result
+    return writer
 
 
 class TestBuildPayload:
@@ -90,24 +101,21 @@ class TestModeLabel:
 class TestStartBestVersion:
     """订阅完成后按洗版类型自动创建洗版订阅。"""
 
-    def _orch(self, oper, best_version_type="all", related_downloads_fn=None):
+    def _orch(self, writer, best_version_type="all", related_downloads_fn=None):
         """构造带自动洗版类型范围的编排器。"""
         return BestVersionOrchestrator(
             priority_manager=MagicMock(spec=PriorityManager),
-            subscribe_oper=oper, best_version_type=best_version_type,
+            subscribe_writer=writer, best_version_type=best_version_type,
             related_downloads_fn=related_downloads_fn)
 
     def test_creates_best_version_when_type_enabled(self):
-        """创建洗版订阅成功时应发 SubscribeAdded 事件并发送订阅通知。"""
-        oper = MagicMock()
-        oper.add.return_value = (5, "")
-        send_event = MagicMock()
+        """创建洗版订阅成功时应由正式 writer 持久化并发送订阅通知。"""
+        writer = _writer()
         notify = MagicMock()
         orch = BestVersionOrchestrator(
             priority_manager=MagicMock(spec=PriorityManager),
-            subscribe_oper=oper,
+            subscribe_writer=writer,
             best_version_type="all",
-            send_subscribe_added_fn=send_event,
             notify_fn=notify,
         )
         sub = _sub(best_version=0, season=1, save_path="/m", sites="s",
@@ -115,41 +123,42 @@ class TestStartBestVersion:
         sid = orch.start_best_version(sub, mediainfo=_mediainfo())
 
         assert sid == 5
-        send_event.assert_called_once()
-        assert send_event.call_args.args[0] == 5
         notify.assert_called_once()
         assert notify.call_args.args[0].endswith("已添加洗版订阅")
         assert "reason" not in notify.call_args.kwargs
         assert "user" not in notify.call_args.kwargs
-        _args, kwargs = oper.add.call_args
-        payload = kwargs["payload"]
-        assert kwargs["identity"]["media_id"] == "100"
+        _args, kwargs = writer.add.call_args
+        identity = kwargs["identity"]
+        patch = kwargs["payload"]
+        assert isinstance(identity, SubscriptionIdentity)
+        assert identity.media_id == "100"
+        assert isinstance(patch, SubscriptionPatch)
+        payload = patch.to_payload()
         assert payload["best_version"] == 1 and payload["season"] == 1
         assert payload["best_version_full"] == 1
         assert payload["manual_total_episode"] == 0
         assert payload["filter"] == "r"
         assert payload["filter_groups"] == ["g1"]
 
-    def test_uses_v3_subscribe_oper_signature(self):
-        """自动洗版应通过 V3 订阅应用服务适配 canonical Oper 写入签名。"""
-        oper = create_autospec(SubscribeOper, instance=True)
-        oper.add.return_value = (5, "")
+    def test_uses_subscription_writer_contract(self):
+        """自动洗版应通过正式 writer 传递明确身份和字段补丁。"""
+        writer = _writer()
 
-        assert self._orch(oper).start_best_version(_sub(best_version=0), _mediainfo()) == 5
+        assert self._orch(writer).start_best_version(_sub(best_version=0), _mediainfo()) == 5
 
-        oper.add.assert_called_once()
-        _args, kwargs = oper.add.call_args
+        writer.add.assert_called_once()
+        _args, kwargs = writer.add.call_args
         assert set(kwargs) >= {"identity", "payload", "username"}
-        assert "mediainfo" not in kwargs
+        assert isinstance(kwargs["identity"], SubscriptionIdentity)
+        assert isinstance(kwargs["payload"], SubscriptionPatch)
 
     def test_create_failure_notifies_error_and_image(self):
         """自动创建洗版订阅失败时应推送主程序返回的错误原因。"""
-        oper = MagicMock()
-        oper.add.return_value = (None, "订阅已存在")
+        writer = _writer((None, "订阅已存在"))
         notify = MagicMock()
         orch = BestVersionOrchestrator(
             priority_manager=MagicMock(spec=PriorityManager),
-            subscribe_oper=oper,
+            subscribe_writer=writer,
             best_version_type="all",
             notify_fn=notify,
         )
@@ -168,69 +177,66 @@ class TestStartBestVersion:
         assert "user" not in notify.call_args.kwargs
 
     def test_skips_when_already_best_version(self):
-        oper = MagicMock()
-        self._orch(oper).start_best_version(_sub(best_version=1), object())
-        oper.add.assert_not_called()
+        writer = _writer()
+        self._orch(writer).start_best_version(_sub(best_version=1), object())
+        writer.add.assert_not_called()
 
     def test_skips_without_mediainfo(self):
-        oper = MagicMock()
-        self._orch(oper).start_best_version(_sub(best_version=0), None)
-        oper.add.assert_not_called()
+        writer = _writer()
+        self._orch(writer).start_best_version(_sub(best_version=0), None)
+        writer.add.assert_not_called()
 
     def test_tv_type_skips_movie_subscription(self):
         """剧集洗版范围不应为电影订阅创建洗版。"""
-        oper = MagicMock()
+        writer = _writer()
         sub = _sub(best_version=0, type="电影")
 
-        sid = self._orch(oper, best_version_type="tv").start_best_version(sub, object())
+        sid = self._orch(writer, best_version_type="tv").start_best_version(sub, object())
 
         assert sid is None
-        oper.add.assert_not_called()
+        writer.add.assert_not_called()
 
     def test_movie_type_creates_movie_subscription(self):
         """电影洗版范围应为电影订阅创建洗版。"""
-        oper = MagicMock()
-        oper.add.return_value = (6, "")
+        writer = _writer((6, ""))
         sub = _sub(best_version=0, type=MediaType.MOVIE)
 
-        sid = self._orch(oper, best_version_type="movie").start_best_version(sub, _mediainfo())
+        sid = self._orch(writer, best_version_type="movie").start_best_version(sub, _mediainfo())
 
         assert sid == 6
-        oper.add.assert_called_once()
-        _args, kwargs = oper.add.call_args
-        assert "best_version_full" not in kwargs["payload"]
+        writer.add.assert_called_once()
+        _args, kwargs = writer.add.call_args
+        assert "best_version_full" not in kwargs["payload"].to_payload()
 
     def test_movie_best_version_inherits_movie_current_priority(self):
         """电影自动洗版应继承普通订阅本次完成资源的优先级。"""
-        oper = MagicMock()
-        oper.add.return_value = (6, "")
+        writer = _writer((6, ""))
         sub = _sub(best_version=0, type=MediaType.MOVIE, current_priority=95)
 
-        sid = self._orch(oper, best_version_type="movie").start_best_version(sub, _mediainfo())
+        sid = self._orch(writer, best_version_type="movie").start_best_version(sub, _mediainfo())
 
         assert sid == 6
-        _args, kwargs = oper.add.call_args
-        assert kwargs["payload"]["current_priority"] == 95
+        _args, kwargs = writer.add.call_args
+        assert kwargs["payload"].to_payload()["current_priority"] == 95
 
     def test_movie_best_version_invalid_current_priority_defaults_to_zero(self):
         """电影完成快照里的异常优先级按未建立质量基线处理。"""
-        oper = MagicMock()
-        oper.add.return_value = (6, "")
+        writer = _writer((6, ""))
         sub = _sub(best_version=0, type=MediaType.MOVIE, current_priority="invalid")
 
-        sid = self._orch(oper, best_version_type="movie").start_best_version(sub, _mediainfo())
+        sid = self._orch(writer, best_version_type="movie").start_best_version(sub, _mediainfo())
 
         assert sid == 6
-        _args, kwargs = oper.add.call_args
-        assert kwargs["payload"]["current_priority"] == 0
+        _args, kwargs = writer.add.call_args
+        assert kwargs["payload"].to_payload()["current_priority"] == 0
 
     def test_movie_best_version_skips_when_movie_current_priority_is_top(self):
         """电影普通订阅已达顶档时不应再创建洗版订阅，并推送提示。"""
-        oper = MagicMock()
+        writer = _writer()
         notify = MagicMock()
         orch = BestVersionOrchestrator(
             priority_manager=MagicMock(spec=PriorityManager),
-            subscribe_oper=oper,
+            subscribe_writer=writer,
             best_version_type="movie",
             notify_fn=notify,
         )
@@ -239,7 +245,7 @@ class TestStartBestVersion:
         sid = orch.start_best_version(sub, mediainfo=_mediainfo())
 
         assert sid is None
-        oper.add.assert_not_called()
+        writer.add.assert_not_called()
         notify.assert_called_once()
         assert notify.call_args.args[0].endswith("已达顶档，跳过洗版订阅")
         assert "reason" not in notify.call_args.kwargs
@@ -248,67 +254,66 @@ class TestStartBestVersion:
 
     def test_unknown_media_type_skips_all_scope(self):
         """未知媒体类型不能被 all 范围误当成剧集创建洗版。"""
-        oper = MagicMock()
+        writer = _writer()
         sub = _sub(best_version=0, type=MediaType.UNKNOWN)
 
-        sid = self._orch(oper, best_version_type="all").start_best_version(sub, object())
+        sid = self._orch(writer, best_version_type="all").start_best_version(sub, object())
 
         assert sid is None
-        oper.add.assert_not_called()
+        writer.add.assert_not_called()
 
     def test_no_type_skips_all_subscriptions(self):
         """关闭洗版类型范围时不应创建任何洗版订阅。"""
-        oper = MagicMock()
+        writer = _writer()
         sub = _sub(best_version=0, type="电影")
 
-        sid = self._orch(oper, best_version_type="no").start_best_version(sub, object())
+        sid = self._orch(writer, best_version_type="no").start_best_version(sub, object())
 
         assert sid is None
-        oper.add.assert_not_called()
+        writer.add.assert_not_called()
 
     def test_tv_episode_skips_without_related_episode_downloads(self):
         """分集洗版：没有关联分集下载历史时不自动创建洗版订阅。"""
-        oper = MagicMock()
+        writer = _writer()
         sub = _sub(best_version=0, type="电视剧")
         related = MagicMock(return_value=[])
 
         sid = self._orch(
-            oper,
+            writer,
             best_version_type="tv_episode",
             related_downloads_fn=related,
         ).start_best_version(sub, _mediainfo())
 
         assert sid is None
         related.assert_called_once_with(sub)
-        oper.add.assert_not_called()
+        writer.add.assert_not_called()
 
     def test_tv_episode_skips_single_related_episode_download(self):
         """分集洗版：只有 1 条关联下载历史视为合集/单次下载，不自动洗版。"""
-        oper = MagicMock()
+        writer = _writer()
         sub = _sub(best_version=0, type="电视剧")
 
         sid = self._orch(
-            oper,
+            writer,
             best_version_type="tv_episode",
             related_downloads_fn=MagicMock(return_value=[object()]),
         ).start_best_version(sub, object())
 
         assert sid is None
-        oper.add.assert_not_called()
+        writer.add.assert_not_called()
 
     def test_tv_episode_creates_when_multiple_related_episode_downloads(self):
         """分集洗版：存在多条关联分集下载历史时创建洗版订阅。"""
-        oper = MagicMock()
-        oper.add.return_value = (7, "")
+        writer = _writer((7, ""))
         sub = _sub(best_version=0, type="电视剧")
 
         sid = self._orch(
-            oper,
+            writer,
             best_version_type="tv_episode",
             related_downloads_fn=MagicMock(return_value=[object(), object()]),
         ).start_best_version(sub, _mediainfo())
 
         assert sid == 7
-        oper.add.assert_called_once()
-        _args, kwargs = oper.add.call_args
-        assert kwargs["payload"]["best_version_full"] == 1
+        writer.add.assert_called_once()
+        _args, kwargs = writer.add.call_args
+        assert kwargs["payload"].to_payload()["best_version_full"] == 1

--- a/tests/v3/subscribeassistantenhanced/test_plugin_integration.py
+++ b/tests/v3/subscribeassistantenhanced/test_plugin_integration.py
@@ -99,6 +99,20 @@ def test_converter_is_wired():
     assert converter._notification_image.__func__ is plugin._resolve_notification_image.__func__
 
 
+def test_subscription_creation_uses_host_transactional_writer():
+    """新增订阅不注入查询 Oper，交由宿主配置的事务 writer 处理。"""
+    plugin = SubscribeAssistantEnhanced()
+    plugin.init_plugin({})
+
+    converter = plugin._modules["converter"]
+    orchestrator = plugin._modules["orchestrator"]
+
+    assert converter._subscribe_oper is plugin._subscribe_oper
+    assert converter._subscribe_history_oper is plugin._subscribe_history_oper
+    assert converter._subscribe_writer is None
+    assert orchestrator._subscribe_writer is None
+
+
 def test_orchestrator_uses_shared_notification_image_resolver():
     """自动洗版通知与状态通知共用订阅图片优先策略。"""
     plugin = SubscribeAssistantEnhanced()
@@ -2330,8 +2344,8 @@ def test_best_version_notification_without_image_has_single_plugin_source():
     plugin.init_plugin({"notify": True, "best_version_type": "all"})
     plugin.post_message = MagicMock()
     orchestrator = plugin._modules["orchestrator"]
-    orchestrator._subscribe_oper = MagicMock()
-    orchestrator._subscribe_oper.add.return_value = (8, "")
+    orchestrator._subscribe_writer = MagicMock()
+    orchestrator._subscribe_writer.add.return_value = (8, "")
     media = _mediainfo()
     media.get_message_image = lambda: ""
 
@@ -3462,6 +3476,7 @@ class TestNoDownloadCheck:
             "no_download_actions": [action],
         })
         plugin._subscribe_oper = MagicMock()
+        plugin._subscribe_history_oper = MagicMock()
         plugin._subscribe_oper.list.return_value = [subscribe]
         plugin._recognize_mediainfo = MagicMock(return_value=mediainfo)
         plugin._last_download_date = MagicMock(return_value=None)
@@ -3748,7 +3763,7 @@ class TestNoDownloadCheck:
 
         plugin._recognize_mediainfo.assert_called_once_with(subscribe)
         plugin._last_download_date.assert_called_once_with(subscribe)
-        plugin._subscribe_oper.add_history.assert_called_once_with(**subscribe.to_dict())
+        plugin._subscribe_history_oper.add.assert_called_once_with(subscribe.to_dict())
         plugin._subscribe_oper.delete.assert_called_once_with(25)
 
     def test_overdue_tv_pause_action_preserves_no_download_pause_detail(self):


### PR DESCRIPTION
## 背景

最新 V3 宿主收口了 Chain 运行上下文和订阅持久化合同：`ChainRuntimeContext` 改为显式注入 repository，订阅新增由宿主事务 writer 负责，订阅历史写入也已拆分到独立 Oper。个人插件仓的共享 fixture 和 SAE 测试仍沿用旧合同，导致完整 V3 回归失败，并会让测试替身掩盖真实运行路径。

## 调整

- 为共享 Chain 测试上下文显式注入九个 repository，移除已删除的 data ports locator。
- SAE 新增洗版订阅交由宿主配置的事务 writer，测试按 `SubscriptionIdentity` 与 `SubscriptionPatch` 合同断言。
- 订阅完成历史统一写入 `SubscribeHistoryOper`。
- 移除事务 writer 已负责的重复 `SubscribeAdded` 手工事件。
- 增加入门装配合同，防止后续重新把查询 `SubscribeOper` 注入订阅新增路径。

## 验证

- SAE focused：`1358 passed`
- SAE 覆盖率：line `93.22%`、method `97.88%`
- 完整分组：CI `56 passed`、V3 `1406 passed`、兼容 V2 `81 passed`
- 插件版本门禁、三份 package JSON 解析、compileall、pre-push hook、`git diff --check` 均通过

## 交付边界

这是解除最新宿主测试阻塞的 PR-only 调整。SAE 版本保持 `0.7.5`，未修改 package、README、workflow 或 icons；不进行 tag 或 GitHub Release。
