### PR TITLE
feat(v3): 迁移第二批三个插件

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -281,7 +281,8 @@
             "v1.6": "优化执行周期输入，需要MoviePilot v2.2.1+",
             "v1.5": "MoviePilot V2 版本Plex元数据刷新插件"
         },
-        "release": true
+        "release": true,
+        "v3": false
     },
     "Commands": {
         "name": "命令管理",
@@ -294,7 +295,8 @@
         "history": {
             "v1.0": "增加命令管理插件，实现微信、Telegram等客户端的命令管理"
         },
-        "release": true
+        "release": true,
+        "v3": false
     },
     "WebhookNotify": {
         "name": "Webhook消息推送",
@@ -308,7 +310,8 @@
             "v1.1": "新增 APIKEY 认证配置。",
             "v1.0": "新增通用 Webhook 通知入口。"
         },
-        "release": true
+        "release": true,
+        "v3": false
     },
     "AutoDiagnosis": {
         "name": "自动诊断",

--- a/package.v3.json
+++ b/package.v3.json
@@ -96,5 +96,47 @@
             "v2.0": "MoviePilot V3 版本WebDAV备份插件"
         },
         "release": true
+    },
+    "PlexRefreshRecent": {
+        "name": "Plex元数据刷新",
+        "description": "定时通知Plex刷新最近入库元数据。",
+        "labels": "Plex,刮削",
+        "version": "2.0.0",
+        "icon": "Plex_A.png",
+        "author": "InfinityPacer",
+        "level": 1,
+        "system_version": ">=3.0.0",
+        "history": {
+            "v2.0.0": "适配 MoviePilot V3 媒体服务与事件接口，保持最近媒体刷新流程。"
+        },
+        "release": true
+    },
+    "Commands": {
+        "name": "命令管理",
+        "description": "实现微信、Telegram等客户端的命令管理。",
+        "labels": "工具",
+        "version": "2.0.0",
+        "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/commands.png",
+        "author": "InfinityPacer",
+        "level": 1,
+        "system_version": ">=3.0.0",
+        "history": {
+            "v2.0.0": "迁移至 MoviePilot V3 SDK，适配命令注册事件与通知客户端筛选。"
+        },
+        "release": true
+    },
+    "WebhookNotify": {
+        "name": "Webhook消息推送",
+        "description": "接收 Webhook 消息并推送到通知客户端。",
+        "labels": "通知,工具",
+        "version": "2.0.0",
+        "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/webhooknotify.png",
+        "author": "InfinityPacer",
+        "level": 1,
+        "system_version": ">=3.0.0",
+        "history": {
+            "v2.0.0": "迁移至 MoviePilot V3 稳定接口，保持 Webhook 请求与通知转发行为。"
+        },
+        "release": true
     }
 }

--- a/plugins.v3/commands/__init__.py
+++ b/plugins.v3/commands/__init__.py
@@ -1,0 +1,401 @@
+"""按通知客户端配置管理 MoviePilot 远程命令菜单。"""
+
+import json
+from collections.abc import Mapping
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.plugins import _PluginBase
+from app.schemas.event import CommandRegisterEventData
+from app.schemas.system import ServiceInfo
+from app.schemas.types import ChainEventType
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+from app.sdk.services import NotificationHelper
+
+
+class Commands(_PluginBase):
+    """按通知客户端配置筛选并调整远程命令菜单。"""
+
+    plugin_name = "命令管理"
+    plugin_desc = "实现微信、Telegram等客户端的命令管理。"
+    plugin_icon = (
+        "https://raw.githubusercontent.com/InfinityPacer/"
+        "MoviePilot-Plugins/main/icons/commands.png"
+    )
+    plugin_version = "2.0.0"
+    plugin_author = "InfinityPacer"
+    author_url = "https://github.com/InfinityPacer"
+    plugin_config_prefix = "commands_"
+    plugin_order = 42
+    auth_level = 1
+
+    # 通知服务目录由宿主 SDK 在插件初始化时绑定，避免导入期抓取运行时模块。
+    notify_helper: Optional[NotificationHelper] = None
+    _enabled = False
+    _notify_clients: List[str] = []
+    _custom_commands: Dict[str, Dict[str, dict]] = {}
+
+    def init_plugin(self, config: Optional[dict] = None):
+        """读取命令菜单配置，并在每次重载时重置旧实例状态。"""
+        self.notify_helper = NotificationHelper()
+        self._enabled = False
+        self._notify_clients = []
+        self._custom_commands = {}
+        if not config:
+            return
+
+        self._enabled = bool(config.get("enabled", False))
+        notify_clients = config.get("notify_clients")
+        if isinstance(notify_clients, (list, tuple, set)):
+            self._notify_clients = [str(name) for name in notify_clients if name]
+        elif notify_clients:
+            self._notify_clients = [str(notify_clients)]
+        self._custom_commands = self.__parse_custom_commands(
+            config.get("custom_commands")
+        )
+
+    @staticmethod
+    def __parse_custom_commands(value: Any) -> Dict[str, Dict[str, dict]]:
+        """解析表单中的 JSON 菜单配置，非法输入按空配置处理。"""
+        try:
+            if isinstance(value, Mapping):
+                parsed = dict(value)
+            elif value in (None, ""):
+                return {}
+            else:
+                parsed = json.loads(value)
+            if not isinstance(parsed, dict):
+                raise ValueError("自定义命令必须是 JSON 对象")
+            return parsed
+        except (TypeError, ValueError, json.JSONDecodeError) as error:
+            logger.error(f"自定义命令格式错误，请检查，{error}")
+            return {}
+
+    def __get_notify_helper(self) -> NotificationHelper:
+        """返回已绑定的通知服务目录，兼容宿主调用表单前读取配置的顺序。"""
+        if self.notify_helper is None:
+            self.notify_helper = NotificationHelper()
+        return self.notify_helper
+
+    @property
+    def service_infos(self) -> Optional[Dict[str, ServiceInfo]]:
+        """返回已选择且当前运行中的通知客户端。"""
+        if not self._notify_clients:
+            logger.warning("尚未配置通知客户端，请检查配置")
+            return None
+
+        services = self.__get_notify_helper().get_services(
+            name_filters=self._notify_clients
+        )
+        if not services:
+            logger.warning("获取通知客户端实例失败，请检查配置")
+            return None
+
+        return services
+
+    def get_state(self) -> bool:
+        """返回插件是否已启用。"""
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """本插件不注册额外的远程命令。"""
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """本插件不暴露自有 HTTP API。"""
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """拼装插件配置页面和默认配置。"""
+        notify_helper = self.__get_notify_helper()
+        return [
+            {
+                'component': 'VForm',
+                'content': [
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'enabled',
+                                            'label': '启用插件',
+                                            'hint': '开启后插件将处于激活状态',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'multiple': True,
+                                            'chips': True,
+                                            'clearable': True,
+                                            'model': 'notify_clients',
+                                            'label': '启用命令菜单的通知客户端',
+                                            'hint': '选择启用命令菜单的通知客户端',
+                                            'persistent-hint': True,
+                                            'items': [
+                                                {"title": config.name, "value": config.name}
+                                                for config in notify_helper.get_configs().values()
+                                                if config.type in ["wechat", "telegram"]
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VTabs',
+                        'props': {
+                            'model': '_tabs',
+                            'style': {
+                                'margin-top': '8px',
+                                'margin-bottom': '16px'
+                            },
+                            'stacked': False,
+                            'fixed-tabs': False
+                        },
+                        'content': [
+                            {
+                                'component': 'VTab',
+                                'props': {
+                                    'value': 'preset_tab'
+                                },
+                                'text': '系统预置'
+                            }, {
+                                'component': 'VTab',
+                                'props': {
+                                    'value': 'custom_tab'
+                                },
+                                'text': '自定义'
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VWindow',
+                        'props': {
+                            'model': '_tabs'
+                        },
+                        'content': [
+                            {
+                                'component': 'VWindowItem',
+                                'props': {
+                                    'value': 'preset_tab'
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VRow',
+                                        'content': [
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    "cols": 12
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VAceEditor',
+                                                        'props': {
+                                                            'modelvalue': 'preset_commands',
+                                                            'lang': 'json',
+                                                            'theme': 'monokai',
+                                                            'style': (
+                                                                'height: 35rem; font-size: 14px'
+                                                            ),
+                                                            'readonly': True
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VWindowItem',
+                                'props': {
+                                    'value': 'custom_tab'
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VRow',
+                                        'content': [
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    "cols": 12
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VAceEditor',
+                                                        'props': {
+                                                            'modelvalue': 'custom_commands',
+                                                            'lang': 'json',
+                                                            'theme': 'monokai',
+                                                            'style': (
+                                                                'height: 35rem; font-size: 14px'
+                                                            )
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'props': {
+                            'style': {
+                                'margin-top': '12px'
+                            }
+                        },
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal',
+                                            'text': '注意：企业微信目前仅支持3个一级菜单和5个二级菜单'
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ], {
+            "enabled": False,
+            "custom_commands": self.__get_default_commands()
+        }
+
+    def get_page(self) -> None:
+        """保持空钩子，使宿主不声明详情页能力。"""
+        pass
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """本插件不注册后台服务。"""
+        return []
+
+    def stop_service(self) -> None:
+        """本插件没有需要停止的后台服务。"""
+
+    @eventmanager.register(ChainEventType.CommandRegister)
+    def handle_command_register(self, event: Event):
+        """按来源和客户端配置拦截或裁剪命令注册事件。"""
+        if not event or not event.event_data:
+            return
+
+        event_data: CommandRegisterEventData = event.event_data
+
+        logger.info(f"处理命令注册事件 - {event_data}")
+
+        if event_data.cancel:
+            logger.debug("该事件已被其他事件处理器处理，跳过后续操作")
+            return
+
+        if event_data.origin == "CommandChain":
+            config = self.get_config() or {}
+            config["preset_commands"] = json.dumps(
+                event_data.commands,
+                indent=4,
+                ensure_ascii=False,
+            )
+            self.update_config(config=config)
+            return
+
+        if event_data.origin not in ["WeChat", "Telegram"]:
+            logger.info(f"尚未支持的事件源: {event_data.origin}，跳过拦截")
+            return
+
+        event_data.source = self.plugin_name
+        services = self.service_infos
+        if not services or event_data.service not in services:
+            event_data.cancel = True
+            logger.warning(f"命令注册被拦截，{event_data}")
+            return
+
+        event_data.cancel = False
+        custom_commands = (self._custom_commands or {}).get(event_data.service) or {}
+        if not isinstance(custom_commands, Mapping):
+            logger.warning(f"未能获取到 {event_data.service} 相关的自定义命令，跳过处理")
+            return
+        if not custom_commands:
+            logger.info(f"未能获取到 {event_data.service} 相关的自定义命令，跳过处理")
+            return
+
+        logger.debug(f"Initial commands before processing: {event_data.commands}")
+        for cmd_key in list(event_data.commands):
+            command = event_data.commands[cmd_key]
+            custom_command = custom_commands.get(cmd_key)
+            if not isinstance(command, dict) or not isinstance(custom_command, Mapping):
+                del event_data.commands[cmd_key]
+                continue
+
+            command["category"] = custom_command.get(
+                "category", command.get("category")
+            )
+            command["description"] = custom_command.get(
+                "description", command.get("description")
+            )
+        logger.debug(f"Final commands after processing: {event_data.commands}")
+
+    @staticmethod
+    def __get_default_commands() -> str:
+        """返回自定义命令配置的示例值。"""
+        return """{
+    "通知渠道1": {
+        "/cookiecloud": {
+            "type": "preset",
+            "description": "同步站点",
+            "category": "站点"
+        },
+        "/sites": {
+            "type": "preset",
+            "description": "查询站点",
+            "category": "站点"
+        }
+    },
+    "通知渠道2": {
+        "/restart": {
+            "type": "preset",
+            "description": "重启系统",
+            "category": "管理"
+        },
+        "/version": {
+            "type": "preset",
+            "description": "当前版本",
+            "category": "管理"
+        }
+    }
+}"""

--- a/plugins.v3/plexrefreshrecent/__init__.py
+++ b/plugins.v3/plexrefreshrecent/__init__.py
@@ -1,0 +1,547 @@
+"""按时间窗口刷新 Plex 最近入库媒体的元数据。"""
+
+import threading
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from app.plugins import _PluginBase
+from app.schemas.system import ServiceInfo
+from app.schemas.types import EventType, MessageType
+from app.sdk.config import settings
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+from app.sdk.services import MediaServerHelper
+
+lock = threading.Lock()
+
+
+class PlexRefreshRecent(_PluginBase):
+    """调度 Plex 最近媒体查询，并去重提交元数据刷新请求。"""
+
+    # 插件名称
+    plugin_name = "Plex元数据刷新"
+    # 插件描述
+    plugin_desc = "定时通知Plex刷新最近入库元数据。"
+    # 插件图标
+    plugin_icon = "Plex_A.png"
+    # 插件版本
+    plugin_version = "2.0.0"
+    # 插件作者
+    plugin_author = "InfinityPacer"
+    # 作者主页
+    author_url = "https://github.com/InfinityPacer"
+    # 插件配置项ID前缀
+    plugin_config_prefix = "plexrefreshrecent_"
+    # 加载顺序
+    plugin_order = 90
+    # 可使用的用户级别
+    auth_level = 1
+
+    # region 私有属性
+    mediaserver_helper = None
+    # 是否开启
+    _enabled = False
+    # 任务执行间隔
+    _cron = None
+    # 时间范围
+    _offset_days = "0"
+    # 立即运行一次
+    _onlyonce = False
+    # 发送通知
+    _notify = False
+    # limit
+    _limit = None
+    # 强制刷新
+    _force = False
+    # 媒体服务器
+    _mediaservers = None
+    # 定时器
+    _scheduler = None
+    # 退出事件
+    _event = threading.Event()
+
+    # endregion
+
+    def init_plugin(self, config: Optional[dict] = None):
+        """应用配置并重建一次性任务；周期任务由宿主服务目录管理。"""
+        self.stop_service()
+        self._event.clear()
+        self.mediaserver_helper = MediaServerHelper()
+        if not config:
+            self._enabled = False
+            return
+
+        self._enabled = bool(config.get("enabled"))
+        self._cron = config.get("cron")
+        self._notify = bool(config.get("notify"))
+        self._onlyonce = bool(config.get("onlyonce"))
+        self._force = bool(config.get("force"))
+        self._mediaservers = config.get("mediaservers") or []
+        try:
+            self._offset_days = int(config.get("offset_days", 3))
+        except (TypeError, ValueError):
+            self._offset_days = 3
+
+        try:
+            self._limit = int(config.get("limit", 1000))
+        except (TypeError, ValueError):
+            self._limit = 1000
+
+        self._scheduler = BackgroundScheduler(timezone=settings.TZ)
+        if self._onlyonce:
+            logger.info("Plex元数据刷新服务启动，立即运行一次")
+            self._scheduler.add_job(
+                func=self.refresh_recent,
+                trigger="date",
+                run_date=datetime.now(tz=pytz.timezone(settings.TZ)) + timedelta(seconds=3),
+                name="Plex元数据刷新",
+            )
+
+            # 关闭一次性开关
+            self._onlyonce = False
+
+        self.update_config(
+            {
+                "onlyonce": False,
+                "cron": self._cron,
+                "enabled": self._enabled,
+                "offset_days": self._offset_days,
+                "notify": self._notify,
+                "limit": self._limit,
+                "force": self._force,
+                "mediaservers": self._mediaservers
+            }
+        )
+
+        # 启动任务
+        if self._scheduler.get_jobs():
+            self._scheduler.print_jobs()
+            self._scheduler.start()
+
+    def service_infos(self) -> Optional[Dict[str, ServiceInfo]]:
+        """
+        服务信息
+        """
+        if not self._mediaservers:
+            logger.warning("尚未配置媒体服务器，请检查配置")
+            return None
+
+        if not self.mediaserver_helper:
+            self.mediaserver_helper = MediaServerHelper()
+
+        services = self.mediaserver_helper.get_services(
+            name_filters=self._mediaservers,
+            type_filter="plex",
+        )
+        if not services:
+            logger.warning("获取媒体服务器实例失败，请检查配置")
+            return None
+
+        active_services = {}
+        for service_name, service_info in services.items():
+            if not service_info.instance or service_info.instance.is_inactive():
+                logger.warning(f"媒体服务器 {service_name} 未连接，请检查配置")
+            else:
+                active_services[service_name] = service_info
+
+        if not active_services:
+            logger.warning("没有已连接的媒体服务器，请检查配置")
+            return None
+
+        return active_services
+
+    def get_state(self) -> bool:
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """
+        定义远程控制命令
+        :return: 命令关键字、事件、描述、附带数据
+        """
+        return [
+            {
+                "cmd": "/refresh_plex_recent",
+                "event": EventType.PluginAction,
+                "desc": "Plex元数据刷新",
+                "category": "",
+                "data": {"action": "refresh_plex_recent_event"},
+            }
+        ]
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """本插件没有自有 HTTP API。"""
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """
+        拼装插件配置页面，需要返回两块数据：1、页面配置；2、数据结构
+        """
+        return [
+            {
+                'component': 'VForm',
+                'content': [
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {'cols': 12, 'md': 3},
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'enabled',
+                                            'label': '启用插件',
+                                            'hint': '开启后插件将处于激活状态',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {'cols': 12, 'md': 3},
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'force',
+                                            'label': '强制刷新',
+                                            'hint': '无论是否已存在，将重新刷新元数据',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {'cols': 12, 'md': 3},
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'notify',
+                                            'label': '发送通知',
+                                            'hint': '是否在特定事件发生时发送通知',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {'cols': 12, 'md': 3},
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'onlyonce',
+                                            'label': '立即运行一次',
+                                            'hint': '插件将立即运行一次',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {'cols': 12, 'md': 4},
+                                'content': [
+                                    {
+                                        'component': 'VCronField',
+                                        'props': {
+                                            'model': 'cron',
+                                            'label': '执行周期',
+                                            'placeholder': '5位cron表达式',
+                                            'hint': '使用cron表达式指定执行周期，如 0 8 * * *',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {'cols': 12, 'md': 4},
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'offset_days',
+                                            'label': '几天内',
+                                            'hint': '从当前日期往前几天内的数据',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {'cols': 12, 'md': 4},
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'limit',
+                                            'label': '最大元数据数量',
+                                            'hint': '一次刷新的最大元数据条数',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'multiple': True,
+                                            'chips': True,
+                                            'clearable': True,
+                                            'model': 'mediaservers',
+                                            'label': '媒体服务器',
+                                            'items': [
+                                                {"title": config.name, "value": config.name}
+                                                for config in (
+                                                    self.mediaserver_helper
+                                                    .get_configs()
+                                                    .values()
+                                                )
+                                                if config.type == "plex"
+                                            ],
+                                            'hint': '选择媒体服务器',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ], {
+            "enabled": False,
+            "notify": True,
+            "cron": "0 */3 * * *",
+            "offset_days": "3",
+            "limit": 1000,
+            "force": False,
+            "mediaservers": []
+        }
+
+    def get_page(self) -> Optional[List[dict]]:
+        """保持空钩子，使宿主不声明详情页能力。"""
+        pass
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """
+        注册插件公共服务
+        [{
+            "id": "服务ID",
+            "name": "服务名称",
+            "trigger": "触发器：cron/interval/date/CronTrigger.from_crontab()",
+            "func": self.xxx,
+            "kwargs": {} # 定时器参数
+        }]
+        """
+        services = []
+
+        if self._enabled and self._cron:
+            try:
+                trigger = CronTrigger.from_crontab(self._cron)
+            except (TypeError, ValueError) as error:
+                logger.error(f"Plex元数据刷新执行周期无效：{error}")
+            else:
+                logger.info(f"刷新Plex最近入库元数据定时服务启动，时间间隔 {self._cron} ")
+                services.append({
+                    "id": "PlexRefreshRecent",
+                    "name": "Plex元数据刷新",
+                    "trigger": trigger,
+                    "func": self.refresh_recent,
+                    "kwargs": {}
+                })
+
+        if not services:
+            logger.info("Plex元数据刷新定时服务未开启")
+
+        return services
+
+    def stop_service(self):
+        """停止插件自有的一次性调度器并释放旧任务。"""
+        scheduler = self._scheduler
+        self._scheduler = None
+        self._event.set()
+        try:
+            if scheduler:
+                scheduler.remove_all_jobs()
+                if scheduler.running:
+                    scheduler.shutdown()
+        except Exception as error:
+            logger.warning(f"停止Plex元数据刷新任务失败：{error}")
+        finally:
+            self._event.clear()
+
+    @eventmanager.register(EventType.PluginAction)
+    def refresh_recent(self, event: Event = None):
+        """刷新配置媒体服务器在时间窗口内新增的 Plex 媒体元数据。"""
+        if self._event.is_set():
+            return
+
+        if event:
+            logger.info(f"event： {event}")
+            event_data = event.event_data
+            action = (
+                event_data.get("action")
+                if isinstance(event_data, dict)
+                else getattr(event_data, "action", None)
+            )
+            if action != "refresh_plex_recent_event":
+                return
+
+        if not self.__check_plex_media_server():
+            return
+
+        with lock:
+            logger.info("准备刷新最近入库元数据")
+            msg = ""
+            try:
+                success, count = self.__refresh_plex()
+                # 发送通知
+                if self._notify:
+                    if success:
+                        msg = f"元数据刷新完成，刷新条数：{count}"
+                    else:
+                        msg = "元数据刷新失败，请检查日志"
+            except Exception as e:
+                logger.error(e)
+                msg = f"元数据刷新失败，失败原因：{e}"
+
+        logger.info("已完成最近入库元数据刷新")
+        if self._notify:
+            self.post_message(
+                mtype=MessageType.SiteMessage,
+                title=f"【Plex最近{self._offset_days}天元数据刷新】",
+                text=msg
+            )
+
+    def __refresh_plex(self) -> Tuple[bool, int]:
+        """遍历已连接 Plex 服务，并按服务隔离远端查询和刷新异常。"""
+        services = self.service_infos()
+        if not services:
+            return False, 0
+
+        refreshed_count = 0
+        for service_name, service in services.items():
+            try:
+                plex_wrapper = service.instance
+                plex = plex_wrapper.get_plex() if plex_wrapper else None
+                if not plex:
+                    logger.warning(f"{service_name} 获取 Plex 实例失败，请检查配置")
+                    continue
+                logger.info(f"准备对 {service_name} 进行元数据刷新")
+                timestamp = self.__get_timestamp(offset_day=-int(self._offset_days))
+                library_items = plex.library.search(
+                    limit=self._limit,
+                    **{"addedAt>": timestamp},
+                )
+
+                refreshed_items = {}
+                for item in library_items or []:
+                    try:
+                        self.__refresh_metadata(item, refreshed_items)
+                    except Exception as error:
+                        logger.error(
+                            f"{service_name} 刷新媒体元数据过程中发生异常，{error}"
+                        )
+                refreshed_count += len(refreshed_items)
+                logger.info(
+                    f"{service_name} 元数据刷新已完成，刷新条数：{len(refreshed_items)}"
+                )
+            except Exception as error:
+                logger.error(
+                    f"{service_name} 刷新最近元数据过程中发生异常，{error}"
+                )
+
+        return True, refreshed_count
+
+    def __refresh_metadata(self, item, refreshed_items):
+        """刷新单个 Plex 项，并利用父级键避免同一媒体树重复请求。"""
+        rating_key = getattr(item, "ratingKey", None)
+        if not rating_key:
+            logger.warning("Plex 媒体项缺少 ratingKey，跳过刷新")
+            return
+
+        parent_rating_key = getattr(item, "parentRatingKey", None)
+        grandparent_rating_key = getattr(item, "grandparentRatingKey", None)
+
+        summary = getattr(item, "summary", "")
+
+        parent_title = getattr(item, "parentTitle", None)
+        grandparent_title = getattr(item, "grandparentTitle", None)
+
+        parent_info = f"{parent_title} " if parent_title else ""
+        grandparent_info = f"{grandparent_title} " if grandparent_title else ""
+
+        # 检查当前项是否已刷新或其任一上级是否已刷新
+        if (rating_key in refreshed_items or
+                (parent_rating_key and parent_rating_key in refreshed_items) or
+                (grandparent_rating_key and grandparent_rating_key in refreshed_items)):
+            logger.info(
+                f"父级已刷新，跳过此项：{grandparent_info}{parent_info}"
+                f"{getattr(item, 'title', '')} ({getattr(item, 'type', '')})"
+            )
+            return
+
+        item_type = getattr(item, "TYPE", getattr(item, "type", None))
+        if item_type != "season":
+            if self._force or not summary:
+                item.refresh()
+                logger.info(
+                    f"刷新元数据已请求：{grandparent_info}{parent_info}"
+                    f"{getattr(item, 'title', '')} ({getattr(item, 'type', '')})"
+                )
+                refreshed_items[rating_key] = True
+        else:
+            logger.info(
+                f"季度项无需单独刷新：{grandparent_info}{parent_info}"
+                f"{getattr(item, 'title', '')} ({getattr(item, 'type', '')})"
+            )
+
+    @staticmethod
+    def __get_timestamp(offset_day: int) -> int:
+        """
+       获取相对于当前日期偏移指定天数的时间戳
+       :param offset_day: 偏移天数，正数表示未来，负数表示过去
+       :return: 偏移后的时间戳
+       """
+        current_time = datetime.now()
+        target_time = current_time + timedelta(days=offset_day)
+        target_timestamp = int(target_time.timestamp())
+        return target_timestamp
+
+    def __check_plex_media_server(self) -> bool:
+        """
+        检查Plex媒体服务器配置
+        """
+        if not self.service_infos():
+            logger.error("Plex 配置不正确，请检查")
+            return False
+        return True

--- a/plugins.v3/webhooknotify/README.md
+++ b/plugins.v3/webhooknotify/README.md
@@ -1,0 +1,120 @@
+# Webhook消息推送
+
+接收 Webhook 消息并推送到通知客户端。
+
+> 兼容性：MoviePilot v3.x（最低版本：v3.0.0）
+> 适用场景：路由、服务器、服务进程或其他外部监控系统的告警通知
+
+## 版本更新日志
+
+- v2.0.0
+  - 迁移至 MoviePilot V3 稳定接口，保持 Webhook 请求与通知转发行为。
+- v1.1
+  - 新增 APIKEY 认证配置。
+- v1.0
+  - 新增通用 Webhook 通知入口。
+
+## 功能概览
+
+- 提供支持独立 API Key 的 `GET` 和 `POST` Webhook，避免向外部系统提供 MoviePilot 公共 `API_TOKEN`。
+- 接收外部请求中的 `title` 和 `body`，任意一项非空即可转发为所配置类型的消息。
+- 支持选择 MoviePilot 消息类型，默认为“插件”，用于匹配通知渠道的接收设置。
+- 复用 MoviePilot 通知历史和已配置的 WebPush、Telegram、微信等通知渠道。
+- 不负责健康检查、故障判断、重试或告警去重，调用方只负责在需要通知时发送请求。
+
+## API
+
+| 方法 | 地址 | 说明 |
+| --- | --- | --- |
+| `POST` | `/api/v1/plugin/WebhookNotify/webhook` | 从 JSON 请求体接收入站通知 |
+| `GET` | `/api/v1/plugin/WebhookNotify/webhook?title=...&body=...` | 从查询参数接收入站通知 |
+
+认证信息支持以下任一传递方式：
+
+- 请求头：`X-API-KEY: <API_KEY>`
+- 查询参数：`?apikey=<API_KEY>`
+
+配置“APIKEY”后，`API_KEY` 必须使用插件中配置的 Key；留空时使用 MoviePilot 公共 `API_TOKEN`。两种模式使用相同的请求头和查询参数名称。
+
+`POST` 请求头使用 `Content-Type: application/json`，请求体格式如下：
+
+```json
+{
+  "title": "路由故障",
+  "body": "主线路连续 3 次探测失败"
+}
+```
+
+`title` 和 `body` 均为可选字段，但至少需要提供一项非空内容；`title` 最长 200 个字符，`body` 最长 10000 个字符。`GET` 请求使用同名查询参数。接口成功接收后返回：
+
+```json
+{
+  "success": true,
+  "message": "通知已提交",
+  "data": {}
+}
+```
+
+`POST` 示例：
+
+```bash
+curl -X POST \
+  "https://moviepilot.example.com/api/v1/plugin/WebhookNotify/webhook" \
+  -H "X-API-KEY: WEBHOOK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"路由故障","body":"主线路连续 3 次探测失败"}'
+```
+
+仅发送正文的 `GET` 示例：
+
+```bash
+curl --get \
+  "https://moviepilot.example.com/api/v1/plugin/WebhookNotify/webhook" \
+  --data-urlencode "apikey=WEBHOOK_API_KEY" \
+  --data-urlencode "body=主线路连续 3 次探测失败"
+```
+
+## 配置说明
+
+| 配置项 | 标识 | 类型 | 默认值 | 说明 | 备注 |
+| --- | --- | --- | --- | --- | --- |
+| 启用插件 | `enabled` | bool | `false` | 是否接收入站 Webhook | 停用时接口返回 `503` |
+| [消息类型](#cfg-notify_type) | `notify_type` | enum | `Plugin`（插件） | 设置通知分类和渠道过滤类型 | 调用方不能通过 Webhook 覆盖 |
+| [APIKEY](#cfg-api_key) | `api_key` | string | 空 | 设置 Webhook 专用凭据 | 留空时使用主程序公共 `API_TOKEN` |
+
+## 深入说明
+
+<a id="cfg-notify_type"></a>
+#### 消息类型（`notify_type`）
+
+MoviePilot 的通知渠道可分别选择接收哪些消息类型。Webhook 消息会使用这里选择的类型进入通知链，只有允许该类型的渠道才会向客户端推送；该配置不改变标题或正文内容。
+
+可选值为：`Download`（资源下载）、`Organize`（整理入库）、`Subscribe`（订阅）、`SiteMessage`（站点）、`MediaServer`（媒体服务器）、`Manual`（手动处理）、`Plugin`（插件）、`Agent`（智能体）和 `Other`（其它）。默认使用 `Plugin`（插件）；配置缺失或不是有效枚举值时同样按“插件”处理。
+
+<a id="cfg-api_key"></a>
+#### APIKEY（`api_key`）
+
+配置后，Webhook 只接受该独立 Key，不再接受 MoviePilot 公共 `API_TOKEN`。外部监控系统仍通过 `X-API-KEY` 请求头或 `apikey` 查询参数传递凭据。留空时由主程序使用同样的入口校验公共 `API_TOKEN`。
+
+建议使用足够长的随机字符串，并优先通过 `X-API-KEY` 请求头传递，避免查询参数被反向代理访问日志记录。独立 Key 泄露后只需在插件配置中轮换，不影响 MoviePilot 的其他公共 API。
+
+## 使用步骤
+
+1. 在插件市场安装并启用 Webhook消息推送。
+2. 选择消息类型，并确认 MoviePilot 中至少有一个已启用通知渠道允许接收该类型。
+3. 建议配置 APIKEY，并在调用方中通过 `X-API-KEY` 请求头传递；未配置时使用 MoviePilot 公共 `API_TOKEN`。
+4. 使用 `GET` 查询参数或 `POST` JSON 发送通知，`title` 和 `body` 至少提供一项，确认客户端收到通知。
+
+## 注意事项 / 已知风险
+
+- 独立 API Key 和公共 `API_TOKEN` 都属于敏感凭据，请通过 HTTPS 传输；优先使用请求头，避免凭据进入 URL 日志。
+- 插件只负责提交通知，不会为重复请求做去重；健康监测的失败阈值、恢复判定和重试策略由调用方负责。
+- 消息是否实际发送仍受 MoviePilot 通知渠道配置和所选消息类型开关影响。
+
+## 故障排查
+
+- 插件请求日志位于 `/config/logs/plugins/webhooknotify.log`，记录请求方式、消息类型以及标题、正文是否存在，不记录 API Key 或消息内容。
+- 返回 `401`：已配置独立 API Key 时检查插件 Key；未配置时检查 MoviePilot 公共 `API_TOKEN`。凭据应通过 `X-API-KEY` 或 `apikey` 传递。
+- 返回 `422`：检查参数长度、JSON 格式，并确认 `title`、`body` 至少有一项为非空字符串。
+- 返回 `503`：插件在 WebUI 中处于停用状态。
+- 接口返回成功但客户端无消息：检查通知渠道是否启用，以及是否允许接收插件配置的消息类型。

--- a/plugins.v3/webhooknotify/__init__.py
+++ b/plugins.v3/webhooknotify/__init__.py
@@ -1,0 +1,280 @@
+"""通过 Webhook 接收外部消息并提交到 MoviePilot 通知链。"""
+
+from __future__ import annotations
+
+from secrets import compare_digest
+from typing import Annotated, Any
+
+from fastapi import Depends, HTTPException, Query, Security, status
+from pydantic import BaseModel, Field, model_validator
+
+from app.plugins import _PluginBase
+from app.schemas.message import Message
+from app.schemas.response import Response
+from app.schemas.types import MessageType
+from app.sdk.logging import logger
+from app.sdk.security import api_key_header, api_key_query
+
+
+class WebhookNotifyPayload(BaseModel):
+    """外部 Webhook 通知的消息载荷。"""
+
+    # 标题和正文均可单独发送，避免调用方为缺失字段构造无意义占位文本。
+    title: str | None = Field(default=None, max_length=200)
+    body: str | None = Field(default=None, max_length=10000)
+
+    @model_validator(mode="after")
+    def validate_message(self) -> "WebhookNotifyPayload":
+        """把纯空白字段视为缺失，并保证通知至少包含一项可见内容。"""
+        if self.title is not None and not self.title.strip():
+            self.title = None
+        if self.body is not None and not self.body.strip():
+            self.body = None
+        if self.title is None and self.body is None:
+            raise ValueError("title 和 body 至少提供一项")
+        return self
+
+
+class WebhookNotify(_PluginBase):
+    """接收入站 Webhook，并转发到 MoviePilot 已配置的通知渠道。"""
+
+    plugin_name = "Webhook消息推送"
+    plugin_desc = "接收 Webhook 消息并推送到通知客户端。"
+    plugin_icon = (
+        "https://raw.githubusercontent.com/InfinityPacer/"
+        "MoviePilot-Plugins/main/icons/webhooknotify.png"
+    )
+    plugin_version = "2.0.0"
+    plugin_author = "InfinityPacer"
+    author_url = "https://github.com/InfinityPacer"
+    plugin_config_prefix = "webhooknotify_"
+    plugin_order = 999
+    auth_level = 1
+
+    _enabled = False
+    # MoviePilot 通知渠道按消息类型过滤，默认使用专用的插件分类。
+    _notify_type = MessageType.Plugin
+    _api_key = ""
+
+    def init_plugin(self, config: dict | None = None) -> None:
+        """加载插件开关、消息类型和可选的独立 API Key。"""
+        config = config or {}
+        self._enabled = bool(config.get("enabled", False))
+        notify_type = config.get("notify_type", MessageType.Plugin.name)
+        self._notify_type = (
+            MessageType.__members__.get(notify_type, MessageType.Plugin)
+            if isinstance(notify_type, str)
+            else MessageType.Plugin
+        )
+        api_key = config.get("api_key")
+        self._api_key = api_key.strip() if isinstance(api_key, str) else ""
+
+    def get_state(self) -> bool:
+        """返回 Webhook 接收能力是否启用。"""
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> list[dict[str, Any]]:
+        """Webhook 通知没有需要注册到聊天客户端的命令。"""
+        return []
+
+    def get_api(self) -> list[dict[str, Any]]:
+        """按独立 Key 配置状态注册对应的入站认证方式。"""
+        use_plugin_key = bool(self._api_key)
+        dependencies = [Depends(self._verify_api_key)] if use_plugin_key else []
+        return [
+            {
+                "path": "/webhook",
+                "endpoint": self.receive_webhook,
+                "methods": ["POST"],
+                "auth": "apikey",
+                "allow_anonymous": use_plugin_key,
+                "dependencies": dependencies.copy(),
+                "response_model": Response,
+                "summary": "接收 Webhook JSON 通知",
+                "description": "使用 API Key 接收 JSON；title 和 body 至少提供一项。",
+            },
+            {
+                "path": "/webhook",
+                "endpoint": self.receive_webhook_get,
+                "methods": ["GET"],
+                "auth": "apikey",
+                "allow_anonymous": use_plugin_key,
+                "dependencies": dependencies.copy(),
+                "response_model": Response,
+                "summary": "接收 Webhook 查询通知",
+                "description": "使用 API Key 接收查询参数；title 和 body 至少提供一项。",
+            },
+        ]
+
+    def get_form(self) -> tuple[list[dict], dict[str, Any]]:
+        """展示启用开关、消息类型和入站请求约定。"""
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 4},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "enabled",
+                                            "label": "启用插件",
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "model": "notify_type",
+                                            "label": "消息类型",
+                                            "items": [
+                                                {"title": item.value, "value": item.name}
+                                                for item in MessageType
+                                            ],
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VTextField",
+                                        "props": {
+                                            "model": "api_key",
+                                            "label": "APIKEY",
+                                            "type": "password",
+                                            "placeholder": "留空则使用主程序 API Token",
+                                            "clearable": True,
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VAlert",
+                                        "props": {
+                                            "type": "info",
+                                            "variant": "tonal",
+                                            "text": (
+                                                "GET/POST /api/v1/plugin/"
+                                                "WebhookNotify/webhook，使用 X-API-KEY "
+                                                "或 apikey 认证，title 和 body 至少提供一项。"
+                                            ),
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "notify_type": MessageType.Plugin.name,
+            "api_key": "",
+        }
+
+    def get_page(self) -> None:
+        """保持空钩子，使宿主不声明详情页能力。"""
+        pass
+
+    def stop_service(self) -> None:
+        """Webhook消息推送没有后台服务需要停止。"""
+
+    def receive_webhook(self, payload: WebhookNotifyPayload) -> Response:
+        """接收 POST JSON，并把外部消息交给 MoviePilot 通知链。"""
+        return self._post_notification(payload, request_method="POST")
+
+    def receive_webhook_get(
+        self,
+        title: Annotated[str | None, Query(max_length=200)] = None,
+        body: Annotated[str | None, Query(max_length=10000)] = None,
+    ) -> Response:
+        """接收 GET 查询参数，并把外部消息交给 MoviePilot 通知链。"""
+        if not ((title and title.strip()) or (body and body.strip())):
+            raise HTTPException(
+                status_code=422,
+                detail="title 和 body 至少提供一项",
+            )
+        return self._post_notification(
+            WebhookNotifyPayload(title=title, body=body),
+            request_method="GET",
+        )
+
+    def _verify_api_key(
+        self,
+        key_query: Annotated[str | None, Security(api_key_query)] = None,
+        key_header: Annotated[str | None, Security(api_key_header)] = None,
+    ) -> str:
+        """校验插件独立 Key。"""
+        supplied_key = key_header or key_query
+        if (
+            not supplied_key
+            or not self._api_key
+            or not compare_digest(supplied_key, self._api_key)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="API Key 校验不通过",
+            )
+        return supplied_key
+
+    def _post_notification(
+        self,
+        payload: WebhookNotifyPayload,
+        request_method: str,
+    ) -> Response:
+        """执行统一的启用状态检查和通知提交。"""
+        if not self._enabled:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Webhook消息推送插件未启用",
+            )
+
+        logger.info(
+            "接收 %s Webhook 消息，消息类型：%s，包含标题：%s，包含正文：%s",
+            request_method,
+            self._notify_type.value,
+            bool(payload.title),
+            bool(payload.body),
+        )
+        self.chain.post_message(
+            Message(
+                mtype=self._notify_type,
+                title=payload.title,
+                text=payload.body,
+            )
+        )
+        logger.info("%s Webhook 消息已提交到 MoviePilot 通知链", request_method)
+        return Response(success=True, message="通知已提交", data={})

--- a/tests/v3/commands/test_commands.py
+++ b/tests/v3/commands/test_commands.py
@@ -1,0 +1,250 @@
+"""Commands 的配置、事件和生命周期合同测试。"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from app.plugins.commands import Commands
+from app.runtime.extensions.plugin.contracts import supports_plugin_hook
+from app.schemas.event import CommandRegisterEventData
+from app.schemas.types import ChainEventType
+from app.sdk.events import Event
+
+
+def _plugin(
+    *,
+    notify_clients=None,
+    custom_commands=None,
+    services=None,
+    notify_helper=None,
+) -> Commands:
+    """构造不依赖完整插件 Runtime 的纯逻辑实例。"""
+    plugin = object.__new__(Commands)
+    plugin.notify_helper = notify_helper or MagicMock()
+    plugin._enabled = True
+    plugin._notify_clients = list(notify_clients or [])
+    plugin._custom_commands = custom_commands or {}
+    plugin.notify_helper.get_services.return_value = services or {}
+    return plugin
+
+
+def _event(*, origin="WeChat", service="Telegram", commands=None, cancel=False):
+    """构造经过宿主事件合同校验的命令注册事件。"""
+    payload = CommandRegisterEventData(
+        commands=commands or {},
+        origin=origin,
+        service=service,
+        cancel=cancel,
+    )
+    return Event(ChainEventType.CommandRegister, payload)
+
+
+def test_v3_source_uses_sdk_boundaries_and_public_command_schema():
+    """Commands V3 实现仅从 SDK 获取事件、通知服务和日志入口。"""
+    source = (
+        Path(__file__).parents[3] / "plugins.v3" / "commands" / "__init__.py"
+    ).read_text(encoding="utf-8")
+
+    assert "from app.sdk.events import Event, eventmanager" in source
+    assert "from app.sdk.logging import logger" in source
+    assert "from app.sdk.services import NotificationHelper" in source
+    assert "from app.schemas.event import CommandRegisterEventData" in source
+    assert "from app.schemas.types import ChainEventType" in source
+    for legacy_prefix in (
+        "from app.compat",
+        "from app.core",
+        "from app.helper",
+        "from app.log",
+        "from app.db",
+    ):
+        assert legacy_prefix not in source
+
+
+def test_init_plugin_parses_json_and_resets_state(monkeypatch):
+    """重载时应解析 JSON 菜单并清理上一次实例遗留的选择。"""
+    helper = MagicMock()
+    monkeypatch.setattr("app.plugins.commands.NotificationHelper", lambda: helper)
+    plugin = object.__new__(Commands)
+
+    plugin.init_plugin(
+        {
+            "enabled": 1,
+            "notify_clients": ("Telegram", "WeChat"),
+            "custom_commands": json.dumps(
+                {"Telegram": {"/sites": {"category": "站点"}}}
+            ),
+        }
+    )
+
+    assert plugin.get_state() is True
+    assert plugin._notify_clients == ["Telegram", "WeChat"]
+    assert plugin._custom_commands == {
+        "Telegram": {"/sites": {"category": "站点"}}
+    }
+
+    plugin.init_plugin({"enabled": False, "custom_commands": "{"})
+
+    assert plugin.get_state() is False
+    assert plugin._notify_clients == []
+    assert plugin._custom_commands == {}
+    assert helper is plugin.notify_helper
+
+
+def test_service_infos_filters_selected_notification_clients():
+    """通知服务查询必须把用户选择的客户端名称传给 SDK。"""
+    helper = MagicMock()
+    services = {"Telegram": object()}
+    plugin = _plugin(
+        notify_clients=["Telegram", "WeChat"],
+        services=services,
+        notify_helper=helper,
+    )
+
+    assert plugin.service_infos == services
+    helper.get_services.assert_called_once_with(
+        name_filters=["Telegram", "WeChat"]
+    )
+
+
+def test_command_chain_origin_persists_preset_commands_without_intercepting():
+    """CommandChain 来源只更新预置命令快照，不拦截事件。"""
+    plugin = _plugin(notify_clients=[])
+    plugin.get_config = MagicMock(return_value={"enabled": True})
+    plugin.update_config = MagicMock()
+    commands = {"/sites": {"category": "站点", "description": "查询站点"}}
+    event = _event(origin="CommandChain", commands=commands)
+
+    plugin.handle_command_register(event)
+
+    plugin.get_config.assert_called_once_with()
+    plugin.update_config.assert_called_once_with(
+        config={
+            "enabled": True,
+            "preset_commands": json.dumps(commands, indent=4, ensure_ascii=False),
+        }
+    )
+    assert event.event_data.cancel is False
+
+
+def test_unsupported_origin_is_passed_through():
+    """非微信和 Telegram 来源保持原始事件，不触发客户端筛选。"""
+    helper = MagicMock()
+    plugin = _plugin(
+        notify_clients=["Telegram"],
+        notify_helper=helper,
+        services={"Telegram": object()},
+    )
+    event = _event(origin="Slack", commands={"/sites": {"category": "站点"}})
+
+    plugin.handle_command_register(event)
+
+    assert event.event_data.cancel is False
+    assert event.event_data.source == "未知拦截源"
+    helper.get_services.assert_not_called()
+
+
+def test_unselected_notification_client_is_intercepted():
+    """未选中的通知客户端必须取消命令注册，避免泄漏完整菜单。"""
+    plugin = _plugin(notify_clients=["Telegram"], services={})
+    event = _event(origin="WeChat", service="WeChat")
+
+    plugin.handle_command_register(event)
+
+    assert event.event_data.cancel is True
+    assert event.event_data.source == plugin.plugin_name
+
+
+def test_selected_client_is_allowed_and_commands_are_pruned_and_overridden():
+    """选中客户端仅保留自定义命令，并覆盖允许声明的菜单字段。"""
+    plugin = _plugin(
+        notify_clients=["Telegram"],
+        services={"Telegram": object()},
+        custom_commands={
+            "Telegram": {
+                "/sites": {"category": "自定义站点"},
+            }
+        },
+    )
+    commands = {
+        "/sites": {
+            "category": "站点",
+            "description": "查询站点",
+            "event": "sites",
+        },
+        "/version": {
+            "category": "管理",
+            "description": "当前版本",
+            "event": "version",
+        },
+    }
+    event = _event(origin="Telegram", service="Telegram", commands=commands)
+
+    plugin.handle_command_register(event)
+
+    assert event.event_data.cancel is False
+    assert event.event_data.source == plugin.plugin_name
+    assert event.event_data.commands == {
+        "/sites": {
+            "category": "自定义站点",
+            "description": "查询站点",
+            "event": "sites",
+        }
+    }
+
+
+def test_selected_client_without_custom_commands_is_allowed_unchanged():
+    """客户端已选中但没有自定义菜单时，保留宿主预置命令。"""
+    plugin = _plugin(
+        notify_clients=["Telegram"],
+        services={"Telegram": object()},
+    )
+    commands = {"/sites": {"category": "站点", "description": "查询站点"}}
+    event = _event(origin="Telegram", service="Telegram", commands=commands)
+
+    plugin.handle_command_register(event)
+
+    assert event.event_data.cancel is False
+    assert event.event_data.commands == commands
+
+
+def test_already_cancelled_event_is_not_modified():
+    """已被其他处理器取消的事件必须保持原状态并跳过客户端查询。"""
+    helper = MagicMock()
+    plugin = _plugin(
+        notify_clients=["Telegram"],
+        notify_helper=helper,
+        services={"Telegram": object()},
+    )
+    event = _event(origin="Telegram", service="Telegram", cancel=True)
+
+    plugin.handle_command_register(event)
+
+    assert event.event_data.cancel is True
+    assert event.event_data.source == "未知拦截源"
+    helper.get_services.assert_not_called()
+
+
+def test_lifecycle_and_empty_capabilities_contract(monkeypatch):
+    """插件生命周期与无自有命令、API、页面和服务的声明保持稳定。"""
+    helper = MagicMock()
+    monkeypatch.setattr("app.plugins.commands.NotificationHelper", lambda: helper)
+    plugin = object.__new__(Commands)
+
+    plugin.init_plugin()
+
+    assert plugin.get_state() is False
+    assert plugin.get_command() == []
+    assert plugin.get_api() == []
+    assert plugin.get_page() is None
+    assert supports_plugin_hook(plugin, "get_page") is False
+    assert plugin.get_service() == []
+    plugin.stop_service()
+
+
+def test_default_form_commands_are_valid_json():
+    """配置表单提供的预置示例必须可直接解析。"""
+    plugin = _plugin()
+    _form, defaults = plugin.get_form()
+
+    assert defaults["enabled"] is False
+    assert json.loads(defaults["custom_commands"])["通知渠道1"]["/sites"]

--- a/tests/v3/plexrefreshrecent/test_plexrefreshrecent.py
+++ b/tests/v3/plexrefreshrecent/test_plexrefreshrecent.py
@@ -1,0 +1,311 @@
+"""PlexRefreshRecent V3 的服务、刷新和生命周期合同测试。"""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import app.plugins.plexrefreshrecent as plexrefreshrecent
+from app.runtime.extensions.plugin.contracts import supports_plugin_hook
+
+
+PLUGIN = plexrefreshrecent.PlexRefreshRecent
+
+
+def _plugin(*, enabled: bool = True, force: bool = False) -> PLUGIN:
+    """构造不依赖真实服务目录的插件实例。"""
+    plugin = object.__new__(PLUGIN)
+    plugin.mediaserver_helper = MagicMock()
+    plugin._enabled = enabled
+    plugin._cron = "0 */3 * * *"
+    plugin._offset_days = 3
+    plugin._onlyonce = False
+    plugin._notify = False
+    plugin._limit = 1000
+    plugin._force = force
+    plugin._mediaservers = ["Plex A"]
+    plugin._scheduler = None
+    plugin._event.clear()
+    return plugin
+
+
+def _item(
+        key: str,
+        *,
+        item_type: str = "episode",
+        summary: str = "",
+        parent: str | None = None,
+        grandparent: str | None = None,
+        title: str | None = None,
+) -> SimpleNamespace:
+    """构造带 Plex 外部对象字段的媒体项。"""
+    return SimpleNamespace(
+        ratingKey=key,
+        parentRatingKey=parent,
+        grandparentRatingKey=grandparent,
+        summary=summary,
+        parentTitle="Season 1" if parent else None,
+        grandparentTitle="Show" if grandparent else None,
+        title=title or key,
+        type=item_type,
+        TYPE=item_type,
+        refresh=MagicMock(),
+    )
+
+
+def _service(name: str, items=None, *, inactive: bool = False) -> SimpleNamespace:
+    """构造媒体服务信息及 Plex library 查询对象。"""
+    plex = SimpleNamespace(
+        library=SimpleNamespace(search=MagicMock(return_value=items or []))
+    )
+    instance = SimpleNamespace(
+        is_inactive=MagicMock(return_value=inactive),
+        get_plex=MagicMock(return_value=plex),
+    )
+    return SimpleNamespace(name=name, instance=instance, type="plex")
+
+
+def test_v3_entry_uses_sdk_boundaries_and_version() -> None:
+    """V3 插件入口应只通过公开 SDK 访问配置、事件、日志和媒体服务。"""
+    source_path = Path(__file__).parents[3] / "plugins.v3" / "plexrefreshrecent" / "__init__.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+    assert PLUGIN.plugin_version == "2.0.0"
+    assert "app.sdk.config" in imported_modules
+    assert "app.sdk.events" in imported_modules
+    assert "app.sdk.logging" in imported_modules
+    assert "app.sdk.services" in imported_modules
+    assert "NotificationType" not in source_path.read_text(encoding="utf-8")
+    assert not any(
+        module.startswith(("app.compat", "app.core", "app.db", "app.helper", "app.log"))
+        for module in imported_modules
+    )
+
+
+def test_service_infos_filters_selected_plex_services_and_drops_inactive() -> None:
+    """只保留选中的已连接 Plex 服务，非 Plex/未连接项由服务端口过滤或丢弃。"""
+    plugin = _plugin()
+    active = _service("Plex A")
+    inactive = _service("Plex B", inactive=True)
+    plugin.mediaserver_helper.get_services.return_value = {
+        "Plex A": active,
+        "Plex B": inactive,
+    }
+
+    result = plugin.service_infos()
+
+    assert result == {"Plex A": active}
+    plugin.mediaserver_helper.get_services.assert_called_once_with(
+        name_filters=["Plex A"],
+        type_filter="plex",
+    )
+
+
+def test_service_infos_returns_none_without_selection_or_active_service() -> None:
+    """没有选择媒体服务器或没有可用实例时不执行远端刷新。"""
+    plugin = _plugin()
+    plugin._mediaservers = []
+    assert plugin.service_infos() is None
+    plugin._mediaservers = ["Plex A"]
+    plugin.mediaserver_helper.get_services.return_value = {
+        "Plex A": _service("Plex A", inactive=True),
+    }
+    assert plugin.service_infos() is None
+
+
+def test_refresh_queries_time_window_and_counts_each_item_once(monkeypatch) -> None:
+    """查询使用配置的时间窗口和上限，多个服务的刷新计数不重复累加。"""
+    plugin = _plugin()
+    plugin._mediaservers = ["Plex A", "Plex B"]
+    first_items = [_item("1"), _item("2", parent="1")]
+    second_items = [_item("3", summary="已有摘要"), _item("4")]
+    first = _service("Plex A", first_items)
+    second = _service("Plex B", second_items)
+    plugin.mediaserver_helper.get_services.return_value = {
+        "Plex A": first,
+        "Plex B": second,
+    }
+    monkeypatch.setattr(
+        PLUGIN,
+        "_PlexRefreshRecent__get_timestamp",
+        staticmethod(lambda offset_day: 123456),
+    )
+
+    success, count = plugin._PlexRefreshRecent__refresh_plex()
+
+    assert (success, count) == (True, 2)
+    first.instance.get_plex.return_value.library.search.assert_called_once_with(
+        limit=1000,
+        **{"addedAt>": 123456},
+    )
+    second.instance.get_plex.return_value.library.search.assert_called_once_with(
+        limit=1000,
+        **{"addedAt>": 123456},
+    )
+    first_items[0].refresh.assert_called_once_with()
+    first_items[1].refresh.assert_not_called()
+    second_items[0].refresh.assert_not_called()
+    second_items[1].refresh.assert_called_once_with()
+
+
+def test_refresh_metadata_honors_force_summary_and_season_rules() -> None:
+    """非强制模式跳过已有摘要，强制模式刷新；season 始终不直接请求刷新。"""
+    plugin = _plugin(force=False)
+    with_summary = _item("1", summary="已有摘要")
+    without_summary = _item("2")
+    season = _item("3", item_type="season")
+    refreshed = {}
+
+    for item in (with_summary, without_summary, season):
+        plugin._PlexRefreshRecent__refresh_metadata(item, refreshed)
+
+    with_summary.refresh.assert_not_called()
+    without_summary.refresh.assert_called_once_with()
+    season.refresh.assert_not_called()
+    assert refreshed == {"2": True}
+
+    forced = _plugin(force=True)
+    forced_item = _item("4", summary="已有摘要")
+    forced._PlexRefreshRecent__refresh_metadata(forced_item, refreshed)
+    forced_item.refresh.assert_called_once_with()
+    assert refreshed["4"] is True
+
+
+def test_refresh_metadata_deduplicates_parent_and_grandparent() -> None:
+    """同一媒体树中已刷新的当前项、父项或祖父项均阻止后续重复请求。"""
+    plugin = _plugin()
+    refreshed = {}
+    root = _item("root")
+    child = _item("child", parent="root")
+    grandchild = _item("grandchild", grandparent="root")
+    plugin._PlexRefreshRecent__refresh_metadata(root, refreshed)
+    plugin._PlexRefreshRecent__refresh_metadata(child, refreshed)
+    plugin._PlexRefreshRecent__refresh_metadata(grandchild, refreshed)
+
+    root.refresh.assert_called_once_with()
+    child.refresh.assert_not_called()
+    grandchild.refresh.assert_not_called()
+    assert refreshed == {"root": True}
+
+
+def test_refresh_isolates_item_and_service_exceptions() -> None:
+    """单个媒体项或某个服务失败时继续处理其它工作，并保留已成功计数。"""
+    plugin = _plugin()
+    failed_item = _item("failed")
+    failed_item.refresh.side_effect = RuntimeError("refresh failed")
+    good_item = _item("good")
+    failing_service = _service("Plex A", [failed_item, good_item])
+    healthy_item = _item("healthy")
+    healthy_service = _service("Plex B", [healthy_item])
+    failing_search = _service("Plex C")
+    failing_search.instance.get_plex.return_value.library.search.side_effect = RuntimeError(
+        "search failed"
+    )
+    plugin._mediaservers = ["Plex A", "Plex B", "Plex C"]
+    plugin.mediaserver_helper.get_services.return_value = {
+        "Plex A": failing_service,
+        "Plex B": healthy_service,
+        "Plex C": failing_search,
+    }
+
+    success, count = plugin._PlexRefreshRecent__refresh_plex()
+
+    assert (success, count) == (True, 2)
+    failed_item.refresh.assert_called_once_with()
+    good_item.refresh.assert_called_once_with()
+    healthy_item.refresh.assert_called_once_with()
+
+
+def test_refresh_recent_accepts_only_declared_action_and_posts_summary() -> None:
+    """事件入口过滤远程命令，成功执行后按配置发送摘要通知。"""
+    plugin = _plugin()
+    plugin._notify = True
+    plugin._PlexRefreshRecent__check_plex_media_server = MagicMock(return_value=True)
+    plugin._PlexRefreshRecent__refresh_plex = MagicMock(return_value=(True, 7))
+    plugin.post_message = MagicMock()
+
+    plugin.refresh_recent(SimpleNamespace(event_data={"action": "other"}))
+    plugin._PlexRefreshRecent__refresh_plex.assert_not_called()
+
+    plugin.refresh_recent(
+        SimpleNamespace(event_data={"action": "refresh_plex_recent_event"})
+    )
+    plugin._PlexRefreshRecent__refresh_plex.assert_called_once_with()
+    plugin.post_message.assert_called_once_with(
+        mtype=plexrefreshrecent.MessageType.SiteMessage,
+        title="【Plex最近3天元数据刷新】",
+        text="元数据刷新完成，刷新条数：7",
+    )
+
+
+def test_init_plugin_schedules_onlyonce_and_stop_releases_scheduler(monkeypatch) -> None:
+    """配置重载先停止旧调度器，一次性任务加入后启动，并可再次停止。"""
+    plugin = _plugin(enabled=False)
+    plugin._scheduler = None
+    helper = MagicMock()
+    scheduler = MagicMock()
+    scheduler.get_jobs.side_effect = [["job"], ["job"]]
+    scheduler.running = False
+    monkeypatch.setattr(plexrefreshrecent, "MediaServerHelper", MagicMock(return_value=helper))
+    monkeypatch.setattr(plexrefreshrecent, "BackgroundScheduler", MagicMock(return_value=scheduler))
+    plugin.update_config = MagicMock()
+
+    plugin.init_plugin(
+        {
+            "enabled": True,
+            "notify": True,
+            "onlyonce": True,
+            "force": True,
+            "cron": "0 8 * * *",
+            "offset_days": "2",
+            "limit": "25",
+            "mediaservers": ["Plex A"],
+        }
+    )
+
+    assert plugin.get_state() is True
+    scheduler.add_job.assert_called_once()
+    assert scheduler.add_job.call_args.kwargs["trigger"] == "date"
+    scheduler.start.assert_called_once_with()
+    plugin.update_config.assert_called_once_with(
+        {
+            "onlyonce": False,
+            "cron": "0 8 * * *",
+            "enabled": True,
+            "offset_days": 2,
+            "notify": True,
+            "limit": 25,
+            "force": True,
+            "mediaservers": ["Plex A"],
+        }
+    )
+
+    plugin.stop_service()
+
+    scheduler.remove_all_jobs.assert_called_once_with()
+    assert plugin._scheduler is None
+
+
+def test_get_service_exposes_cron_registration_and_rejects_invalid_expression() -> None:
+    """周期服务通过宿主服务注册合同暴露，非法 cron 不应让插件加载失败。"""
+    plugin = _plugin()
+    services = plugin.get_service()
+    assert len(services) == 1
+    assert services[0]["id"] == "PlexRefreshRecent"
+    assert services[0]["func"] == plugin.refresh_recent
+
+    plugin._cron = "invalid"
+    assert plugin.get_service() == []
+
+
+def test_empty_api_and_page_capability_are_explicit() -> None:
+    """没有扩展 API 或详情页时不向宿主声明对应能力。"""
+    plugin = _plugin()
+    assert plugin.get_api() == []
+    assert plugin.get_page() is None
+    assert supports_plugin_hook(plugin, "get_page") is False

--- a/tests/v3/webhooknotify/test_webhooknotify.py
+++ b/tests/v3/webhooknotify/test_webhooknotify.py
@@ -1,0 +1,322 @@
+"""WebhookNotify V3 的路由、鉴权与通知转发合同测试。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.plugins.webhooknotify import WebhookNotify, WebhookNotifyPayload
+from app.runtime.extensions.plugin.contracts import supports_plugin_hook
+from app.schemas.message import Message
+from app.schemas.response import Response
+from app.schemas.types import MessageType
+from app.sdk.config import settings
+from app.sdk.security import verify_apikey
+
+
+def _build_test_app(plugin: WebhookNotify) -> FastAPI:
+    """按 V3 插件 API 元数据注册最小 FastAPI 应用。"""
+    test_app = FastAPI()
+    for source_api in plugin.get_api():
+        api = source_api.copy()
+        path = api.pop("path")
+        auth = api.pop("auth")
+        allow_anonymous = api.pop("allow_anonymous")
+        dependencies = list(api.get("dependencies") or ())
+        if not allow_anonymous:
+            assert auth == "apikey"
+            dependencies.append(Depends(verify_apikey))
+        api["dependencies"] = dependencies
+        test_app.add_api_route(path, **api)
+    return test_app
+
+
+def _mock_notification_chain(plugin: WebhookNotify) -> MagicMock:
+    """替换通知链提交方法，便于检查最终 Message 合同。"""
+    post_message = MagicMock()
+    plugin.chain.post_message = post_message
+    return post_message
+
+
+def _assert_notification(
+    post_message: MagicMock,
+    *,
+    mtype: MessageType,
+    title: str | None = None,
+    text: str | None = None,
+) -> None:
+    """确认通知只包含 Webhook 提供的消息字段。"""
+    post_message.assert_called_once()
+    notification = post_message.call_args.args[0]
+    assert isinstance(notification, Message)
+    assert notification.mtype == mtype
+    assert notification.title == title
+    assert notification.text == text
+    assert notification.source is None
+    assert notification.link is None
+
+
+def test_payload_accepts_either_field_and_rejects_empty_message():
+    assert WebhookNotifyPayload(title="告警").body is None
+    assert WebhookNotifyPayload(body="故障").title is None
+    assert WebhookNotifyPayload(title="告警", body="故障").body == "故障"
+
+    with pytest.raises(ValidationError, match="title 和 body 至少提供一项"):
+        WebhookNotifyPayload()
+    with pytest.raises(ValidationError, match="title 和 body 至少提供一项"):
+        WebhookNotifyPayload(title=" ", body="\n")
+
+
+def test_api_uses_host_api_key_auth_without_plugin_key():
+    plugin = WebhookNotify()
+    plugin.init_plugin({"api_key": "   "})
+
+    api_definitions = plugin.get_api()
+
+    assert len(api_definitions) == 2
+    assert {tuple(api["methods"]) for api in api_definitions} == {
+        ("GET",),
+        ("POST",),
+    }
+    assert all(api["path"] == "/webhook" for api in api_definitions)
+    assert all(api["auth"] == "apikey" for api in api_definitions)
+    assert all(api["allow_anonymous"] is False for api in api_definitions)
+    assert all(api["dependencies"] == [] for api in api_definitions)
+    assert all(api["response_model"] is Response for api in api_definitions)
+
+
+def test_api_uses_plugin_key_dependency_when_configured():
+    plugin = WebhookNotify()
+    plugin.init_plugin({"api_key": "plugin-key"})
+
+    api_definitions = plugin.get_api()
+
+    assert all(api["auth"] == "apikey" for api in api_definitions)
+    assert all(api["allow_anonymous"] is True for api in api_definitions)
+    assert all(len(api["dependencies"]) == 1 for api in api_definitions)
+
+
+@pytest.mark.parametrize(
+    "request_kwargs",
+    [
+        {"headers": {"X-API-KEY": "moviepilot-key"}},
+        {"params": {"apikey": "moviepilot-key"}},
+    ],
+)
+def test_host_api_key_auth_accepts_public_api_token(monkeypatch, request_kwargs):
+    plugin = WebhookNotify()
+    plugin.init_plugin({"enabled": True})
+    post_message = _mock_notification_chain(plugin)
+    monkeypatch.setattr(settings, "API_TOKEN", "moviepilot-key")
+    client = TestClient(_build_test_app(plugin))
+
+    unauthorized = client.post("/webhook", json={"title": "未认证"})
+    authorized = client.post(
+        "/webhook",
+        json={"title": "路由故障", "body": "主线路不可达"},
+        **request_kwargs,
+    )
+
+    assert unauthorized.status_code == 401
+    assert authorized.status_code == 200
+    assert authorized.json() == {
+        "success": True,
+        "message": "通知已提交",
+        "data": {},
+    }
+    _assert_notification(
+        post_message,
+        mtype=MessageType.Plugin,
+        title="路由故障",
+        text="主线路不可达",
+    )
+
+
+@pytest.mark.parametrize(
+    "request_kwargs",
+    [
+        {"headers": {"X-API-KEY": "plugin-key"}},
+        {"params": {"apikey": "plugin-key"}},
+    ],
+)
+def test_plugin_api_key_replaces_public_api_token(monkeypatch, request_kwargs):
+    plugin = WebhookNotify()
+    plugin.init_plugin({"enabled": True, "api_key": "plugin-key"})
+    post_message = _mock_notification_chain(plugin)
+    monkeypatch.setattr(settings, "API_TOKEN", "moviepilot-key")
+    client = TestClient(_build_test_app(plugin))
+
+    missing = client.post("/webhook", json={"title": "独立认证"})
+    public_token = client.post(
+        "/webhook",
+        json={"title": "公共令牌"},
+        headers={"X-API-KEY": "moviepilot-key"},
+    )
+    wrong_header_overrides_query = client.post(
+        "/webhook?apikey=plugin-key",
+        json={"title": "错误头"},
+        headers={"X-API-KEY": "wrong-key"},
+    )
+    authorized = client.post(
+        "/webhook",
+        json={"title": "独立认证"},
+        **request_kwargs,
+    )
+
+    assert missing.status_code == 401
+    assert public_token.status_code == 401
+    assert wrong_header_overrides_query.status_code == 401
+    assert authorized.status_code == 200
+    _assert_notification(post_message, mtype=MessageType.Plugin, title="独立认证")
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_title", "expected_text"),
+    [
+        ({"title": "只有标题"}, "只有标题", None),
+        ({"body": "只有正文"}, None, "只有正文"),
+    ],
+)
+def test_post_accepts_title_or_body(
+    monkeypatch,
+    payload: dict[str, str],
+    expected_title: str | None,
+    expected_text: str | None,
+):
+    plugin = WebhookNotify()
+    plugin.init_plugin({"enabled": True})
+    post_message = _mock_notification_chain(plugin)
+    monkeypatch.setattr(settings, "API_TOKEN", "unit-test-token")
+    client = TestClient(_build_test_app(plugin))
+
+    response = client.post(
+        "/webhook?apikey=unit-test-token",
+        json=payload,
+    )
+
+    assert response.status_code == 200
+    _assert_notification(
+        post_message,
+        mtype=MessageType.Plugin,
+        title=expected_title,
+        text=expected_text,
+    )
+
+
+@pytest.mark.parametrize(
+    ("params", "expected_title", "expected_text"),
+    [
+        ({"title": "只有标题"}, "只有标题", None),
+        ({"body": "只有正文"}, None, "只有正文"),
+    ],
+)
+def test_get_accepts_title_or_body(
+    monkeypatch,
+    params: dict[str, str],
+    expected_title: str | None,
+    expected_text: str | None,
+):
+    plugin = WebhookNotify()
+    plugin.init_plugin({"enabled": True})
+    post_message = _mock_notification_chain(plugin)
+    monkeypatch.setattr(settings, "API_TOKEN", "unit-test-token")
+    client = TestClient(_build_test_app(plugin))
+    params["apikey"] = "unit-test-token"
+
+    response = client.get("/webhook", params=params)
+
+    assert response.status_code == 200
+    _assert_notification(
+        post_message,
+        mtype=MessageType.Plugin,
+        title=expected_title,
+        text=expected_text,
+    )
+
+
+def test_get_and_post_reject_missing_content(monkeypatch):
+    plugin = WebhookNotify()
+    plugin.init_plugin({"enabled": True})
+    post_message = _mock_notification_chain(plugin)
+    monkeypatch.setattr(settings, "API_TOKEN", "unit-test-token")
+    client = TestClient(_build_test_app(plugin))
+
+    post_response = client.post("/webhook?apikey=unit-test-token", json={})
+    get_response = client.get("/webhook?apikey=unit-test-token")
+
+    assert post_response.status_code == 422
+    assert get_response.status_code == 422
+    post_message.assert_not_called()
+
+
+def test_disabled_plugin_returns_service_unavailable(monkeypatch):
+    plugin = WebhookNotify()
+    post_message = _mock_notification_chain(plugin)
+    monkeypatch.setattr(settings, "API_TOKEN", "unit-test-token")
+    client = TestClient(_build_test_app(plugin))
+
+    response = client.post(
+        "/webhook?apikey=unit-test-token",
+        json={"title": "标题"},
+    )
+
+    assert plugin.get_state() is False
+    assert response.status_code == 503
+    post_message.assert_not_called()
+
+
+def test_configured_message_type_is_forwarded_or_defaults_to_plugin():
+    plugin = WebhookNotify()
+    plugin.init_plugin({"enabled": True, "notify_type": "Manual"})
+    post_message = _mock_notification_chain(plugin)
+
+    response = plugin.receive_webhook(WebhookNotifyPayload(title="标题"))
+
+    assert response.success is True
+    _assert_notification(post_message, mtype=MessageType.Manual, title="标题")
+
+    plugin.init_plugin({"enabled": True, "notify_type": "invalid"})
+    post_message.reset_mock()
+    response = plugin.receive_webhook(WebhookNotifyPayload(title="标题"))
+
+    assert response.success is True
+    _assert_notification(post_message, mtype=MessageType.Plugin, title="标题")
+
+
+def test_form_and_lifecycle_defaults():
+    plugin = WebhookNotify()
+
+    assert plugin.get_state() is False
+    assert plugin.get_command() == []
+    assert plugin.get_page() is None
+    assert supports_plugin_hook(plugin, "get_page") is False
+    _, defaults = plugin.get_form()
+    assert defaults == {
+        "enabled": False,
+        "notify_type": MessageType.Plugin.name,
+        "api_key": "",
+    }
+
+
+def test_logging_does_not_include_message_or_key(monkeypatch):
+    plugin = WebhookNotify()
+    plugin.init_plugin({"enabled": True, "api_key": "unit-test-token"})
+    _mock_notification_chain(plugin)
+    log_info = MagicMock()
+    monkeypatch.setattr("app.plugins.webhooknotify.logger.info", log_info)
+
+    response = plugin.receive_webhook(
+        WebhookNotifyPayload(title="敏感标题", body="敏感正文")
+    )
+
+    assert response.success is True
+    logged_values = " ".join(
+        str(value)
+        for call in log_info.call_args_list
+        for value in (*call.args, *call.kwargs.values())
+    )
+    assert "敏感标题" not in logged_values
+    assert "敏感正文" not in logged_values
+    assert "unit-test-token" not in logged_values


### PR DESCRIPTION
## 目标

将 WebhookNotify、PlexRefreshRecent 和 Commands 从 V2 fallback 迁移为 V3 专用实现，统一发布为 2.0.0，并阻止 V3 继续回退加载旧实现。

## 主要变更

- 新增三个 `plugins.v3` 实现，并在 `package.v3.json` 声明 `system_version >=3.0.0`、版本和发布说明；对应 V2 条目仅增加 `v3:false`。
- WebhookNotify 改用公开安全、日志、消息与响应合同，保留独立 API Key/公共 API Token、GET/POST、`data: {}` 成功响应和通知转发行为。
- PlexRefreshRecent 改用公开配置、事件、日志和媒体服务 SDK，保留 Plex 业务对象操作，修正多服务刷新计数并隔离单项、单服务异常。
- Commands 改用公开事件、通知服务和日志 SDK，保留命令快照、客户端筛选、菜单裁剪与覆盖行为。
- 仅同步 WebhookNotify 原有插件 README；Commands 和 PlexRefreshRecent 不新增 README，仓库根 README 保持不变。
- 为三个插件补充 38 个 V3 聚焦测试，并锁定空详情页能力、Webhook 鉴权与响应、Plex 时间窗口/去重/生命周期、命令事件处理等合同。

## 验证

- 聚焦测试：38 passed
- 插件仓标准分组：CI 56 passed；V3 1456 passed；兼容 V2 61 passed
- 受影响生产文件 Pylint：10.00/10
- `compileall`、三份 package JSON、版本门禁、pre-push、禁止旧依赖扫描和 `git diff --check` 均通过

## 兼容边界

- V2 源码未修改，旧版本仍由历史宿主使用。
- V3 实现不依赖 `app.compat`、旧 `app.core/helper/log/utils` 路径、宿主 Model、裸 Session 或数据库装饰器。
- Plex 实例与媒体项操作属于插件业务合同，继续由聚焦测试承担版本适配成本。
