### PR TITLE
迁移 AuxiliaryAuth、PlexAutoLanguages 与 PlexLocalization 至 V3

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -112,7 +112,8 @@
         "history": {
             "v1.1": "MoviePilot V2 版本自定义排序插件"
         },
-        "release": true
+        "release": true,
+        "v3": false
     },
     "WeatherWidget": {
         "name": "天气",
@@ -186,7 +187,8 @@
             "v0.4": "兼容 MoviePilot v2.13.14 的 python-dateutil 运行依赖",
             "v0.3": "MoviePilot V2 版本Plex自动语言插件"
         },
-        "release": true
+        "release": true,
+        "v3": false
     },
     "PlexLocalization": {
         "name": "Plex中文本地化",
@@ -202,7 +204,8 @@
             "v1.8": "优化执行周期输入，需要MoviePilot v2.2.1+",
             "v1.7": "MoviePilot V2 版本Plex中文本地化插件"
         },
-        "release": true
+        "release": true,
+        "v3": false
     },
     "PlexEdition": {
         "name": "PlexEdition",
@@ -267,7 +270,8 @@
             "v1.1": "支持 Plex 辅助认证校验",
             "v1.0": "增加辅助认证插件，支持使用第三方系统进行辅助认证"
         },
-        "release": true
+        "release": true,
+        "v3": false
     },
     "PlexRefreshRecent": {
         "name": "Plex元数据刷新",

--- a/package.v3.json
+++ b/package.v3.json
@@ -138,5 +138,47 @@
             "v2.0.0": "迁移至 MoviePilot V3 稳定接口，保持 Webhook 请求与通知转发行为。"
         },
         "release": true
+    },
+    "AuxiliaryAuth": {
+        "name": "辅助认证",
+        "description": "支持使用第三方系统进行辅助认证。",
+        "labels": "认证",
+        "version": "2.0.0",
+        "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/auxiliaryauth.png",
+        "author": "InfinityPacer",
+        "level": 1,
+        "system_version": ">=3.0.0",
+        "history": {
+            "v2.0.0": "迁移至 MoviePilot V3 事件、媒体服务与日志接口，保持辅助认证拦截流程。"
+        },
+        "release": true
+    },
+    "PlexAutoLanguages": {
+        "name": "Plex自动语言",
+        "description": "实现自动选择Plex电视节目的音轨和字幕语言。",
+        "labels": "Plex",
+        "version": "1.0.0",
+        "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/plexautolanguages.png",
+        "author": "InfinityPacer",
+        "level": 1,
+        "system_version": ">=3.0.0",
+        "history": {
+            "v1.0.0": "迁移至 MoviePilot V3 媒体服务与工具接口，修正插件数据目录与内部导入。"
+        },
+        "release": true
+    },
+    "PlexLocalization": {
+        "name": "Plex中文本地化",
+        "description": "实现拼音排序、搜索及类型标签中文本地化功能。",
+        "labels": "Plex",
+        "version": "3.0.0",
+        "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/plexlocalization.png",
+        "author": "InfinityPacer",
+        "level": 1,
+        "system_version": ">=3.0.0",
+        "history": {
+            "v3.0.0": "迁移至 MoviePilot V3 配置、事件、媒体服务与工具接口，保持 Plex 中文本地化流程。"
+        },
+        "release": true
     }
 }

--- a/plugins.v3/auxiliaryauth/__init__.py
+++ b/plugins.v3/auxiliaryauth/__init__.py
@@ -1,0 +1,224 @@
+"""按已连接的媒体服务限制外部媒体服务器认证。"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from app.plugins import _PluginBase
+from app.schemas.event import AuthInterceptCredentials
+from app.schemas.system import ServiceInfo
+from app.schemas.types import ChainEventType
+from app.sdk.events import Event, eventmanager
+from app.sdk.logging import logger
+from app.sdk.services import MediaServerHelper
+
+
+class AuxiliaryAuth(_PluginBase):
+    """只允许配置且已连接的媒体服务通过认证拦截事件。"""
+
+    plugin_name = "辅助认证"
+    plugin_desc = "支持使用第三方系统进行辅助认证。"
+    plugin_icon = (
+        "https://raw.githubusercontent.com/InfinityPacer/"
+        "MoviePilot-Plugins/main/icons/auxiliaryauth.png"
+    )
+    plugin_version = "2.0.0"
+    plugin_author = "InfinityPacer"
+    author_url = "https://github.com/InfinityPacer"
+    plugin_config_prefix = "auxiliaryauth_"
+    plugin_order = 41
+    auth_level = 1
+
+    _SUPPORTED_CHANNELS: ClassVar[frozenset[str]] = frozenset(
+        ("Emby", "Jellyfin", "Plex")
+    )
+    mediaserver_helper: MediaServerHelper | None = None
+    _enabled = False
+    _mediaservers: ClassVar[list[str]] = []
+    _allow_anonymous = False
+
+    def init_plugin(self, config: dict | None = None) -> None:
+        """加载开关和媒体服务选择，并在重载时清理旧配置状态。"""
+        self.mediaserver_helper = MediaServerHelper()
+        config = config or {}
+        self._enabled = bool(config.get("enabled", False))
+        mediaservers = config.get("mediaservers") or []
+        self._mediaservers = (
+            list(mediaservers)
+            if isinstance(mediaservers, (list, tuple, set))
+            else []
+        )
+        self._allow_anonymous = bool(config.get("allow_anonymous", False))
+
+    @property
+    def service_infos(self) -> dict[str, ServiceInfo] | None:
+        """返回配置选中且当前有可用实例的媒体服务。"""
+        if not self._mediaservers:
+            logger.warning("尚未配置媒体服务器，请检查配置")
+            return None
+
+        if not self.mediaserver_helper:
+            self.mediaserver_helper = MediaServerHelper()
+        services = self.mediaserver_helper.get_services(name_filters=self._mediaservers)
+        if not services:
+            logger.warning("获取媒体服务器实例失败，请检查配置")
+            return None
+
+        active_services: dict[str, ServiceInfo] = {}
+        for service_name, service_info in services.items():
+            if not service_info.instance or service_info.instance.is_inactive():
+                logger.warning(f"媒体服务器 {service_name} 未连接，请检查配置")
+            else:
+                active_services[service_name] = service_info
+
+        if not active_services:
+            logger.warning("没有已连接的媒体服务器，请检查配置")
+            return None
+        return active_services
+
+    def get_state(self) -> bool:
+        """返回插件是否启用。"""
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> list[dict[str, Any]]:
+        """本插件不注册远程控制命令。"""
+        return []
+
+    def get_api(self) -> list[dict[str, Any]]:
+        """本插件不暴露自有 HTTP API。"""
+        return []
+
+    def get_form(self) -> tuple[list[dict], dict[str, Any]]:
+        """拼装插件配置页面和默认配置。"""
+        if not self.mediaserver_helper:
+            self.mediaserver_helper = MediaServerHelper()
+        media_server_items = [
+            {"title": config.name, "value": config.name}
+            for config in self.mediaserver_helper.get_configs().values()
+            if config.name
+        ]
+        return [
+            {
+                "component": "VForm",
+                "content": [
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12, "md": 6},
+                                "content": [
+                                    {
+                                        "component": "VSwitch",
+                                        "props": {
+                                            "model": "enabled",
+                                            "label": "启用插件",
+                                            "hint": "开启后插件将处于激活状态",
+                                            "persistent-hint": True,
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VSelect",
+                                        "props": {
+                                            "multiple": True,
+                                            "chips": True,
+                                            "clearable": True,
+                                            "model": "mediaservers",
+                                            "label": "启用辅助认证的媒体服务器",
+                                            "hint": "选择启用辅助认证的媒体服务器",
+                                            "persistent-hint": True,
+                                            "items": media_server_items,
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "component": "VRow",
+                        "content": [
+                            {
+                                "component": "VCol",
+                                "props": {"cols": 12},
+                                "content": [
+                                    {
+                                        "component": "VAlert",
+                                        "props": {
+                                            "type": "info",
+                                            "variant": "tonal",
+                                            "text": (
+                                                "注意：启用辅助认证需要在 app.env 文件或环境变量中设置 "
+                                                "AUXILIARY_AUTH_ENABLE 参数为开启状态"
+                                            ),
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ], {
+            "enabled": False,
+            "mediaservers": [],
+            "allow_anonymous": False,
+        }
+
+    def get_page(self) -> None:
+        """本插件没有详情页。"""
+        pass  # noqa: PIE790  # pylint: disable=unnecessary-pass
+
+    def get_service(self) -> list[dict[str, Any]]:
+        """本插件不注册后台服务。"""
+        return []
+
+    def stop_service(self) -> None:
+        """本插件没有需要停止的后台服务。"""
+
+    @eventmanager.register(ChainEventType.AuthIntercept)
+    def handle_auth_intercept(self, event: Event) -> None:
+        """阻止未配置或不可用媒体服务的认证继续执行。"""
+        if not self._enabled or not event or not event.event_data:
+            return
+
+        event_data: AuthInterceptCredentials = event.event_data
+        logger.info(
+            f"处理认证通过拦截事件 - 用户名: {event_data.username}, "
+            f"渠道: {event_data.channel}, 服务: {event_data.service}"
+        )
+
+        if event_data.cancel:
+            logger.debug("该事件已被其他事件处理器处理，跳过后续操作")
+            return
+
+        if event_data.channel not in self._SUPPORTED_CHANNELS:
+            logger.info(f"尚未支持处理渠道: {event_data.channel}，跳过拦截")
+            return
+
+        services = self.service_infos
+        if not services or event_data.service not in services:
+            event_data.cancel = True
+            event_data.source = self.plugin_name
+            logger.warning(
+                f"认证被拦截，用户：{event_data.username}，渠道：{event_data.channel}，"
+                f"服务：{event_data.service}，拦截源：{event_data.source}"
+            )
+            return
+
+        event_data.cancel = False
+        logger.info(
+            f"用户：{event_data.username}，渠道: {event_data.channel}，"
+            f"服务 {event_data.service} 允许认证通过"
+        )

--- a/plugins.v3/plexautolanguages/__init__.py
+++ b/plugins.v3/plexautolanguages/__init__.py
@@ -1,0 +1,526 @@
+"""根据 Plex 播放和媒体库事件自动选择剧集音轨及字幕语言。"""
+
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from ruamel.yaml import YAML
+
+from app.plugins import _PluginBase
+from app.schemas.system import MediaServerConf, ServiceInfo
+from app.sdk.logging import logger
+from app.sdk.network import UrlUtils
+from app.sdk.services import MediaServerHelper
+
+from .languageprovider import LanguageProvider
+
+
+class PlexAutoLanguages(_PluginBase):
+    """在宿主媒体服务目录和插件数据目录之上运行 Plex 自动语言服务。"""
+    # 插件名称
+    plugin_name = "Plex自动语言"
+    # 插件描述
+    plugin_desc = "实现自动选择Plex电视节目的音轨和字幕语言。"
+    # 插件图标
+    plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/plexautolanguages.png"
+    # 插件版本
+    plugin_version = "1.0.0"
+    # 插件作者
+    plugin_author = "InfinityPacer"
+    # 作者主页
+    author_url = "https://github.com/InfinityPacer"
+    # 插件配置项ID前缀
+    plugin_config_prefix = "plexautolanguages_"
+    # 加载顺序
+    plugin_order = 96
+    # 可使用的用户级别
+    auth_level = 1
+
+    # region 私有属性
+    mediaserver_helper = None
+    # lang服务
+    _lang_provider = None
+    # Thread
+    _lang_thread = None
+
+    # 是否开启
+    _enabled = False
+    # 媒体服务器
+    _mediaserver = None
+    # 自动切换
+    _auto_switch = None
+    # 更新级别
+    _update_level = "show"
+    # 更新策略
+    _update_strategy = "all"
+    # 播放时触发
+    _trigger_on_play = True
+    # 扫描时触发
+    _trigger_on_scan = True
+
+    # 退出事件
+    _event = threading.Event()
+
+    # endregion
+
+    default_yaml = Path(__file__).parent / "config/default.yaml"
+
+    def __init__(self):
+        super().__init__()
+        self.mediaserver_helper = None
+        self._lang_provider = None
+        self._lang_thread = None
+        self._enabled = False
+        self._mediaserver = None
+        self._auto_switch = False
+        self._update_level = "show"
+        self._update_strategy = "all"
+        self._trigger_on_play = True
+        self._trigger_on_scan = True
+        self._event = threading.Event()
+
+    @property
+    def user_yaml(self) -> Path:
+        """返回插件数据目录中的用户 YAML，避免修改随代码发布的资源。"""
+        return self.get_data_path() / "user.yaml"
+
+    def init_plugin(self, config: Optional[dict] = None):
+        self.stop_service()
+        self._event.clear()
+        self.mediaserver_helper = MediaServerHelper()
+        self._enabled = False
+        self._mediaserver = None
+        self._auto_switch = False
+        if self._lang_thread and self._lang_thread.is_alive():
+            logger.error("旧的自动语言线程尚未停止，本次配置不会启动新线程")
+            return
+        self._lang_provider = None
+        self._lang_thread = None
+        if not config:
+            return
+        self._enabled = bool(config.get("enabled"))
+        self._mediaserver = config.get("mediaserver")
+        self._auto_switch = bool(config.get("auto_switch"))
+        self._update_level = config.get("update_level", "show")
+        self._update_strategy = config.get("update_strategy", "all")
+        self._trigger_on_play = bool(config.get("trigger_on_play", True))
+        self._trigger_on_scan = bool(config.get("trigger_on_scan", True))
+        if self._enabled and self._auto_switch:
+            self.__start_auto_switch()
+
+    @property
+    def service_info(self) -> Optional[ServiceInfo]:
+        """
+        服务信息
+        """
+        if not self._mediaserver:
+            logger.warning("尚未配置媒体服务器，请检查配置")
+            return None
+
+        if not self.mediaserver_helper:
+            self.mediaserver_helper = MediaServerHelper()
+
+        service = self.mediaserver_helper.get_service(name=self._mediaserver, type_filter="plex")
+        if not service:
+            logger.warning("获取媒体服务器实例失败，请检查配置")
+            return None
+
+        if not service.instance or service.instance.is_inactive():
+            logger.warning(f"媒体服务器 {self._mediaserver} 未连接，请检查配置")
+            return None
+
+        return service
+
+    @property
+    def plex_config(self) -> Optional[MediaServerConf]:
+        """
+        Plex配置
+        """
+        if not self.service_info:
+            return None
+        if not self.service_info.config or not self.service_info.config.config:
+            return None
+        return self.service_info.config
+
+    def __start_auto_switch(self):
+        logger.info("正在准备停止服务")
+
+        self.stop_service()
+
+        if self._lang_thread and self._lang_thread.is_alive():
+            logger.error("旧的自动语言线程尚未停止，取消本次启动")
+            return
+
+        logger.info("正在初始化相关服务")
+
+        if not self.__check_plex_media_server():
+            return
+
+        try:
+            self.__update_user_config()
+
+            self._lang_provider = LanguageProvider(default_config_path=self.default_yaml,
+                                                   user_config_path=self.user_yaml,
+                                                   data_path=self.get_data_path(),
+                                                   logger=logger)
+
+            self._lang_thread = threading.Thread(target=self._lang_provider.start)
+            self._lang_thread.daemon = True
+            self._lang_thread.start()
+        except Exception as e:
+            logger.info("初始化失败，请检查配置信息：" + str(e))
+
+    def get_state(self) -> bool:
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """
+        定义远程控制命令
+        :return: 命令关键字、事件、描述、附带数据
+        """
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """
+        拼装插件配置页面，需要返回两块数据：1、页面配置；2、数据结构
+        """
+        if not self.mediaserver_helper:
+            self.mediaserver_helper = MediaServerHelper()
+
+        return [
+            {
+                'component': 'VForm',
+                'content': [
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 3
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'enabled',
+                                            'label': '启用插件',
+                                            'hint': '开启后插件将处于激活状态',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 3
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'auto_switch',
+                                            'label': '自动切换',
+                                            'hint': '启用后将自动切换剧集语言',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 3
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'trigger_on_play',
+                                            'label': '播放时触发',
+                                            'hint': '播放文件是否触发语言更新',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 3
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'trigger_on_scan',
+                                            'label': '扫描时触发',
+                                            'hint': '扫描新文件时是否触发语言更新',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'model': 'mediaserver',
+                                            'label': '媒体服务器',
+                                            'items': [{"title": config.name, "value": config.name}
+                                                      for config in self.mediaserver_helper.get_configs().values()
+                                                      if config.type == "plex"],
+                                            'hint': '选择媒体服务器',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'model': 'update_level',
+                                            'label': '更新级别',
+                                            'items': [
+                                                {'title': '剧集', 'value': 'show'},
+                                                {'title': '季', 'value': 'season'}
+                                            ],
+                                            'hint': '选择更新整个剧集或仅更新当前季',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'model': 'update_strategy',
+                                            'label': '更新策略',
+                                            'items': [
+                                                {'title': '所有剧集', 'value': 'all'},
+                                                {'title': '接下来的剧集', 'value': 'next'}
+                                            ],
+                                            'hint': '选择更新所有剧集或仅更新接下来的剧集',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal'
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'span',
+                                                'text': '基于 '
+                                            },
+                                            {
+                                                'component': 'a',
+                                                'props': {
+                                                    'href': 'https://github.com/RemiRigal/Plex-Auto-Languages',
+                                                    'target': '_blank',
+                                                    'style': 'text-decoration: underline;'
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'u',
+                                                        'text': 'Plex Auto Languages'
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'component': 'span',
+                                                'text': ' 项目编写，特此感谢 '
+                                            },
+                                            {
+                                                'component': 'a',
+                                                'props': {
+                                                    'href': 'https://github.com/RemiRigal',
+                                                    'target': '_blank',
+                                                    'style': 'text-decoration: underline;'
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'u',
+                                                        'text': 'RemiRigal'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal',
+                                            'text': '注意：本插件仍在完善阶段，可能存在导致性能消耗、异常退出等问题，请详细查阅 '
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'a',
+                                                'props': {
+                                                    'href': 'https://github.com/RemiRigal/Plex-Auto-Languages/blob/master/README.md',
+                                                    'target': '_blank'
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'u',
+                                                        'text': 'README'
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+            }
+        ], {
+            "enabled": False,
+            "auto_switch": True,
+            "update_level": "show",
+            "update_strategy": "all",
+            "trigger_on_play": True,
+            "trigger_on_scan": True
+        }
+
+    def get_page(self) -> None:
+        """本插件没有详情页。"""
+        pass
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """
+        注册插件公共服务
+        [{
+            "id": "服务ID",
+            "name": "服务名称",
+            "trigger": "触发器：cron/interval/date/CronTrigger.from_crontab()",
+            "func": self.xxx,
+            "kwargs": {} # 定时器参数
+        }]
+        """
+        return []
+
+    def stop_service(self) -> bool:
+        """
+        退出插件
+        """
+        try:
+            if self._lang_provider:
+                self._lang_provider.stop()
+                logger.info("auto language has been requested to stop.")
+            if self._lang_thread:
+                self._lang_thread.join(timeout=10)  # 等待线程完成，增加超时避免死锁
+                if self._lang_thread.is_alive():
+                    logger.error("thread has not stopped after waiting 10 seconds")
+                    return False
+                else:
+                    self._lang_thread = None
+                    self._lang_provider = None
+                    logger.info("thread has been joined successfully.")
+            else:
+                self._lang_provider = None
+            self._event.set()  # 通知其他可能等待的线程
+            self._event.clear()  # 立即重置事件状态
+            return True
+        except Exception as e:
+            logger.error(f"Error stopping service: {e}", exc_info=True)  # 记录堆栈信息
+            return False
+
+    def __check_plex_media_server(self) -> bool:
+        """检查Plex媒体服务器配置"""
+        if not self.plex_config:
+            logger.error(f"Plex 配置不正确，请检查")
+            return False
+
+        return True
+
+    def __update_user_config(self):
+        yaml = YAML()
+        # 保留引号和注释
+        yaml.preserve_quotes = True
+
+        # 读取用户配置并保留注释
+        with open(self.default_yaml, "r", encoding="utf-8") as stream:
+            user_config = yaml.load(stream).get("plexautolanguages", {})
+
+        # 更新 plex_config
+        user_config["update_level"] = self._update_level
+        user_config["update_strategy"] = self._update_strategy
+        user_config["trigger_on_play"] = self._trigger_on_play
+        user_config["trigger_on_scan"] = self._trigger_on_scan
+        plex_config = user_config.get("plex", {})
+        plex_config["url"] = UrlUtils.standardize_base_url(self.plex_config.config.get("host"))
+        plex_config["token"] = self.plex_config.config.get("token")
+
+        # 写回到 YAML 文件中并保留注释
+        self.user_yaml.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.user_yaml, "w", encoding="utf-8") as stream:
+            yaml.dump({"plexautolanguages": user_config}, stream)

--- a/plugins.v3/plexautolanguages/config/default.yaml
+++ b/plugins.v3/plexautolanguages/config/default.yaml
@@ -1,0 +1,86 @@
+plexautolanguages:
+  # 更新整个剧集的语言或仅更新当前季
+  # 可接受的值：
+  #   - show（默认）
+  #   - season
+  update_level: "show"
+
+  # 更新剧集/季的所有剧集或仅更新接下来的剧集
+  # 可接受的值：
+  #   - all（默认）
+  #   - next
+  update_strategy: "all"
+
+  # 播放文件是否触发语言更新，默认为 'true'
+  trigger_on_play: true
+
+  # 扫描新文件时是否触发语言更新，默认为 'true'
+  # 新增的剧集将根据最近观看的剧集更新语言，若该剧从未被观看则根据第一集更新语言
+  trigger_on_scan: true
+
+  # 浏览 Plex 库是否触发语言更新，默认为 'false'
+  # 仅 Plex 网络客户端和 Plex for Windows 应用程序支持此功能
+  # 仅当您希望在更新剧集的默认轨道时执行更改，即使未播放该剧集时，才将此参数设置为 'true'
+  # 将此参数设置为 'true' 可能会导致更高的资源使用
+  trigger_on_activity: false
+
+  # 每当 Plex 服务器扫描其库时是否刷新缓存库，默认为 'true'
+  # 禁用此参数将阻止 PlexAutoLanguages 检测已存在剧集的更新文件
+  # 如果您的电视剧库很大（10k+ 剧集），建议禁用此参数
+  refresh_library_on_scan: false
+
+  # PlexAutoLanguages 将忽略具有以下任何 Plex 标签的剧集
+  ignore_labels:
+    - PAL_IGNORE
+
+  # Plex 配置
+  plex:
+    # 一个有效的 Plex URL（必填）
+    url: "http://plex:32400"
+    # 一个有效的 Plex 令牌（必填）
+    token: "MY_PLEX_TOKEN"
+
+  scheduler:
+    # 是否启用调度程序，默认为 'true'
+    # 调度程序将对所有最近播放的电视剧进行更深入的分析
+    enable: false
+    # 调度程序开始任务的时间，格式为 'HH:MM'，默认为 '02:00'
+    schedule_time: "04:30"
+
+  notifications:
+    # 是否通过 Apprise 启用通知，默认为 'false'
+    # 每当进行语言更改时发送通知
+    enable: false
+    # Apprise 配置的数组，详见 Apprise 文档：https://github.com/caronc/apprise
+    # 数组 'users' 可以指定以将通知 URL 与特定用户关联
+    #   如果不存在，默认为所有用户
+    # 数组 'events' 可以指定以仅获取特定事件的通知
+    #   有效的事件值："play_or_activity" "new_episode" "updated_episode" "scheduler"
+    #   如果不存在，默认为所有事件
+    apprise_configs:
+      # 此 URL 将在所有事件期间通知所有更改
+      - "discord://webhook_id/webhook_token"
+      # 这些 URL 将仅在用户 "MyUser1" 和 "MyUser2" 的语言更改时通知
+      - urls:
+          - "gotify://hostname/token"
+          - "pover://user@token"
+        users:
+          - "MyUser1"
+          - "MyUser2"
+      # 此 URL 将仅在用户 "MyUser3" 的播放或活动事件期间通知语言更改
+      - urls:
+          - "tgram://bottoken/ChatID"
+        users:
+          - "MyUser3"
+        events:
+          - "play_or_activity"
+      # 此 URL 将仅在调度程序任务期间通知语言更改
+      - urls:
+          - "gotify://hostname/token"
+        events:
+          - "scheduler"
+      - "..."
+
+  # 是否启用调试模式，默认为 'false'
+  # 启用调试模式将显著增加输出日志的数量
+  debug: true

--- a/plugins.v3/plexautolanguages/core/alerts/__init__.py
+++ b/plugins.v3/plexautolanguages/core/alerts/__init__.py
@@ -1,0 +1,5 @@
+from .base import PlexAlert             # noqa: F401
+from .activity import PlexActivity      # noqa: F401
+from .playing import PlexPlaying        # noqa: F401
+from .timeline import PlexTimeline      # noqa: F401
+from .status import PlexStatus          # noqa: F401

--- a/plugins.v3/plexautolanguages/core/alerts/activity.py
+++ b/plugins.v3/plexautolanguages/core/alerts/activity.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from datetime import datetime, timedelta
+from plexapi.video import Episode
+
+from ..constants import EventType
+from app.sdk.logging import logger
+from .base import PlexAlert
+
+if TYPE_CHECKING:
+    from ..plex_server import PlexServer
+
+
+class PlexActivity(PlexAlert):
+
+    TYPE = "activity"
+
+    TYPE_LIBRARY_REFRESH_ITEM = "library.refresh.items"
+    TYPE_LIBRARY_UPDATE_SECTION = "library.update.section"
+    TYPE_PROVIDER_SUBSCRIPTIONS_PROCESS = "provider.subscriptions.process"
+    TYPE_MEDIA_GENERATE_BIF = "media.generate.bif"
+
+    def is_type(self, activity_type: str):
+        return self.type == activity_type
+
+    @property
+    def event(self):
+        return self._message.get("event", None)
+
+    @property
+    def type(self):
+        return self._message.get("Activity", {}).get("type", None)
+
+    @property
+    def item_key(self):
+        return self._message.get("Activity", {}).get("Context", {}).get("key", None)
+
+    @property
+    def user_id(self):
+        return self._message.get("Activity", {}).get("userID", None)
+
+    def process(self, plex: PlexServer):
+        if self.event != "ended":
+            return
+        if not self.is_type(self.TYPE_LIBRARY_REFRESH_ITEM):
+            return
+
+        # Switch to the user's Plex instance
+        user_plex = plex.get_plex_instance_of_user(self.user_id)
+        if user_plex is None:
+            return
+
+        # Skip if not an Episode
+        item = user_plex.fetch_item(self.item_key)
+        if item is None or not isinstance(item, Episode):
+            return
+
+        # Skip if the show should be ignored
+        if plex.should_ignore_show(item.show()):
+            logger.debug(f"[Activity] Ignoring episode {item} due to Plex show labels")
+            return
+
+        # Skip if this item has already been seen in the last 3 seconds
+        activity_key = (self.user_id, self.item_key)
+        if activity_key in plex.cache.recent_activities and \
+                plex.cache.recent_activities[activity_key] > datetime.now() - timedelta(seconds=3):
+            return
+        plex.cache.recent_activities[activity_key] = datetime.now()
+
+        # Change tracks if needed
+        item.reload()
+        user = plex.get_user_by_id(self.user_id)
+        if user is None:
+            return
+        logger.debug(f"[Activity] User: {user.name} | Episode: {item}")
+        plex.change_tracks(user.name, item, EventType.PLAY_OR_ACTIVITY)

--- a/plugins.v3/plexautolanguages/core/alerts/base.py
+++ b/plugins.v3/plexautolanguages/core/alerts/base.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..plex_server import PlexServer
+
+
+class PlexAlert():
+
+    TYPE = None
+
+    def __init__(self, message: dict):
+        self._message = message
+
+    @property
+    def message(self):
+        return self._message
+
+    def process(self, plex: PlexServer):
+        raise NotImplementedError

--- a/plugins.v3/plexautolanguages/core/alerts/playing.py
+++ b/plugins.v3/plexautolanguages/core/alerts/playing.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from plexapi.video import Episode
+
+from ..constants import EventType
+from app.sdk.logging import logger
+from .base import PlexAlert
+
+if TYPE_CHECKING:
+    from ..plex_server import PlexServer
+
+
+class PlexPlaying(PlexAlert):
+
+    TYPE = "playing"
+
+    @property
+    def client_identifier(self):
+        return self._message.get("clientIdentifier", None)
+
+    @property
+    def item_key(self):
+        return self._message.get("key", None)
+
+    @property
+    def session_key(self):
+        return self._message.get("sessionKey", None)
+
+    @property
+    def session_state(self):
+        return self._message.get("state", None)
+
+    def process(self, plex: PlexServer):
+        # Get User id and user's Plex instance
+        if self.client_identifier not in plex.cache.user_clients:
+            user_id, username = plex.get_user_from_client_identifier(self.client_identifier)
+            if user_id is None:
+                return
+            plex.cache.user_clients[self.client_identifier] = (user_id, username)
+        else:
+            user_id, username = plex.cache.user_clients[self.client_identifier]
+        user_plex = plex.get_plex_instance_of_user(user_id)
+        if user_plex is None:
+            return
+
+        # Skip if not an Episode
+        item = user_plex.fetch_item(self.item_key)
+        if item is None or not isinstance(item, Episode):
+            return
+
+        # Skip if the show should be ignored
+        if plex.should_ignore_show(item.show()):
+            logger.debug(f"[Play Session] Ignoring episode {item} due to Plex show labels")
+            return
+
+        # Skip is the session state is unchanged
+        if self.session_key in plex.cache.session_states and plex.cache.session_states[self.session_key] == self.session_state:
+            return
+        logger.debug(f"[Play Session] "
+                     f"Session: {self.session_key} | State: '{self.session_state}' | User id: {user_id} | Episode: {item}")
+        plex.cache.session_states[self.session_key] = self.session_state
+
+        # Reset cache if the session is stopped
+        if self.session_state == "stopped":
+            logger.debug(f"[Play Session] End of session {self.session_key} for user {user_id}")
+            del plex.cache.session_states[self.session_key]
+            del plex.cache.user_clients[self.client_identifier]
+
+        # Skip if selected streams are unchanged
+        item.reload()
+        audio_stream, subtitle_stream = plex.get_selected_streams(item)
+        pair_id = (
+            audio_stream.id if audio_stream is not None else None,
+            subtitle_stream.id if subtitle_stream is not None else None
+        )
+        if item.key in plex.cache.default_streams and plex.cache.default_streams[item.key] == pair_id:
+            return
+        plex.cache.default_streams.setdefault(item.key, pair_id)
+
+        # Change tracks if needed
+        plex.change_tracks(username, item, EventType.PLAY_OR_ACTIVITY)

--- a/plugins.v3/plexautolanguages/core/alerts/status.py
+++ b/plugins.v3/plexautolanguages/core/alerts/status.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from ..constants import EventType
+from app.sdk.logging import logger
+from .base import PlexAlert
+
+if TYPE_CHECKING:
+    from ..plex_server import PlexServer
+
+
+class PlexStatus(PlexAlert):
+
+    TYPE = "status"
+
+    @property
+    def title(self):
+        return self._message.get("title", None)
+
+    def process(self, plex: PlexServer):
+        if self.title != "Library scan complete":
+            return
+        logger.debug("[Status] The Plex server scanned the library")
+
+        if plex.config.get("refresh_library_on_scan"):
+            added, updated = plex.cache.refresh_library_cache()
+        else:
+            added = plex.get_recently_added_episodes(minutes=5)
+            updated = []
+
+        # Process recently added episodes
+        if len(added) > 0:
+            logger.debug(f"[Status] Found {len(added)} newly added episode(s)")
+            for item in added:
+                # Check if the item should be ignored
+                if plex.should_ignore_show(item.show()):
+                    continue
+
+                # Check if the item has already been processed
+                if not plex.cache.should_process_recently_added(item.key, item.addedAt):
+                    continue
+
+                # Change tracks for all users
+                logger.info(f"[Status] Processing newly added episode {plex.get_episode_short_name(item)}")
+                plex.process_new_or_updated_episode(item.key, EventType.NEW_EPISODE, True)
+
+        # Process updated episodes
+        if len(updated) > 0:
+            logger.debug(f"[Status] Found {len(updated)} updated episode(s)")
+            for item in updated:
+                # Check if the item should be ignored
+                if plex.should_ignore_show(item.show()):
+                    continue
+
+                # Check if the item has already been processed
+                if not plex.cache.should_process_recently_updated(item.key):
+                    continue
+
+                # Change tracks for all users
+                logger.info(f"[Status] Processing updated episode {plex.get_episode_short_name(item)}")
+                plex.process_new_or_updated_episode(item.key, EventType.UPDATED_EPISODE, False)

--- a/plugins.v3/plexautolanguages/core/alerts/timeline.py
+++ b/plugins.v3/plexautolanguages/core/alerts/timeline.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+from datetime import datetime, timedelta
+from plexapi.video import Episode
+
+from ..constants import EventType
+from app.sdk.logging import logger
+from .base import PlexAlert
+
+if TYPE_CHECKING:
+    from ..plex_server import PlexServer
+
+
+class PlexTimeline(PlexAlert):
+
+    TYPE = "timeline"
+
+    @property
+    def has_metadata_state(self):
+        return "metadataState" in self._message
+
+    @property
+    def has_media_state(self):
+        return "mediaState" in self._message
+
+    @property
+    def item_id(self):
+        return int(self._message.get("itemID", None))
+
+    @property
+    def identifier(self):
+        return self._message.get("identifier", None)
+
+    @property
+    def state(self):
+        return self._message.get("state", None)
+
+    @property
+    def entry_type(self):
+        return self._message.get("type", None)
+
+    def process(self, plex: PlexServer):
+        if self.has_metadata_state or self.has_media_state:
+            return
+        if self.identifier != "com.plexapp.plugins.library" or self.state != 5 or self.entry_type == -1:
+            return
+
+        # Skip if not an Episode
+        item = plex.fetch_item(self.item_id)
+        if item is None or not isinstance(item, Episode):
+            return
+
+        # Skip if the show should be ignored
+        if plex.should_ignore_show(item.show()):
+            logger.debug(f"[Timeline] Ignoring episode {item} due to Plex show labels")
+            return
+
+        # Check if the item has been added recently
+        if item.addedAt < datetime.now() - timedelta(minutes=5):
+            return
+
+        # Check if the item has already been processed
+        if not plex.cache.should_process_recently_added(item.key, item.addedAt):
+            return
+
+        # Change tracks for all users
+        logger.info(f"[Timeline] Processing newly added episode {plex.get_episode_short_name(item)}")
+        plex.process_new_or_updated_episode(self.item_id, EventType.NEW_EPISODE, True)

--- a/plugins.v3/plexautolanguages/core/constants.py
+++ b/plugins.v3/plexautolanguages/core/constants.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class EventType(Enum):
+
+    PLAY_OR_ACTIVITY = 0
+    NEW_EPISODE = 1
+    UPDATED_EPISODE = 2
+    SCHEDULER = 3

--- a/plugins.v3/plexautolanguages/core/exceptions.py
+++ b/plugins.v3/plexautolanguages/core/exceptions.py
@@ -1,0 +1,7 @@
+
+class InvalidConfiguration(Exception):
+    pass
+
+
+class UserNotFound(Exception):
+    pass

--- a/plugins.v3/plexautolanguages/core/plex_alert_handler.py
+++ b/plugins.v3/plexautolanguages/core/plex_alert_handler.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from queue import Queue, Empty
+from threading import Thread, Event
+from time import sleep
+from typing import TYPE_CHECKING
+
+from requests.exceptions import ReadTimeout
+from urllib3.exceptions import ReadTimeoutError
+
+from app.sdk.logging import logger
+
+from .alerts import PlexActivity, PlexTimeline, PlexPlaying, PlexStatus
+
+if TYPE_CHECKING:
+    from .plex_server import PlexServer
+
+class PlexAlertHandler:
+
+    def __init__(self, plex: PlexServer, trigger_on_play: bool, trigger_on_scan: bool, trigger_on_activity: bool):
+        self._plex = plex
+        self._trigger_on_play = trigger_on_play
+        self._trigger_on_scan = trigger_on_scan
+        self._trigger_on_activity = trigger_on_activity
+        self._alerts_queue = Queue()
+        self._stop_event = Event()
+        self._processor_thread = Thread(target=self._process_alerts)
+        self._processor_thread.daemon = True
+        self._processor_thread.start()
+
+    def stop(self):
+        self._stop_event.set()
+        self._processor_thread.join(timeout=10)
+        if self._processor_thread.is_alive():
+            logger.warning("Plex告警处理线程未在 10 秒内停止")
+
+    def __call__(self, message: dict):
+        alert_class = None
+        alert_field = None
+        if self._trigger_on_play and message["type"] == "playing":
+            alert_class = PlexPlaying
+            alert_field = "PlaySessionStateNotification"
+        elif self._trigger_on_activity and message["type"] == "activity":
+            alert_class = PlexActivity
+            alert_field = "ActivityNotification"
+        elif self._trigger_on_scan and message["type"] == "timeline":
+            alert_class = PlexTimeline
+            alert_field = "TimelineEntry"
+        elif self._trigger_on_scan and message["type"] == "status":
+            alert_class = PlexStatus
+            alert_field = "StatusNotification"
+
+        if alert_class is None or alert_field is None or alert_field not in message:
+            return
+
+        for alert_message in message[alert_field]:
+            alert = alert_class(alert_message)
+            self._alerts_queue.put(alert)
+
+    def _process_alerts(self):
+        logger.debug("Starting alert processing thread")
+        retry_counter = 0
+        alert = None
+        while not self._stop_event.is_set():
+            try:
+                if retry_counter == 0:
+                    alert = self._alerts_queue.get(True, 1)
+                if alert is None:
+                    continue
+                try:
+                    alert.process(self._plex)
+                    retry_counter = 0
+                except (ReadTimeout, ReadTimeoutError):
+                    retry_counter += 1
+                    logger.warning(
+                        f"ReadTimeout while processing {alert.TYPE} alert, retrying (attempt {retry_counter})...")
+                    logger.debug(alert.message)
+                    sleep(1)
+                except Exception:
+                    logger.error(f"Unable to process {alert.TYPE}", exc_info=True)
+                    logger.debug(alert.message)
+                    retry_counter = 0
+            except Empty:
+                pass
+        logger.debug("Stopping alert processing thread")

--- a/plugins.v3/plexautolanguages/core/plex_alert_listener.py
+++ b/plugins.v3/plexautolanguages/core/plex_alert_listener.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from typing import Callable
+from websocket import WebSocketApp
+from plexapi.alert import AlertListener
+from plexapi.server import PlexServer as BasePlexServer
+
+from app.sdk.logging import logger
+
+
+class PlexAlertListener(AlertListener):
+
+    def __init__(self, server: BasePlexServer, callback: Callable = None, callbackError: Callable = None):
+        super().__init__(server, callback, callbackError)
+
+    def run(self):
+        url = self._server.url(self.key, includeToken=True).replace("http", "ws")
+        self._ws = WebSocketApp(url, on_message=self._onMessage, on_error=self._onError)
+        self._ws.run_forever(skip_utf8_validation=True)

--- a/plugins.v3/plexautolanguages/core/plex_server.py
+++ b/plugins.v3/plexautolanguages/core/plex_server.py
@@ -1,0 +1,329 @@
+import itertools
+import threading
+from datetime import datetime, timedelta
+from typing import Union, Callable, Any
+
+import requests
+from plexapi.exceptions import NotFound, Unauthorized, BadRequest
+from plexapi.library import ShowSection
+from plexapi.media import MediaPart
+from plexapi.server import PlexServer as BasePlexServer
+from plexapi.video import Episode, Show
+from requests import ConnectionError as RequestsConnectionError
+
+from app.sdk.logging import logger
+
+from .constants import EventType
+from .exceptions import UserNotFound
+from .plex_alert_handler import PlexAlertHandler
+from .plex_alert_listener import PlexAlertListener
+from .plex_server_cache import PlexServerCache
+from .track_changes import TrackChanges, NewOrUpdatedTrackChanges
+from .utils.configuration import Configuration
+
+
+class UnprivilegedPlexServer:
+
+    def __init__(self, url: str, token: str, session: requests.Session | None = None,
+                 stop_event: threading.Event | None = None):
+        self._session = session or requests.Session()
+        self._stop_event = stop_event or threading.Event()
+        self._plex_url = url
+        self._plex = self._get_server(url, token, self._session)
+
+    @property
+    def connected(self):
+        if self._plex is None:
+            return False
+        try:
+            _ = self._plex.library.sections()
+            return True
+        except (BadRequest, RequestsConnectionError):
+            return False
+
+    @property
+    def unique_id(self):
+        return self._plex.machineIdentifier
+
+    def _get_server(self, url: str, token: str, session: requests.Session):
+        if self._stop_event.is_set():
+            return None
+        try:
+            return BasePlexServer(url, token, session=session, timeout=5)
+        except (RequestsConnectionError, Unauthorized):
+            return None
+
+    def fetch_item(self, item_id: Union[str, int]):
+        try:
+            return self._plex.fetchItem(item_id)
+        except NotFound:
+            return None
+
+    def episodes(self):
+        return self._plex.library.all(libtype="episode", container_size=1000)
+
+    def get_recently_added_episodes(self, minutes: int):
+        episodes = []
+        for section in self.get_show_sections():
+            recent = section.searchEpisodes(sort="addedAt:desc", filters={"addedAt>>": f"{minutes}m"})
+            episodes.extend(recent)
+        return episodes
+
+    def get_show_sections(self):
+        return [s for s in self._plex.library.sections() if isinstance(s, ShowSection)]
+
+    @staticmethod
+    def get_last_watched_or_first_episode(show: Show):
+        watched_episodes = show.watched()
+        if len(watched_episodes) == 0:
+            all_episodes = show.episodes()
+            if len(all_episodes) == 0:
+                return None
+            return all_episodes[0]
+        return watched_episodes[-1]
+
+    @staticmethod
+    def get_selected_streams(episode: Union[Episode, MediaPart]):
+        audio_stream = ([a for a in episode.audioStreams() if a.selected] + [None])[0]
+        subtitle_stream = ([s for s in episode.subtitleStreams() if s.selected] + [None])[0]
+        return audio_stream, subtitle_stream
+
+    @staticmethod
+    def get_episode_short_name(episode: Episode, include_show: bool = True):
+        if include_show:
+            return f"'{episode.show().title}' (S{episode.seasonNumber:02}E{episode.episodeNumber:02})"
+        return f"S{episode.seasonNumber:02}E{episode.episodeNumber:02}"
+
+
+class PlexServer(UnprivilegedPlexServer):
+
+    def __init__(self, url: str, token: str, notifier: Any, config: Configuration,
+                 stop_event: threading.Event | None = None):
+        super().__init__(url, token, stop_event=stop_event)
+        self.notifier = notifier
+        self.config = config
+        self._user = self._get_logged_user()
+        if self._user is None:
+            logger.error("Unable to find the user associated with the provided Plex Token")
+            raise UserNotFound
+        logger.info(f"Successfully connected as user '{self.username}' (id: {self.user_id})")
+        self._alert_handler = None
+        self._alert_listener = None
+        self.cache = PlexServerCache(self)
+
+    @property
+    def user_id(self):
+        return self._user.id if self._user is not None else None
+
+    @property
+    def username(self):
+        return self._user.name if self._user is not None else None
+
+    @property
+    def is_alive(self):
+        return self.connected and self._alert_listener is not None and self._alert_listener.is_alive()
+
+    def _get_server(self, url: str, token: str, session: requests.Session, max_tries: int = 5000):
+        for _ in range(max_tries):
+            if self._stop_event.is_set():
+                return None
+            try:
+                return BasePlexServer(url, token, session=session, timeout=5)
+            except Unauthorized as e:
+                logger.warning(
+                    "Unauthorized: make sure your credentials are correct. Retrying to connect to Plex server...")
+                logger.debug(e, exc_info=True)
+            except (RequestsConnectionError, BadRequest) as e:
+                logger.warning("ConnectionError: Unable to connect to Plex server, retrying...")
+                logger.debug(e, exc_info=True)
+            except Exception as e:
+                logger.error("Unexpected error during connection to Plex")
+                logger.error(e, exc_info=True)
+            if self._stop_event.wait(5):
+                return None
+        return None
+
+    def _get_logged_user(self):
+        if self._plex is None:
+            return None
+        plex_username = self._plex.myPlexAccount().username
+        for account in self._plex.systemAccounts():
+            if account.name == plex_username:
+                return account
+        return None
+
+    def save_cache(self):
+        self.cache.save()
+
+    def start_alert_listener(self, error_callback: Callable):
+        trigger_on_play = self.config.get("trigger_on_play")
+        trigger_on_scan = self.config.get("trigger_on_scan")
+        trigger_on_activity = self.config.get("trigger_on_activity")
+        self._alert_handler = PlexAlertHandler(self, trigger_on_play, trigger_on_scan, trigger_on_activity)
+        self._alert_listener = PlexAlertListener(self._plex, self._alert_handler, error_callback)
+        logger.info("Starting alert listener")
+        self._alert_listener.start()
+
+    def get_instance_users(self):
+        users = self.cache.get_instance_users()
+        if users is not None:
+            return users
+        users = []
+        try:
+            for user in self._plex.myPlexAccount().users():
+                server_identifiers = [share.machineIdentifier for share in user.servers]
+                if self.unique_id in server_identifiers:
+                    user.name = user.title
+                    users.append(user)
+            self.cache.set_instance_users(users)
+            return users
+        except BadRequest:
+            logger.warning("Unable to retrieve the users of the account, falling back to cache")
+            return self.cache.get_instance_users(check_validity=False)
+
+    def get_all_user_ids(self):
+        return [self.user_id] + [user.id for user in (self.get_instance_users() or [])]
+
+    def get_plex_instance_of_user(self, user_id: Union[int, str]):
+        if str(self.user_id) == str(user_id):
+            return self
+        matching_users = [u for u in self.get_instance_users() if str(u.id) == str(user_id)]
+        if len(matching_users) == 0:
+            logger.error(f"Unable to find user with id '{user_id}'")
+            return None
+        user = matching_users[0]
+        user_token = self.cache.get_instance_user_token(user.id)
+        if user_token is None:
+            user_token = user.get_token(self.unique_id)
+            self.cache.set_instance_user_token(user.id, user_token)
+        user_plex = UnprivilegedPlexServer(
+            self._plex_url,
+            user_token,
+            session=self._session,
+            stop_event=self._stop_event,
+        )
+        if not user_plex.connected:
+            logger.error(f"Connection to the Plex server failed for user '{matching_users[0].name}'")
+            return None
+        return user_plex
+
+    def get_user_from_client_identifier(self, client_identifier: str):
+        plex_sessions = self._plex.sessions()
+        current_players = list(itertools.chain.from_iterable([s.players for s in plex_sessions]))
+        matching_players = [p for p in current_players if p.machineIdentifier == client_identifier]
+        if len(matching_players) == 0:
+            return (None, None)
+        player = matching_players[0]
+        user = self.get_user_by_id(player.userID)
+        if user is None:
+            return (None, None)
+        return (user.id, user.name)
+
+    def get_user_by_id(self, user_id: Union[int, str]):
+        matching_users = [u for u in [self._user] + (self.get_instance_users() or [])
+                          if str(u.id) == str(user_id)]
+        if len(matching_users) == 0:
+            return None
+        return matching_users[0]
+
+    def should_ignore_show(self, show: Show):
+        for label in show.labels:
+            if label.tag and label.tag in self.config.get("ignore_labels"):
+                return True
+        return False
+
+    def process_new_or_updated_episode(self, item_id: Union[int, str], event_type: EventType, new: bool):
+        track_changes = NewOrUpdatedTrackChanges(event_type, new)
+        for user_id in self.get_all_user_ids():
+            # Switch to the user's Plex instance
+            user_plex = self.get_plex_instance_of_user(user_id)
+            if user_plex is None:
+                continue
+
+            # Get the most recently watched episode or the first one of the show
+            user_item = user_plex.fetch_item(item_id)
+            if user_item is None:
+                continue
+            reference = user_plex.get_last_watched_or_first_episode(user_item.show())
+            if reference is None:
+                continue
+
+            # Change tracks
+            reference.reload()
+            user_item.reload()
+            user = self.get_user_by_id(user_id)
+            if user is None:
+                return
+            track_changes.change_track_for_user(user.name, reference, user_item)
+
+        # Notify changes
+        if track_changes.has_changes:
+            self.notify_changes(track_changes)
+
+    def change_tracks(self, username: str, episode: Episode, event_type: EventType):
+        track_changes = TrackChanges(username, episode, event_type)
+        # Get episodes to update
+        episodes = track_changes.get_episodes_to_update(self.config.get("update_level"),
+                                                        self.config.get("update_strategy"))
+
+        # Get changes to perform
+        track_changes.compute(episodes)
+
+        # Perform changes
+        track_changes.apply()
+
+        # Notify changes
+        if track_changes.has_changes:
+            self.notify_changes(track_changes)
+
+    def notify_changes(self, track_changes: Union[TrackChanges, NewOrUpdatedTrackChanges]):
+        logger.info(f"Language update: {track_changes.inline_description}")
+        if not self.notifier:
+            return
+        title = f"PlexAutoLanguages - {track_changes.title}"
+        if isinstance(track_changes, TrackChanges):
+            self.notifier.notify_user(title, track_changes.description, track_changes.username,
+                                      track_changes.event_type)
+        else:
+            self.notifier.notify(title, track_changes.description, track_changes.event_type)
+
+    def start_deep_analysis(self):
+        # History
+        min_date = datetime.now() - timedelta(days=1)
+        history = self._plex.history(mindate=min_date)
+        for episode in [media for media in history if isinstance(media, Episode)]:
+            user = self.get_user_by_id(episode.accountID)
+            if user is None:
+                continue
+            episode.reload()
+            self.change_tracks(user.name, episode, EventType.SCHEDULER)
+
+        # Scan library
+        added, updated = self.cache.refresh_library_cache()
+        for item in added:
+            if self.should_ignore_show(item.show()):
+                continue
+            if not self.cache.should_process_recently_added(item.key, item.addedAt):
+                continue
+            logger.info(f"[Scheduler] Processing newly added episode {self.get_episode_short_name(item)}")
+            self.process_new_or_updated_episode(item.key, EventType.SCHEDULER, True)
+        for item in updated:
+            if self.should_ignore_show(item.show()):
+                continue
+            if not self.cache.should_process_recently_updated(item.key):
+                continue
+            logger.info(f"[Scheduler] Processing updated episode {self.get_episode_short_name(item)}")
+            self.process_new_or_updated_episode(item.key, EventType.SCHEDULER, False)
+
+    def stop(self):
+        if self._alert_handler:
+            self._alert_handler.stop()
+            self._alert_handler = None
+        if self._alert_listener:
+            listener = self._alert_listener
+            self._alert_listener = None
+            try:
+                listener.stop()
+                listener.join(timeout=10)
+            except Exception as error:
+                logger.warning(f"停止Plex告警监听失败：{error}")

--- a/plugins.v3/plexautolanguages/core/plex_server_cache.py
+++ b/plugins.v3/plexautolanguages/core/plex_server_cache.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+import os
+import json
+import copy
+from typing import TYPE_CHECKING
+from datetime import datetime, timedelta
+from dateutil.parser import isoparse
+
+from app.sdk.logging import logger
+
+from .utils.json_encoders import DateTimeEncoder
+
+if TYPE_CHECKING:
+    from .plex_server import PlexServer
+
+
+class PlexServerCache():
+
+    def __init__(self, plex: PlexServer):
+        self._is_refreshing = False
+        self._encoder = DateTimeEncoder()
+        self._plex = plex
+        self._cache_file_path = self._get_cache_file_path()
+        self._last_refresh = datetime.fromtimestamp(0)
+        # Alerts cache
+        self.session_states = {}     # session_key: session_state
+        self.default_streams = {}    # item_key: (audio_stream_id, substitle_stream_id)
+        self.user_clients = {}       # client_identifier: user_id
+        self.newly_added = {}        # episode_id: added_at
+        self.newly_updated = {}      # episode_id: updated_at
+        self.recent_activities = {}  # (user_id, item_id): timestamp
+        # Users cache
+        self._instance_users = []
+        self._instance_user_tokens = {}
+        self._instance_users_valid_until = datetime.fromtimestamp(0)
+        # Library cache
+        self.episode_parts = {}
+        # Initialization
+        if not self._load():
+            logger.info("Scanning all episodes from the Plex library, this action should only take a few seconds "
+                        "but can take several minutes for larger libraries")
+            self.refresh_library_cache()
+            logger.info(f"Scanned {len(self.episode_parts)} episodes from the library")
+
+    def should_process_recently_added(self, episode_id: str, added_at: datetime):
+        if episode_id in self.newly_added and self.newly_added[episode_id] == added_at:
+            return False
+        self.newly_added[episode_id] = added_at
+        return True
+
+    def should_process_recently_updated(self, episode_id: str):
+        if episode_id in self.newly_updated and self.newly_updated[episode_id] >= self._last_refresh:
+            return False
+        self.newly_updated[episode_id] = datetime.now()
+        return True
+
+    def refresh_library_cache(self):
+        if self._is_refreshing:
+            logger.debug("[Cache] The library cache is already being refreshed")
+            return [], []
+        self._is_refreshing = True
+        logger.debug("[Cache] Refreshing library cache")
+        added = []
+        updated = []
+        new_episode_parts = {}
+        for episode in self._plex.episodes():
+            part_list = new_episode_parts.setdefault(episode.key, [])
+            for part in episode.iterParts():
+                part_list.append(part.key)
+            if episode.key in self.episode_parts and set(self.episode_parts[episode.key]) != set(part_list):
+                updated.append(episode)
+            elif episode.key not in self.episode_parts:
+                added.append(episode)
+        self.episode_parts = new_episode_parts
+        logger.debug("[Cache] Done refreshing library cache")
+        self._last_refresh = datetime.now()
+        self.save()
+        self._is_refreshing = False
+        return added, updated
+
+    def get_instance_users(self, check_validity=True):
+        if check_validity and datetime.now() > self._instance_users_valid_until:
+            return None
+        return copy.deepcopy(self._instance_users)
+
+    def set_instance_users(self, instance_users):
+        self._instance_users = copy.deepcopy(instance_users)
+        self._instance_users_valid_until = datetime.now() + timedelta(hours=12)
+        for user in self._instance_users:
+            if str(user.id) in self._instance_user_tokens:
+                continue
+            self._instance_user_tokens[str(user.id)] = user.get_token(self._plex.unique_id)
+
+    def get_instance_user_token(self, user_id):
+        return self._instance_user_tokens.get(str(user_id), None)
+
+    def set_instance_user_token(self, user_id, token):
+        self._instance_user_tokens[str(user_id)] = token
+
+    def _get_cache_file_path(self):
+        data_dir = self._plex.config.get("data_dir")
+        cache_dir = os.path.join(data_dir, "cache")
+        if not os.path.exists(cache_dir):
+            os.makedirs(cache_dir)
+        return os.path.join(cache_dir, self._plex.unique_id)
+
+    def _load(self):
+        if not os.path.exists(self._cache_file_path) or not os.path.isfile(self._cache_file_path):
+            return False
+        logger.debug("[Cache] Loading server cache from file")
+        try:
+            with open(self._cache_file_path, "r", encoding="utf-8") as stream:
+                cache = json.load(stream)
+        except json.JSONDecodeError:
+            logger.warning("[Cache] The cache is corrupted, clearing the cache before trying again")
+            if os.path.exists(self._cache_file_path) and os.path.isfile(self._cache_file_path):
+                os.remove(self._cache_file_path)
+            return False
+        self.newly_updated = cache.get("newly_updated", self.newly_updated)
+        self.newly_updated = {key: isoparse(value) for key, value in self.newly_updated.items()}
+        self.newly_added = cache.get("newly_added", self.newly_added)
+        self.newly_added = {key: isoparse(value) for key, value in self.newly_added.items()}
+        self.episode_parts = cache.get("episode_parts", )
+        self._last_refresh = isoparse(cache.get("last_refresh", self._last_refresh))
+        return True
+
+    def save(self):
+        logger.debug("[Cache] Saving server cache to file")
+        cache = {
+            "newly_updated": self.newly_updated,
+            "newly_added": self.newly_added,
+            "episode_parts": self.episode_parts,
+            "last_refresh": self._last_refresh
+        }
+        with open(self._cache_file_path, "w", encoding="utf-8") as stream:
+            stream.write(self._encoder.encode(cache))

--- a/plugins.v3/plexautolanguages/core/track_changes.py
+++ b/plugins.v3/plexautolanguages/core/track_changes.py
@@ -1,0 +1,251 @@
+from typing import List, Union
+from plexapi.video import Episode
+from plexapi.media import AudioStream, SubtitleStream, MediaPart
+
+from .constants import EventType
+from app.sdk.logging import logger
+
+
+class TrackChanges():
+
+    def __init__(self, username: str, reference: Episode, event_type: EventType):
+        self._reference = reference
+        self._username = username
+        self._event_type = event_type
+        self._audio_stream, self._subtitle_stream = self._get_selected_streams(reference)
+        self._changes = []
+        self._description = ""
+        self._title = ""
+        self._computed = False
+
+    @property
+    def computed(self):
+        return self._computed
+
+    @property
+    def event_type(self):
+        return self._event_type
+
+    @property
+    def description(self):
+        return self._description
+
+    @property
+    def inline_description(self):
+        return self._description.replace("\n", " | ")
+
+    @property
+    def title(self):
+        return self._title
+
+    @property
+    def reference_name(self):
+        return f"{self._reference.show().title} (S{self._reference.seasonNumber:02}E{self._reference.episodeNumber:02})"
+
+    @property
+    def has_changes(self):
+        return len(self._changes) > 0
+
+    @property
+    def username(self):
+        return self._username
+
+    @property
+    def change_count(self):
+        return len(self._changes)
+
+    def get_episodes_to_update(self, update_level: str, update_strategy: str):
+        show_or_season = None
+        if update_level == "show":
+            show_or_season = self._reference.show()
+        elif update_level == "season":
+            show_or_season = self._reference.season()
+        episodes = show_or_season.episodes()
+        if update_strategy == "next":
+            episodes = [e for e in episodes if self._is_episode_after(e)]
+        return episodes
+
+    def compute(self, episodes: List[Episode]):
+        logger.debug(f"[Language Update] Checking language update for show "
+                     f"{self._reference.show()} and user '{self._username}' based on episode {self._reference}")
+        self._changes = []
+        for episode in episodes:
+            episode.reload()
+            for part in episode.iterParts():
+                current_audio_stream, current_subtitle_stream = self._get_selected_streams(part)
+                # Audio stream
+                matching_audio_stream = self._match_audio_stream(part.audioStreams())
+                if current_audio_stream is not None and matching_audio_stream is not None and \
+                        matching_audio_stream.id != current_audio_stream.id:
+                    self._changes.append((episode, part, AudioStream.STREAMTYPE, matching_audio_stream))
+                # Subtitle stream
+                matching_subtitle_stream = self._match_subtitle_stream(part.subtitleStreams())
+                if current_subtitle_stream is not None and matching_subtitle_stream is None:
+                    self._changes.append((episode, part, SubtitleStream.STREAMTYPE, None))
+                if matching_subtitle_stream is not None and \
+                        (current_subtitle_stream is None or matching_subtitle_stream.id != current_subtitle_stream.id):
+                    self._changes.append((episode, part, SubtitleStream.STREAMTYPE, matching_subtitle_stream))
+        self._update_description(episodes)
+        self._computed = True
+
+    def apply(self):
+        if not self.has_changes:
+            logger.debug(f"[Language Update] No changes to perform for show "
+                         f"{self._reference.show()} and user '{self.username}'")
+            return
+        logger.debug(f"[Language Update] Performing {len(self._changes)} change(s) for show {self._reference.show()}")
+        for episode, part, stream_type, new_stream in self._changes:
+            stream_type_name = "audio" if stream_type == AudioStream.STREAMTYPE else "subtitle"
+            logger.debug(f"[Language Update] Updating {stream_type_name} stream of episode {episode} to {new_stream}")
+            if stream_type == AudioStream.STREAMTYPE:
+                part.setDefaultAudioStream(new_stream)
+            elif stream_type == SubtitleStream.STREAMTYPE and new_stream is None:
+                part.resetDefaultSubtitleStream()
+            elif stream_type == SubtitleStream.STREAMTYPE:
+                part.setDefaultSubtitleStream(new_stream)
+
+    def _is_episode_after(self, episode: Episode):
+        return self._reference.seasonNumber < episode.seasonNumber or \
+            (self._reference.seasonNumber == episode.seasonNumber and self._reference.episodeNumber < episode.episodeNumber)
+
+    def _update_description(self, episodes: List[Episode]):
+        if len(episodes) == 0:
+            self._title = ""
+            self._description = ""
+            return
+        season_numbers = [e.seasonNumber for e in episodes]
+        min_season_number, max_season_number = min(season_numbers), max(season_numbers)
+        min_episode_number = min([e.episodeNumber for e in episodes if e.seasonNumber == min_season_number])
+        max_episode_number = max([e.episodeNumber for e in episodes if e.seasonNumber == max_season_number])
+        from_str = f"S{min_season_number:02}E{min_episode_number:02}"
+        to_str = f"S{max_season_number:02}E{max_episode_number:02}"
+        range_str = f"{from_str} - {to_str}" if from_str != to_str else from_str
+        nb_updated = len({e.key for e, _, _, _ in self._changes})
+        nb_total = len(episodes)
+        self._title = self._reference.show().title
+        self._description = (
+            f"Show: {self._reference.show().title}\n"
+            f"User: {self._username}\n"
+            f"Audio: {self._audio_stream.displayTitle if self._audio_stream is not None else 'None'}\n"
+            f"Subtitles: {self._subtitle_stream.displayTitle if self._subtitle_stream is not None else 'None'}\n"
+            f"Updated episodes: {nb_updated}/{nb_total} ({range_str})"
+        )
+
+    def _match_audio_stream(self, audio_streams: List[AudioStream]):
+        # The reference stream can be 'None'
+        if self._audio_stream is None:
+            return None
+        # We only want stream with the same language code
+        streams = [s for s in audio_streams if s.languageCode == self._audio_stream.languageCode]
+        if len(streams) == 0:
+            return None
+        if len(streams) == 1:
+            return streams[0]
+        # If multiple streams match, order them based on a score
+        scores = [0] * len(streams)
+        for index, stream in enumerate(streams):
+            if self._audio_stream.codec == stream.codec:
+                scores[index] += 5
+            if self._audio_stream.audioChannelLayout == stream.audioChannelLayout:
+                scores[index] += 3
+            if self._audio_stream.channels <= stream.channels:
+                scores[index] += 1
+            if self._audio_stream.title is not None and stream.title is not None and self._audio_stream.title == stream.title:
+                scores[index] += 5
+        return streams[scores.index(max(scores))]
+
+    def _match_subtitle_stream(self, subtitle_streams: List[SubtitleStream]):
+        # If no subtitle is selected, the reference stream can be 'None'
+        if self._subtitle_stream is None:
+            if self._audio_stream is None:
+                return None
+            match_forced_only = True
+            language_code = self._audio_stream.languageCode
+        else:
+            match_forced_only = self._subtitle_stream.forced
+            language_code = self._subtitle_stream.languageCode
+        # We only want stream with the same language code
+        streams = [s for s in subtitle_streams if s.languageCode == language_code]
+        if match_forced_only:
+            streams = [s for s in streams if s.forced]
+        if len(streams) == 0:
+            return None
+        if len(streams) == 1 or match_forced_only:
+            return streams[0]
+        # If multiple streams match, order them based on a score
+        scores = [0] * len(streams)
+        for index, stream in enumerate(streams):
+            if self._subtitle_stream.forced == stream.forced:
+                scores[index] += 3
+            if self._subtitle_stream.codec is not None and stream.codec is not None and \
+                    self._subtitle_stream.codec == stream.codec:
+                scores[index] += 1
+            if self._subtitle_stream.title is not None and stream.title is not None and \
+                    self._subtitle_stream.title == stream.title:
+                scores[index] += 5
+        return streams[scores.index(max(scores))]
+
+    @staticmethod
+    def _get_selected_streams(episode: Union[Episode, MediaPart]):
+        audio_stream = ([a for a in episode.audioStreams() if a.selected] + [None])[0]
+        subtitle_stream = ([s for s in episode.subtitleStreams() if s.selected] + [None])[0]
+        return audio_stream, subtitle_stream
+
+
+class NewOrUpdatedTrackChanges():
+
+    def __init__(self, event_type: EventType, new: bool):
+        self._episode = None
+        self._event_type = event_type
+        self._new = new
+        self._track_changes = []
+        self._description = ""
+        self._title = ""
+
+    @property
+    def episode_name(self):
+        if self._episode is None:
+            return ""
+        return f"{self._episode.show().title} (S{self._episode.seasonNumber:02}E{self._episode.episodeNumber:02})"
+
+    @property
+    def event_type(self):
+        return self._event_type
+
+    @property
+    def description(self):
+        return self._description
+
+    @property
+    def inline_description(self):
+        return self._description.replace("\n", " | ")
+
+    @property
+    def title(self):
+        return self._title
+
+    @property
+    def has_changes(self):
+        return sum([1 for tc in self._track_changes if tc.has_changes]) > 0
+
+    def change_track_for_user(self, username: str, reference: Episode, episode: Episode):
+        self._episode = episode
+        track_changes = TrackChanges(username, reference, self._event_type)
+        track_changes.compute([episode])
+        track_changes.apply()
+        self._track_changes.append(track_changes)
+        self._update_description()
+
+    def _update_description(self):
+        if len(self._track_changes) == 0:
+            self._title = ""
+            self._description = ""
+            self._episode = None
+            return
+        event_str = "New" if self._new else "Updated"
+        self._title = f"{event_str}: {self.episode_name}"
+        self._description = (
+            f"Episode: {self.episode_name}\n"
+            f"Status: {event_str} episode\n"
+            f"Updated for all users"
+        )

--- a/plugins.v3/plexautolanguages/core/utils/configuration.py
+++ b/plugins.v3/plexautolanguages/core/utils/configuration.py
@@ -1,0 +1,118 @@
+import os
+import pathlib
+import re
+from collections.abc import Mapping
+
+from ruamel.yaml import YAML
+
+from app.sdk.logging import logger
+
+from ..exceptions import InvalidConfiguration
+
+yaml = YAML(typ="safe")
+
+
+def deep_dict_update(original, update):
+    for key, value in update.items():
+        if isinstance(value, Mapping):
+            original[key] = deep_dict_update(original.get(key, {}), value)
+        else:
+            original[key] = value
+    return original
+
+
+def env_dict_update(original, var_name: str = ""):
+    for key, value in original.items():
+        new_var_name = (f"{var_name}_{key}" if var_name != "" else key).upper()
+        if isinstance(value, Mapping):
+            original[key] = env_dict_update(original[key], new_var_name)
+        elif new_var_name in os.environ:
+            original[key] = yaml.load(os.environ.get(new_var_name))
+            logger.info(f"Setting value of parameter {new_var_name} from environment variable")
+    return original
+
+
+def is_docker():
+    return False
+
+
+class Configuration:
+
+    def __init__(
+            self,
+            default_config_path: pathlib.Path,
+            user_config_path: pathlib.Path,
+            data_path: pathlib.Path,
+    ):
+        self._data_path = pathlib.Path(data_path)
+        if not default_config_path.exists():
+            logger.error("default config is not exists")
+            return
+        with open(default_config_path, "r", encoding="utf-8") as stream:
+            self._config = yaml.load(stream).get("plexautolanguages", {})
+        if user_config_path.exists():
+            logger.info(f"Parsing config file '{user_config_path}'")
+            self._override_from_config_file(user_config_path)
+        self._override_from_env()
+        self._override_plex_token_from_secret()
+        self._postprocess_config()
+        self._validate_config()
+        self._add_system_config()
+
+    def get(self, parameter_path: str):
+        return self._get(self._config, parameter_path)
+
+    def _get(self, config: dict, parameter_path: str):
+        separator = "."
+        if separator in parameter_path:
+            splitted = parameter_path.split(separator)
+            return self._get(config[splitted[0]], separator.join(splitted[1:]))
+        return config[parameter_path]
+
+    def _override_from_config_file(self, user_config_path: pathlib.Path):
+        with open(user_config_path, "r", encoding="utf-8") as stream:
+            user_config = yaml.load(stream).get("plexautolanguages", {})
+        self._config = deep_dict_update(self._config, user_config)
+
+    def _override_from_env(self):
+        self._config = env_dict_update(self._config)
+
+    def _override_plex_token_from_secret(self):
+        plex_token_file_path = os.environ.get("PLEX_TOKEN_FILE", "/run/secrets/plex_token")
+        if not os.path.exists(plex_token_file_path):
+            return
+        logger.info("Getting PLEX_TOKEN from Docker secret")
+        with open(plex_token_file_path, "r", encoding="utf-8") as stream:
+            plex_token = stream.readline().strip()
+        self._config["plex"]["token"] = plex_token
+
+    def _postprocess_config(self):
+        ignore_labels_config = self.get("ignore_labels")
+        if isinstance(ignore_labels_config, str):
+            self._config["ignore_labels"] = ignore_labels_config.split(",")
+
+    def _validate_config(self):
+        if not self.get("plex.url"):
+            logger.error("A Plex URL is required")
+            raise InvalidConfiguration
+        if not self.get("plex.token"):
+            logger.error("A Plex Token is required")
+            raise InvalidConfiguration
+        if self.get("update_level") not in ["show", "season"]:
+            logger.error("The 'update_level' parameter must be either 'show' or 'season'")
+            raise InvalidConfiguration
+        if self.get("update_strategy") not in ["all", "next"]:
+            logger.error("The 'update_strategy' parameter must be either 'all' or 'next'")
+            raise InvalidConfiguration
+        if not isinstance(self.get("ignore_labels"), list):
+            logger.error("The 'ignore_labels' parameter must be a list or a string-based comma separated list")
+            raise InvalidConfiguration
+        if self.get("scheduler.enable") and not re.match(r"^\d{2}:\d{2}$", self.get("scheduler.schedule_time")):
+            logger.error("A valid 'schedule_time' parameter with the format 'HH:MM' is required (ex: 02:30)")
+            raise InvalidConfiguration
+        logger.info("The provided configuration has been successfully validated")
+
+    def _add_system_config(self):
+        self._config["docker"] = is_docker()
+        self._config["data_dir"] = self._data_path
+        self._data_path.mkdir(parents=True, exist_ok=True)

--- a/plugins.v3/plexautolanguages/core/utils/json_encoders.py
+++ b/plugins.v3/plexautolanguages/core/utils/json_encoders.py
@@ -1,0 +1,10 @@
+import json
+from datetime import datetime, date, time
+
+
+class DateTimeEncoder(json.JSONEncoder):
+
+    def default(self, o):
+        if isinstance(o, (datetime, date, time)):
+            return o.isoformat()
+        return super().default(o)

--- a/plugins.v3/plexautolanguages/languageprovider.py
+++ b/plugins.v3/plexautolanguages/languageprovider.py
@@ -1,0 +1,106 @@
+import logging
+import threading
+from pathlib import Path
+from time import sleep
+
+from websocket import WebSocketConnectionClosedException
+
+from .core.plex_server import PlexServer
+from .core.utils.configuration import Configuration
+
+
+class LanguageProvider:
+
+    def __init__(self, default_config_path: Path, user_config_path: Path, data_path: Path, logger: logging.Logger):
+        self.alive = False
+        self.must_stop = False
+        self.stop_signal = False
+        self._stop_event = threading.Event()
+        self.plex_alert_listener = None
+        self.logger = logger
+
+        # Configuration
+        self.config = Configuration(default_config_path, user_config_path, data_path)
+
+        # Notifications
+        self.notifier = None
+        # if self.config.get("notifications.enable"):
+        #     self.notifier = Notifier(self.config.get("notifications.apprise_configs"))
+
+        # Scheduler
+        self.scheduler = None
+        # if self.config.get("scheduler.enable"):
+        #     self.scheduler = Scheduler(self.config.get("scheduler.schedule_time"), self.scheduler_callback)
+
+        # Plex
+        self.plex = None
+
+    def init(self):
+        self.plex = None
+        try:
+            self.plex = PlexServer(self.config.get("plex.url"),
+                                   self.config.get("plex.token"),
+                                   self.notifier,
+                                   self.config,
+                                   stop_event=self._stop_event)
+        except Exception as e:
+            if not self._stop_event.is_set():
+                self.logger.error(e)
+
+    def is_ready(self):
+        return self.alive
+
+    def is_healthy(self):
+        return self.alive and self.plex is not None and self.plex.is_alive
+
+    def stop(self, *_):
+        self.logger.info("Received SIGINT or SIGTERM, stopping gracefully")
+        self.must_stop = True
+        self.stop_signal = True
+        self._stop_event.set()
+
+    def start(self):
+        if self.scheduler:
+            self.scheduler.start()
+
+        while not self.stop_signal:
+            self.must_stop = False
+            self.init()
+            if self.plex is None:
+                break
+            self.plex.start_alert_listener(self.alert_listener_error_callback)
+            self.alive = True
+            count = 0
+            while not self.must_stop:
+                sleep(1)
+                count += 1
+                if count % 60 == 0 and not self.plex.is_alive:
+                    self.logger.warning("Lost connection to the Plex server")
+                    self.must_stop = True
+            self.alive = False
+            self.plex.save_cache()
+            self.plex.stop()
+            if not self.stop_signal:
+                sleep(1)
+                self.logger.info("Trying to restore the connection to the Plex server...")
+
+        if self.scheduler:
+            self.scheduler.shutdown()
+            self.scheduler.join()
+
+    def alert_listener_error_callback(self, error: Exception):
+        if isinstance(error, WebSocketConnectionClosedException):
+            self.logger.warning("The Plex server closed the websocket connection")
+        elif isinstance(error, UnicodeDecodeError):
+            self.logger.debug("Ignoring a websocket payload that could not be decoded")
+            return
+        else:
+            self.logger.error("Alert listener had an unexpected error")
+            self.logger.error(error, exc_info=True)
+        self.must_stop = True
+
+    def scheduler_callback(self):
+        if self.plex is None or not self.plex.is_alive:
+            return
+        self.logger.info("Starting scheduler task")
+        self.plex.start_deep_analysis()

--- a/plugins.v3/plexlocalization/__init__.py
+++ b/plugins.v3/plexlocalization/__init__.py
@@ -1,0 +1,1642 @@
+"""使用 Plex 媒体服务实现标题排序与标签本地化。"""
+
+import concurrent.futures
+import json
+import re
+import threading
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
+
+import plexapi.utils
+import pypinyin
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from plexapi.library import LibrarySection
+
+from app.plugins import _PluginBase
+from app.schemas.system import ServiceInfo
+from app.schemas.types import EventType, MessageType
+from app.sdk.config import settings
+from app.sdk.events import (
+    Event,
+    MediaSnapshot,
+    MetaSnapshot,
+    TransferResultContractData,
+    eventmanager,
+)
+from app.sdk.logging import logger
+from app.sdk.services import MediaServerHelper
+from app.sdk.utilities import StringUtils
+
+lock = threading.Lock()
+TYPES = {"movie": [1], "show": [2], "artist": [8, 9, 10]}
+
+
+class PlexLocalization(_PluginBase):
+    # 插件名称
+    plugin_name = "Plex中文本地化"
+    # 插件描述
+    plugin_desc = "实现拼音排序、搜索及类型标签中文本地化功能。"
+    # 插件图标
+    plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/plexlocalization.png"
+    # 插件版本
+    plugin_version = "3.0.0"
+    # 插件作者
+    plugin_author = "InfinityPacer"
+    # 作者主页
+    author_url = "https://github.com/InfinityPacer"
+    # 插件配置项ID前缀
+    plugin_config_prefix = "plexlocalization_"
+    # 加载顺序
+    plugin_order = 92
+    # 可使用的用户级别
+    auth_level = 1
+
+    # region 私有属性
+    mediaserver_helper = None
+    # 是否开启
+    _enabled = False
+    # 立即运行一次
+    _onlyonce = False
+    # 任务执行间隔
+    _cron = None
+    # 发送通知
+    _notify = False
+    # 需要处理的媒体库
+    _libraries = None
+    # 锁定元数据
+    _lock = None
+    # 入库后运行一次
+    _execute_transfer = None
+    # 入库后延迟执行时间
+    _delay = None
+    # 最近一次入库时间
+    _transfer_time = None
+    # 每批次处理数量
+    _batch_size = None
+    # timeout
+    _timeout = 10
+    # Plex 列表分页大小
+    _page_size = 500
+    # ratingKey 批量读取和验证的安全分块大小
+    _metadata_chunk_size = 100
+    # tags_json
+    _tags_json = None
+    # tags
+    _tags = None
+    # 运行线程数
+    _thread_count = None
+    # 定时器
+    _scheduler = None
+    # 退出事件
+    _event = threading.Event()
+
+    # endregion
+
+    def __init__(self):
+        super().__init__()
+        self.mediaserver_helper = None
+        self._scheduler = None
+        self._scheduler_lock = threading.Lock()
+        self._event = threading.Event()
+        self._transfer_time = None
+
+    @staticmethod
+    def __positive_int(value: Any, default: int) -> int:
+        """读取正整数配置，非法值回退默认值。"""
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+
+    def init_plugin(self, config: dict = None):
+        """应用配置并重建一次性任务，避免重载时残留旧状态。"""
+        self.stop_service()
+        self._event.clear()
+        self.mediaserver_helper = MediaServerHelper()
+        self._enabled = False
+        self._onlyonce = False
+        self._cron = None
+        self._notify = False
+        self._libraries = []
+        self._lock = False
+        self._execute_transfer = False
+        self._transfer_time = None
+        self._delay = 300
+        self._batch_size = 100
+        self._thread_count = 3
+        if not config:
+            return
+        self._enabled = bool(config.get("enabled", False))
+        self._onlyonce = bool(config.get("onlyonce", False))
+        self._cron = config.get("cron")
+        self._notify = bool(config.get("notify", False))
+        self._libraries = config.get("libraries") or []
+        self._lock = bool(config.get("lock", False))
+        self._execute_transfer = bool(config.get("execute_transfer", False))
+        self._tags_json = config.get("tags_json")
+        self._tags = self.__get_tags()
+        self._thread_count = self.__positive_int(config.get("thread_count", 3), default=3)
+        try:
+            self._delay = int(config.get("delay", 300))
+        except (TypeError, ValueError):
+            self._delay = 300
+        self._batch_size = self.__positive_int(config.get("batch_size", 100), default=100)
+
+        # 如果开启了入库后运行一次，延迟时间又不填，默认为300s
+        if self._execute_transfer and not self._delay:
+            self._delay = 300
+
+        # 停止现有任务
+        self.stop_service()
+
+        self._scheduler = BackgroundScheduler(timezone=settings.TZ)
+        if self._onlyonce:
+            logger.info(f"Plex中文本地化服务，立即运行一次")
+            self._scheduler.add_job(
+                func=self.localization,
+                trigger="date",
+                run_date=datetime.now(tz=pytz.timezone(settings.TZ)) + timedelta(seconds=3),
+                name="Plex中文本地化",
+            )
+            # 关闭一次性开关
+            self._onlyonce = False
+
+        config_mapping = {
+            "enabled": self._enabled,
+            "onlyonce": False,
+            "cron": self._cron,
+            "notify": self._notify,
+            "libraries": self._libraries,
+            "lock": self._lock,
+            "tags_json": self._tags_json,
+            "thread_count": self._thread_count,
+            "execute_transfer": self._execute_transfer,
+            "delay": self._delay,
+            "batch_size": self._batch_size
+        }
+        self.update_config(config=config_mapping)
+
+        # 启动任务
+        if self._scheduler.get_jobs():
+            self._scheduler.print_jobs()
+            self._scheduler.start()
+
+    def service_infos(self, name_filters: Optional[List[str]] = None) -> Optional[Dict[str, ServiceInfo]]:
+        """
+        服务信息
+        """
+        services = self.mediaserver_helper.get_services(name_filters=name_filters, type_filter="plex")
+        if not services:
+            logger.warning("获取媒体服务器实例失败，请检查配置")
+            return None
+
+        active_services = {}
+        for service_name, service_info in services.items():
+            if not service_info.instance or service_info.instance.is_inactive():
+                logger.warning(f"媒体服务器 {service_name} 未连接，请检查配置")
+            else:
+                active_services[service_name] = service_info
+
+        if not active_services:
+            logger.warning("没有已连接的媒体服务器，请检查配置")
+            return None
+
+        return active_services
+
+    def service_info(self, name: str) -> Optional[ServiceInfo]:
+        """
+        服务信息
+        """
+        service = self.mediaserver_helper.get_service(name=name, type_filter="plex")
+        if not service:
+            logger.warning("获取媒体服务器实例失败，请检查配置")
+            return None
+
+        if not service.instance or service.instance.is_inactive():
+            logger.warning(f"媒体服务器 {name} 未连接，请检查配置")
+            return None
+
+        return service
+
+    def get_state(self) -> bool:
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """
+        定义远程控制命令
+        :return: 命令关键字、事件、描述、附带数据
+        """
+        pass
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        pass
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """
+        拼装插件配置页面，需要返回两块数据：1、页面配置；2、数据结构
+        """
+        return [
+            {
+                'component': 'VForm',
+                'content': [
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'enabled',
+                                            'label': '启用插件',
+                                            'hint': '开启后插件将处于激活状态',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'notify',
+                                            'label': '发送通知',
+                                            'hint': '是否在特定事件发生时发送通知',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'onlyonce',
+                                            'label': '立即运行一次',
+                                            'hint': '插件将立即运行一次',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'lock',
+                                            'label': '锁定元数据',
+                                            'hint': '部分Plex版本只有锁定时才会生效',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'execute_transfer',
+                                            'label': '入库后运行一次',
+                                            'hint': '在媒体入库后运行一次操作',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'dialog_closed',
+                                            'label': '打开标签设置窗口',
+                                            'hint': '开启时弹出窗口以增加或修改标签',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 3
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCronField',
+                                        'props': {
+                                            'model': 'cron',
+                                            'label': '执行周期',
+                                            'placeholder': '5位cron表达式',
+                                            'hint': '使用cron表达式指定执行周期，如 0 8 * * *',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 3
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'delay',
+                                            'label': '延迟时间（秒）',
+                                            'placeholder': '入库后延迟执行时间',
+                                            'hint': '入库后延迟执行的时间（秒）',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 3
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'thread_count',
+                                            'label': '运行线程数',
+                                            'hint': '执行任务时使用的线程数量，普通用户建议设置为 2 至 4',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 3
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'batch_size',
+                                            'label': '每批次处理数',
+                                            'hint': '每次处理的最大元数据条数，数值越大会占用更多单任务内存',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'multiple': True,
+                                            'chips': True,
+                                            'clearable': True,
+                                            'model': 'libraries',
+                                            'label': '媒体库',
+                                            'items': self.__get_service_library_options(),
+                                            'hint': '选择要处理的媒体库',
+                                            'persistent-hint': True
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCol',
+                                        'props': {
+                                            'cols': 12,
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'VAlert',
+                                                'props': {
+                                                    'type': 'info',
+                                                    'variant': 'tonal'
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'span',
+                                                        'text': '基于 '
+                                                    },
+                                                    {
+                                                        'component': 'a',
+                                                        'props': {
+                                                            'href': 'https://github.com/sqkkyzx/plex_localization_zhcn',
+                                                            'target': '_blank',
+                                                            'style': 'text-decoration: underline;'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'u',
+                                                                'text': 'plex_localization_zhcn'
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        'component': 'span',
+                                                        'text': '、'
+                                                    },
+                                                    {
+                                                        'component': 'a',
+                                                        'props': {
+                                                            'href': 'https://github.com/x1ao4/plex-localization-zh',
+                                                            'target': '_blank',
+                                                            'style': 'text-decoration: underline;'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'u',
+                                                                'text': 'plex-localization-zh'
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        'component': 'span',
+                                                        'text': ' 项目编写，特此感谢 '
+                                                    },
+                                                    {
+                                                        'component': 'a',
+                                                        'props': {
+                                                            'href': 'https://github.com/timmy0209',
+                                                            'target': '_blank',
+                                                            'style': 'text-decoration: underline;'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'u',
+                                                                'text': 'timmy0209'
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        'component': 'span',
+                                                        'text': '、'
+                                                    },
+                                                    {
+                                                        'component': 'a',
+                                                        'props': {
+                                                            'href': 'https://github.com/sqkkyzx',
+                                                            'target': '_blank',
+                                                            'style': 'text-decoration: underline;'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'u',
+                                                                'text': 'sqkkyzx'
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        'component': 'span',
+                                                        'text': '、'
+                                                    },
+                                                    {
+                                                        'component': 'a',
+                                                        'props': {
+                                                            'href': 'https://github.com/x1ao4',
+                                                            'target': '_blank',
+                                                            'style': 'text-decoration: underline;'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'u',
+                                                                'text': 'x1ao4'
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        'component': 'span',
+                                                        'text': '、'
+                                                    },
+                                                    {
+                                                        'component': 'a',
+                                                        'props': {
+                                                            'href': 'https://github.com/anooki-c',
+                                                            'target': '_blank',
+                                                            'style': 'text-decoration: underline;'
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'u',
+                                                                'text': 'anooki-c'
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal',
+                                            'text': '注意：如开启锁定元数据，则本地化后需要在Plex中手动解锁才允许修改，'
+                                                    '请先在测试媒体库验证无问题后再继续使用'
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "component": "VDialog",
+                        "props": {
+                            "model": "dialog_closed",
+                            "max-width": "60rem",
+                            "overlay-class": "v-dialog--scrollable v-overlay--scroll-blocked",
+                            "content-class": "v-card v-card--density-default v-card--variant-elevated rounded-t"
+                        },
+                        "content": [
+                            {
+                                "component": "VCard",
+                                "props": {
+                                    "title": "设置标签"
+                                },
+                                "content": [
+                                    {
+                                        "component": "VDialogCloseBtn",
+                                        "props": {
+                                            "model": "dialog_closed"
+                                        }
+                                    },
+                                    {
+                                        "component": "VCardText",
+                                        "props": {},
+                                        "content": [
+                                            {
+                                                'component': 'VRow',
+                                                'content': [
+                                                    {
+                                                        'component': 'VCol',
+                                                        'props': {
+                                                            'cols': 12,
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'VAceEditor',
+                                                                'props': {
+                                                                    'modelvalue': 'tags_json',
+                                                                    'lang': 'json',
+                                                                    'theme': 'monokai',
+                                                                    'style': 'height: 30rem',
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'component': 'VRow',
+                                                'content': [
+                                                    {
+                                                        'component': 'VCol',
+                                                        'props': {
+                                                            'cols': 12,
+                                                        },
+                                                        'content': [
+                                                            {
+                                                                'component': 'VAlert',
+                                                                'props': {
+                                                                    'type': 'info',
+                                                                    'variant': 'tonal',
+                                                                    'text': '注意：已预置常用标签的中英翻译，若需修改或新增可以在上述内容中添加'
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+            }
+        ], {
+            "enabled": False,
+            "notify": True,
+            "cron": "0 1 * * *",
+            "lock": False,
+            "tags_json": self.__get_preset_tags_json(),
+            "thread_count": 3,
+            "execute_transfer": False,
+            "delay": 300,
+            "batch_size": 100
+        }
+
+    def get_page(self) -> List[dict]:
+        pass
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """
+        注册插件公共服务
+        [{
+            "id": "服务ID",
+            "name": "服务名称",
+            "trigger": "触发器：cron/interval/date/CronTrigger.from_crontab()",
+            "func": self.xxx,
+            "kwargs": {} # 定时器参数
+        }]
+        """
+        if not self._enabled or not self._cron:
+            return []
+        try:
+            trigger = CronTrigger.from_crontab(self._cron)
+        except (TypeError, ValueError) as error:
+            logger.error(f"Plex中文本地化执行周期无效：{error}")
+            return []
+        logger.info(f"Plex中文本地化定时服务启动，时间间隔 {self._cron} ")
+        return [{
+            "id": "PlexLocalization",
+            "name": "Plex中文本地化",
+            "trigger": trigger,
+            "func": self.localization,
+            "kwargs": {}
+        }]
+
+    def stop_service(self):
+        """停止插件自有的一次性调度器，并标记当前扫描应尽快退出。"""
+        self._event.set()
+        try:
+            with self._scheduler_lock:
+                scheduler = self._scheduler
+                self._scheduler = None
+                if scheduler:
+                    scheduler.remove_all_jobs()
+                    if scheduler.running:
+                        scheduler.shutdown()
+        except Exception as e:
+            logger.info(str(e))
+
+    def __get_tags(self) -> dict:
+        """获取标签信息"""
+        try:
+            # 如果预置Json被清空，这里还原为默认Json
+            if not self._tags_json:
+                self._tags_json = self.__get_preset_tags_json()
+
+            # 去掉以//开始的行
+            tags_json = re.sub(r"//.*?\n", "", self._tags_json).strip()
+            tags = json.loads(tags_json)
+            return tags
+        except Exception as e:
+            logger.error(f"解析标签失败，已停用插件，请检查配置项，错误详情: {e}")
+            self._enabled = False
+
+    @staticmethod
+    def __get_preset_tags_json() -> str:
+        """获取预置Json"""
+        desc = ("// 已预置常用标签的中英翻译\n"
+                "// 若有标签需要修改或新增可以在下述内容中添加\n"
+                "// 注意无关内容需使用 // 注释\n")
+        config = """{
+            "Anime": "动画",
+            "Action": "动作",
+            "Mystery": "悬疑",
+            "Tv Movie": "电视电影",
+            "Animation": "动画",
+            "Crime": "犯罪",
+            "Family": "家庭",
+            "Fantasy": "奇幻",
+            "Disaster": "灾难",
+            "Adventure": "冒险",
+            "Short": "短片",
+            "Horror": "恐怖",
+            "History": "历史",
+            "Suspense": "悬疑",
+            "Biography": "传记",
+            "Sport": "运动",
+            "Comedy": "喜剧",
+            "Romance": "爱情",
+            "Thriller": "惊悚",
+            "Documentary": "纪录",
+            "Indie": "独立",
+            "Music": "音乐",
+            "Sci-Fi": "科幻",
+            "Western": "西部",
+            "Children": "儿童",
+            "Martial Arts": "武侠",
+            "Drama": "剧情",
+            "War": "战争",
+            "Musical": "歌舞",
+            "Film-noir": "黑色",
+            "Science Fiction": "科幻",
+            "Film-Noir": "黑色",
+            "Food": "饮食",
+            "War & Politics": "战争与政治",
+            "Sci-Fi & Fantasy": "科幻与奇幻",
+            "Mini-Series": "迷你剧",
+            "Reality": "真人秀",
+            "Home and Garden": "家居与园艺",
+            "Game Show": "游戏节目",
+            "Awards Show": "颁奖典礼",
+            "News": "新闻",
+            "Talk": "访谈",
+            "Talk Show": "脱口秀",
+            "Travel": "旅行",
+            "Soap": "肥皂剧",
+            "Rap": "说唱",
+            "Adult": "成人"
+        }"""
+        return desc + config
+
+    @eventmanager.register(EventType.TransferComplete)
+    def execute_transfer(self, event: Event):
+        """在整理完成事件后安排一次延迟本地化。"""
+        if not self._enabled:
+            return
+
+        if not self._execute_transfer:
+            return
+
+        event_data = event.snapshot().payload
+        if not isinstance(event_data, TransferResultContractData):
+            return
+
+        mediainfo: MediaSnapshot = event_data.mediainfo
+        meta: MetaSnapshot = event_data.meta
+        if not mediainfo or not meta:
+            return
+
+        # 获取媒体信息，确定季度和集数信息，如果存在则添加前缀空格
+        season_episode = f" {meta.season_episode}" if meta.season_episode else ""
+        media_desc = f"{mediainfo.title_year}{season_episode}"
+
+        # 如果最近一次入库时间为None，这里才进行赋值，否则可能是存在尚未执行的任务待执行
+        if not self._transfer_time:
+            self._transfer_time = datetime.now(tz=pytz.timezone(settings.TZ))
+
+        # 根据是否有延迟设置不同的日志消息
+        delay_message = f"{self._delay} 秒后运行一次本地化服务" if self._delay else "准备运行一次本地化服务"
+        logger.info(f"{media_desc} 已入库，{delay_message}")
+
+        with self._scheduler_lock:
+            if not self._scheduler:
+                self._scheduler = BackgroundScheduler(timezone=settings.TZ)
+
+            self._scheduler.remove_all_jobs()
+            self._scheduler.add_job(
+                func=self.__transfer_by_once,
+                trigger="date",
+                run_date=datetime.now(tz=pytz.timezone(settings.TZ)) + timedelta(seconds=self._delay),
+                name="Plex中文本地化",
+            )
+
+            if self._scheduler.get_jobs():
+                self._scheduler.print_jobs()
+                if not self._scheduler.running:
+                    self._scheduler.start()
+
+    def __transfer_by_once(self):
+        """入库后运行一次"""
+        if not self._transfer_time:
+            logger.info("没有获取到最近一次的入库时间，取消执行本地化服务")
+            return
+
+        logger.info(f"正在运行一次本地化服务，入库时间 {self._transfer_time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+        adjusted_time = self._transfer_time - timedelta(minutes=5)
+        logger.info(f"为保证入库数据完整性，前偏移5分钟后的时间：{adjusted_time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+        self.localization(added_time=int(adjusted_time.timestamp()))
+        self._transfer_time = None
+
+    def localization(self, added_time: Optional[int] = None):
+        """本地化服务"""
+        with lock:
+            self._event.clear()
+            logger.info(f"正在准备执行本地化服务")
+            service_libraries = self.__get_service_libraries()
+            if not service_libraries:
+                logger.error(f"Plex 配置不正确，请检查")
+                return
+            logger.info(f"正在准备本地化的媒体库 {service_libraries}")
+            self.__loop_all(service_libraries=service_libraries, thread_count=self._thread_count, added_time=added_time)
+
+    def __get_service_library_options(self):
+        """
+        获取媒体库选项
+        """
+        library_options = []
+        service_infos = self.service_infos()
+        if not service_infos:
+            return library_options
+
+        # 获取所有媒体库
+        for service in service_infos.values():
+            plex = service.instance
+            if not plex or not plex.get_plex():
+                continue
+            plex_server = plex.get_plex()
+            libraries = sorted(plex_server.library.sections(), key=lambda x: x.key)
+            # 遍历媒体库，创建字典并添加到列表中
+            for library in libraries:
+                # 排除照片库
+                if library.TYPE == "photo":
+                    continue
+                library_dict = {
+                    "title": f"{service.name} - {library.key}. {library.title} ({library.TYPE})",
+                    "value": f"{service.name}.{library.key}"
+                }
+                library_options.append(library_dict)
+        return library_options
+
+    def __get_service_libraries(self) -> Optional[Dict[str, Dict[int, Any]]]:
+        """
+        获取 Plex 媒体库信息
+        """
+        if not self._libraries:
+            return None
+
+        service_libraries = defaultdict(set)
+
+        # 1. 处理本地 _libraries，提取出 service_name 和 library_key
+        for library in self._libraries:
+            if not library:
+                continue
+            if "." in library:
+                service_name, library_key = library.split(".", 1)
+                service_libraries[service_name].add(library_key)
+
+        # 2. 获取 service_infos 对象
+        service_infos = self.service_infos(name_filters=list(service_libraries.keys()))
+        if not service_infos:
+            return None
+
+        # 创建存放交集的字典，value 也是字典，key 为 int(library.key)，value 为 library 对象
+        intersected_libraries = {}
+
+        # 3. 遍历 service_infos，验证 Plex 实例并获取媒体库
+        for service_name, library_keys in service_libraries.items():
+            service_info = service_infos.get(service_name)
+            if not service_info or not service_info.instance:
+                continue
+
+            plex = service_info.instance
+            plex_server = plex.get_plex()
+            if not plex_server:
+                continue
+
+            libraries = plex_server.library.sections()
+
+            # 4. 获取 Plex 实例中的有效媒体库，进行比对
+            remote_libraries = {
+                int(library.key): library  # 键为 int(library.key)，值为 library 对象
+                for library in libraries if library.TYPE != "photo"
+            }
+
+            # 计算本地库和远程库的交集，保留匹配的库
+            matched_libraries = {
+                key: library
+                for key, library in remote_libraries.items()
+                if str(key) in library_keys
+            }
+
+            # 如果存在交集，添加到最终结果
+            if matched_libraries:
+                intersected_libraries[service_name] = matched_libraries
+
+        # 5. 返回交集
+        return intersected_libraries if intersected_libraries else None
+
+    def __list_rating_keys(self, plex: Any, library: LibrarySection, type_id: int, is_collection: bool = False,
+                           added_time: Optional[int] = None):
+        """
+        分页获取媒体项目。返回 ratingKey 列表及 complete/failed/stopped 状态。
+        """
+        if not library:
+            return [], "complete"
+
+        if is_collection:
+            endpoint = f"/library/sections/{library.key}/collections"
+        else:
+            endpoint = f"/library/sections/{library.key}/all?type={type_id}"
+            if added_time:
+                endpoint += f"&addedAt>={added_time}"
+
+        rating_keys = []
+        offset = 0
+        previous_page = None
+        while True:
+            if self._event.is_set():
+                return rating_keys, "stopped"
+
+            response = plex.get_data(
+                endpoint=endpoint,
+                headers={
+                    "X-Plex-Container-Start": str(offset),
+                    "X-Plex-Container-Size": str(self._page_size)
+                },
+                timeout=self._timeout
+            )
+            if self._event.is_set():
+                return rating_keys, "stopped"
+            if response is None or response.status_code >= 400:
+                logger.warning(f"分页读取媒体项目失败，媒体库：{library.title}，offset={offset}")
+                return rating_keys, "failed"
+
+            try:
+                payload = response.json()
+                if not isinstance(payload, dict):
+                    raise ValueError("响应体不是对象")
+                if "MediaContainer" not in payload:
+                    raise ValueError("缺少 MediaContainer")
+                container = payload["MediaContainer"]
+                if not isinstance(container, dict):
+                    raise ValueError("MediaContainer 不是对象")
+                page_items = container.get("Metadata", [])
+                if not isinstance(page_items, list) \
+                        or any(not isinstance(data, dict) for data in page_items):
+                    raise ValueError("Metadata 不是对象列表")
+                total_size_value = container.get("totalSize")
+                total_size = int(total_size_value) if total_size_value is not None else None
+                if total_size is not None and total_size < 0:
+                    raise ValueError("totalSize 不能为负数")
+            except (AttributeError, TypeError, ValueError) as e:
+                logger.warning(f"分页响应解析失败，媒体库：{library.title}，offset={offset}，错误：{e}")
+                return rating_keys, "failed"
+
+            response_offset = container.get("offset")
+            if response_offset is not None:
+                try:
+                    if int(response_offset) != offset:
+                        logger.warning(f"分页响应位置不匹配，媒体库：{library.title}，"
+                                       f"请求 offset={offset}，响应 offset={response_offset}")
+                        return rating_keys, "failed"
+                except (TypeError, ValueError):
+                    logger.warning(f"分页响应位置无效，媒体库：{library.title}，offset={response_offset}")
+                    return rating_keys, "failed"
+
+            page_keys = [
+                str(data.get("ratingKey"))
+                for data in page_items
+                if data.get("ratingKey") is not None
+            ]
+            if offset and page_items and page_items == previous_page:
+                logger.warning(f"分页响应未推进，媒体库：{library.title}，offset={offset}")
+                return rating_keys, "failed"
+
+            rating_keys.extend(page_keys)
+            logger.debug(f"媒体库 {library.title} 分页读取完成：offset={offset}，"
+                         f"本页 {len(page_keys)} 条，累计 {len(rating_keys)} 条")
+
+            next_offset = offset + len(page_items)
+            if total_size is not None:
+                if next_offset >= total_size:
+                    break
+                if not page_items:
+                    logger.warning(f"分页响应提前结束，媒体库：{library.title}，offset={offset}，"
+                                   f"totalSize={total_size}")
+                    return rating_keys, "failed"
+            elif not page_items or len(page_items) < self._page_size:
+                break
+
+            previous_page = page_items
+            offset = next_offset
+
+        if len(rating_keys):
+            logger.info(f"<{library.title} {plexapi.utils.reverseSearchType(libtype=type_id)}> "
+                        f"类型共计 {len(rating_keys)} 个{'合集' if is_collection else ''}")
+
+        return rating_keys, "complete"
+
+    def __fetch_item(self, plex: Any, rating_key):
+        """
+        获取条目信息
+        """
+        endpoint = f"/library/metadata/{rating_key}"
+        response = plex.get_data(endpoint=endpoint, timeout=self._timeout)
+        if response is None or response.status_code >= 400:
+            return None
+        datas = (response
+                 .json()
+                 .get("MediaContainer", {})
+                 .get("Metadata", []))
+        return datas[0] if datas else None
+
+    def __fetch_all_items(self, plex: Any, rating_keys):
+        """
+        批量获取条目
+        """
+        endpoint = f"/library/metadata/{','.join(rating_keys)}"
+        response = plex.get_data(endpoint=endpoint, timeout=self._timeout)
+        if response is None or response.status_code >= 400:
+            return None
+        items = (response
+                 .json()
+                 .get("MediaContainer", {})
+                 .get("Metadata", []))
+        return items
+
+    def __put_item_metadata(self, plex: Any, rating_key: str, library_id: int, params: dict,
+                            expected_sort_title: Optional[str], expected_tags: Dict[str, List[str]]) -> bool:
+        """一次提交同一条目的全部元数据变更。最终状态由批次统一回读。"""
+        response = plex.put_data(
+            endpoint=f"/library/sections/{library_id}/all",
+            params=params,
+            timeout=self._timeout)
+        if response is None or response.status_code >= 400:
+            logger.warning(f"更新元数据失败，ratingKey={rating_key}，状态码："
+                           f"{response.status_code if response is not None else '无响应'}")
+            return False
+        return True
+
+    @staticmethod
+    def __metadata_differences(item: Optional[dict], expected_sort_title: Optional[str],
+                               expected_tags: Dict[str, List[str]]) -> List[str]:
+        """比较 Plex 最终元数据与本次写入期望，返回差异说明。"""
+        if not item:
+            return ["无法读取最终状态"]
+
+        differences = []
+        if expected_sort_title is not None:
+            actual_sort_title = item.get("titleSort")
+            if actual_sort_title != expected_sort_title:
+                differences.append(f"标题排序期望：{expected_sort_title}，实际：{actual_sort_title or ''}")
+
+        for tag_type, target_tags in expected_tags.items():
+            field_name = tag_type.capitalize()
+            actual_tags = [tag.get("tag") for tag in item.get(field_name, []) if tag.get("tag")]
+            if set(actual_tags) != set(target_tags):
+                differences.append(f"{tag_type}标签期望：{target_tags}，实际：{actual_tags}")
+        return differences
+
+    @staticmethod
+    def __empty_result_counts() -> Dict[str, int]:
+        """创建批次统计，确保停止路径也参与守恒。"""
+        return {"updated": 0, "failed": 0, "skipped": 0, "unprocessed": 0}
+
+    @staticmethod
+    def __merge_result_counts(target: Dict[str, int], source: Dict[str, int]):
+        """把子块统计合并到业务批次。"""
+        for key in target:
+            target[key] += source[key]
+
+    def __process_rating_key(self, plex: Any, rating_key: str):
+        """
+        处理媒体标识
+        """
+        if not rating_key:
+            return
+        item = self.__fetch_item(plex=plex, rating_key=rating_key)
+        if not item:
+            return
+        self.__process_item(plex=plex, item=item)
+
+    def __process_items_batch(self, plex: Any, rating_keys):
+        """
+        按固定 HTTP 子块处理业务批次，返回更新、失败、跳过和未处理数量。
+        """
+        result_counts = self.__empty_result_counts()
+        for offset in range(0, len(rating_keys), self._metadata_chunk_size):
+            chunk_keys = rating_keys[offset:offset + self._metadata_chunk_size]
+            if self._event.is_set():
+                result_counts["unprocessed"] += len(rating_keys) - offset
+                break
+
+            try:
+                chunk_result = self.__process_items_chunk(plex=plex, rating_keys=chunk_keys)
+            except Exception as e:
+                logger.error(f"处理元数据子块失败，首个 ratingKey={chunk_keys[0] if chunk_keys else ''}: {e}",
+                             exc_info=True)
+                chunk_result = self.__empty_result_counts()
+                chunk_result["failed"] = len(chunk_keys)
+            self.__merge_result_counts(result_counts, chunk_result)
+        return result_counts
+
+    def __process_items_chunk(self, plex: Any, rating_keys: List[str]) -> Dict[str, int]:
+        """读取并处理一个不超过安全上限的 HTTP 子块。"""
+        items = self.__fetch_all_items(plex=plex, rating_keys=rating_keys)
+        if items is None:
+            result_counts = self.__empty_result_counts()
+            result_counts["failed"] = len(rating_keys)
+            return result_counts
+        return self.__process_loaded_items(plex=plex, rating_keys=rating_keys, items=items)
+
+    def __process_loaded_items(self, plex: Any, rating_keys: List[str], items: List[dict]) -> Dict[str, int]:
+        """对已读取元数据执行逐条 PUT，并统一回读成功写入。"""
+        result_counts = self.__empty_result_counts()
+        items_by_rating_key = {
+            str(item.get("ratingKey")): item
+            for item in items
+            if item and item.get("ratingKey") is not None
+        }
+        pending_verification = []
+
+        for index, rating_key in enumerate(rating_keys):
+            if self._event.is_set():
+                result_counts["unprocessed"] += len(rating_keys) - index
+                break
+
+            item = items_by_rating_key.get(str(rating_key))
+            if not item:
+                result_counts["failed"] += 1
+                logger.warning(f"批量读取条目缺失，ratingKey={rating_key}")
+                continue
+
+            try:
+                edit_plan = self.__prepare_item_edit(item=item)
+            except Exception as e:
+                result_counts["failed"] += 1
+                logger.error(f"处理条目失败，ratingKey={rating_key}: {e}", exc_info=True)
+                continue
+
+            if edit_plan is None:
+                result_counts["skipped"] += 1
+                continue
+
+            if self._event.is_set():
+                result_counts["unprocessed"] += len(rating_keys) - index
+                break
+
+            try:
+                updated = self.__put_item_metadata(
+                    plex=plex,
+                    rating_key=edit_plan["rating_key"],
+                    library_id=edit_plan["library_id"],
+                    params=edit_plan["params"],
+                    expected_sort_title=edit_plan["expected_sort_title"],
+                    expected_tags=edit_plan["expected_tags"]
+                )
+            except Exception as e:
+                result_counts["failed"] += 1
+                logger.error(f"更新元数据异常，ratingKey={rating_key}: {e}", exc_info=True)
+                continue
+            if not updated:
+                result_counts["failed"] += 1
+                continue
+            pending_verification.append(edit_plan)
+
+        if not pending_verification:
+            return result_counts
+
+        if self._event.is_set():
+            result_counts["failed"] += len(pending_verification)
+            return result_counts
+
+        verification_keys = [plan["rating_key"] for plan in pending_verification]
+        final_items = self.__fetch_all_items(plex=plex, rating_keys=verification_keys)
+        if final_items is None:
+            result_counts["failed"] += len(pending_verification)
+            return result_counts
+
+        final_items_by_key = {
+            str(item.get("ratingKey")): item
+            for item in final_items
+            if item and item.get("ratingKey") is not None
+        }
+        for plan in pending_verification:
+            rating_key = plan["rating_key"]
+            try:
+                differences = self.__metadata_differences(
+                    item=final_items_by_key.get(rating_key),
+                    expected_sort_title=plan["expected_sort_title"],
+                    expected_tags=plan["expected_tags"]
+                )
+            except Exception as e:
+                result_counts["failed"] += 1
+                logger.error(f"验证元数据异常，ratingKey={rating_key}: {e}", exc_info=True)
+                continue
+            if differences:
+                result_counts["failed"] += 1
+                logger.warning(f"更新元数据未完全生效，ratingKey={rating_key}，{'；'.join(differences)}")
+                continue
+
+            result_counts["updated"] += 1
+            for message in plan["success_logs"]:
+                logger.info(message)
+        return result_counts
+
+    def __process_item(self, plex: Any, item: dict) -> Optional[bool]:
+        """
+        处理元数据。返回 True 表示更新成功，False 表示更新失败，None 表示无需处理。
+        """
+        if not item or item.get("ratingKey") is None:
+            return None
+        result = self.__process_loaded_items(
+            plex=plex,
+            rating_keys=[str(item.get("ratingKey"))],
+            items=[item]
+        )
+        if result["updated"]:
+            return True
+        if result["failed"]:
+            return False
+        return None
+
+    def __prepare_item_edit(self, item: dict) -> Optional[dict]:
+        """计算单条元数据的原子编辑计划，不执行网络请求。"""
+        if not item:
+            return
+
+        rating_key = item.get("ratingKey")
+        library_id = item.get("librarySectionID")
+        if not rating_key or not library_id:
+            return
+
+        item_type = item.get("type")
+        if not item_type:
+            return
+
+        type_id = plexapi.utils.searchType(libtype=item_type)
+        title = item.get("title", "")
+        locked_fields = [field["name"] for field in item.get("Field") or [] if field.get("locked")]
+        edit_params = {
+            "type": type_id,
+            "id": rating_key,
+            "includeExternalMedia": 1
+        }
+        expected_sort_title = None
+        sort_title_changed = False
+        expected_tags = {}
+        tag_updates = []
+        current_sort_title = item.get("titleSort")
+
+        # 如果标题排序没有锁定，尝试更新标题排序
+        if "titleSort" in locked_fields:
+            logger.debug(f"{title}: titleSort is locked, skip")
+        else:
+            if not current_sort_title or StringUtils.is_chinese(current_sort_title):
+                generated_sort_title = self.__convert_to_pinyin(title)
+                if generated_sort_title != title:
+                    expected_sort_title = generated_sort_title
+                    sort_title_changed = True
+                    edit_params.update({
+                        "titleSort.value": expected_sort_title,
+                        "titleSort.locked": 1 if self._lock else 0
+                    })
+
+        tags: dict[str, list] = {
+            "genre": [genre.get("tag") for genre in item.get("Genre", {})],  # 流派
+            "style": [style.get("tag") for style in item.get("Style", {})],  # 风格
+            "mood": [mood.get("tag") for mood in item.get("Mood", {})]  # 情绪
+        }
+
+        # 汉化标签
+        for tag_type, tag_list in tags.items():
+            if tag_list:
+                # 如果标签类型没有锁定，尝试更新标签类型
+                if tag_type in locked_fields:
+                    logger.debug(f"{title}: {tag_type} is locked, skip")
+                else:
+                    target_tags = []
+                    source_tags_to_remove = []
+                    for tag in tag_list:
+                        new_tag = self._tags.get(tag)
+                        if new_tag:
+                            tag_updates.append((tag, new_tag))
+                            source_tags_to_remove.append(tag)
+                        target_tag = new_tag or tag
+                        if target_tag not in target_tags:
+                            target_tags.append(target_tag)
+
+                    if source_tags_to_remove:
+                        expected_tags[tag_type] = target_tags
+                        edit_params[f"{tag_type}.locked"] = 1 if self._lock else 0
+                        for index, target_tag in enumerate(target_tags):
+                            edit_params[f"{tag_type}[{index}].tag.tag"] = target_tag
+                        # Plex 的 tag- 协议使用逗号分隔值；逐项预编码可保留标签内的特殊字符。
+                        edit_params[f"{tag_type}[].tag.tag-"] = ",".join(
+                            quote(str(tag)) for tag in source_tags_to_remove
+                        )
+
+        # Plex 会重置同一编辑请求中未携带的未锁定字段；标签变更时必须显式保持已有排序标题。
+        if expected_tags and expected_sort_title is None \
+                and current_sort_title and "titleSort" not in locked_fields:
+            expected_sort_title = current_sort_title
+            edit_params.update({
+                "titleSort.value": current_sort_title,
+                "titleSort.locked": 1 if self._lock else 0
+            })
+
+        if expected_sort_title is None and not expected_tags:
+            logger.debug(f"{title}（ratingKey={rating_key}）无需更新，跳过")
+            return None
+
+        success_logs = []
+        if sort_title_changed:
+            success_logs.append(f"{title} < {expected_sort_title} >")
+        for tag, new_tag in tag_updates:
+            success_logs.append(f"{title}: {tag} → {new_tag}")
+        return {
+            "rating_key": str(rating_key),
+            "library_id": library_id,
+            "params": edit_params,
+            "expected_sort_title": expected_sort_title,
+            "expected_tags": expected_tags,
+            "success_logs": success_logs
+        }
+
+    def __loop_all(self, service_libraries: Dict[str, Dict[int, Any]], thread_count: int = None,
+                   added_time: Optional[int] = None):
+        """
+        选择媒体库并遍历其中的每一个媒体
+        """
+        if not self._tags:
+            logger.warning("标签本地化配置不能为空，请检查")
+            return
+
+        logger.info(f"当前标签本地化配置为：{self._tags}")
+        overall_start_time = time.time()
+        thread_count = thread_count or 3
+        logger.info(f"正在运行中文本地化，线程数：{thread_count}，锁定元数据：{self._lock}")
+
+        overall_results = {"updated": 0, "failed": 0, "skipped": 0, "unprocessed": 0}
+        completed_services = 0
+        discovered_items = 0
+        failed_services = 0
+        stopped = False
+
+        for service_name, libraries in service_libraries.items():
+            if self._event.is_set():
+                stopped = True
+                break
+
+            service = self.service_info(name=service_name)
+            if not service or not service.instance:
+                failed_services += 1
+                logger.warning(f"获取媒体服务器 {service_name} 实例失败，跳过处理")
+                continue
+
+            service_start_time = time.time()
+            logger.info(f"开始处理媒体服务器 {service.name}")
+
+            # 生成所有需要处理的rating keys
+            rating_keys, scan_status = self.__generate_all_rating_keys(
+                plex=service.instance,
+                libraries=libraries,
+                with_collection=added_time is None,
+                added_time=added_time
+            )
+            if scan_status == "stopped":
+                stopped = True
+                break
+            if scan_status != "complete":
+                failed_services += 1
+                logger.warning(f"媒体服务器 {service.name} 枚举不完整，跳过本次处理")
+                continue
+            discovered_items += len(rating_keys)
+
+            # 分批处理rating keys
+            service_results = self.__process_rating_keys_in_batches(
+                plex=service.instance,
+                rating_keys=rating_keys,
+                thread_count=thread_count,
+                batch_size=self._batch_size
+            )
+            for key in overall_results:
+                overall_results[key] += service_results[key]
+
+            service_elapsed_time = time.time() - service_start_time
+            if self._event.is_set():
+                stopped = True
+                logger.warning(f"媒体服务器 {service.name} 处理已停止，耗时 {service_elapsed_time:.2f} 秒")
+                break
+            completed_services += 1
+            logger.info(f"媒体服务器 {service.name} 处理完成，耗时 {service_elapsed_time:.2f} 秒")
+
+        overall_elapsed_time = time.time() - overall_start_time
+        if added_time:
+            formatted_added_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(added_time))
+            message_text = f"最近一次入库时间：{formatted_added_time}，Plex本地化完成，用时 {overall_elapsed_time :.2f} 秒"
+        else:
+            message_text = f"Plex本地化完成，用时 {overall_elapsed_time :.2f} 秒"
+
+        result_text = (f"完整服务 {completed_services}，失败服务 {failed_services}，发现 {discovered_items}，"
+                       f"更新 {overall_results['updated']}，失败 {overall_results['failed']}，"
+                       f"跳过 {overall_results['skipped']}，未处理 {overall_results['unprocessed']}")
+        if stopped:
+            logger.warning(f"Plex本地化已停止，{result_text}，用时 {overall_elapsed_time:.2f} 秒")
+        elif failed_services:
+            logger.warning(f"Plex本地化未完整完成，{result_text}，"
+                           f"用时 {overall_elapsed_time:.2f} 秒")
+        else:
+            self.__send_message(title="【Plex中文本地化】", text=message_text)
+            logger.info(f"{message_text}，{result_text}")
+
+    def __generate_all_rating_keys(self, plex: Any, libraries, with_collection: bool = True,
+                                   added_time: Optional[int] = None):
+        """
+        生成所有库中唯一且保持首次发现顺序的 ratingKey 列表。
+        """
+        rating_keys = []
+        seen_keys = set()
+
+        def append_unique(keys):
+            """保留跨类型和合集首次出现的 ratingKey。"""
+            for rating_key in keys:
+                if rating_key not in seen_keys:
+                    seen_keys.add(rating_key)
+                    rating_keys.append(rating_key)
+
+        for library in libraries.values():
+            library_types = TYPES.get(library.type, [])
+            for type_id in library_types:
+                keys, status = self.__list_rating_keys(
+                    plex=plex,
+                    library=library,
+                    type_id=type_id,
+                    added_time=added_time
+                )
+                if status != "complete":
+                    return [], status
+                append_unique(keys)
+
+            if with_collection and library_types:
+                keys, status = self.__list_rating_keys(
+                    plex=plex,
+                    library=library,
+                    type_id=library_types[0],
+                    is_collection=True
+                )
+                if status != "complete":
+                    return [], status
+                append_unique(keys)
+
+        return rating_keys, "complete"
+
+    def __process_rating_keys_in_batches(self, plex: Any, rating_keys, thread_count, batch_size=100):
+        """
+        有界提交批次并汇总所有 ratingKey 的终态。
+        """
+        total_keys_count = len(rating_keys)
+        total_batches = (total_keys_count + batch_size - 1) // batch_size
+
+        logger.info(f"总条目：{total_keys_count}，每批处理条数：{batch_size}，总批次数：{total_batches}，准备开始执行")
+
+        pending = {}
+        completed_batches = 0
+        failed_batches = 0
+        total_results = {"updated": 0, "failed": 0, "skipped": 0, "unprocessed": 0}
+        next_start = 0
+        max_pending = thread_count * 2
+
+        def collect_done(done_futures):
+            """汇总已终结 Future，异常批次按失败处理。"""
+            nonlocal completed_batches, failed_batches
+            for future in done_futures:
+                batch_index, batch_keys = pending.pop(future)
+                try:
+                    batch_results = future.result()
+                    logger.debug(f"第{batch_index + 1}批次处理完成："
+                                 f"更新 {batch_results['updated']}，失败 {batch_results['failed']}，"
+                                 f"跳过 {batch_results['skipped']}，未处理 {batch_results['unprocessed']}")
+                    completed_batches += 1
+                    for key in total_results:
+                        total_results[key] += batch_results[key]
+                except Exception as e:
+                    failed_batches += 1
+                    total_results["failed"] += len(batch_keys)
+                    logger.error(f"第{batch_index + 1}批次处理过程中发生错误: {e}", exc_info=True)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=thread_count) as executor:
+            while next_start < total_keys_count or pending:
+                while next_start < total_keys_count and len(pending) < max_pending \
+                        and not self._event.is_set():
+                    batch_keys = rating_keys[next_start:next_start + batch_size]
+                    future = executor.submit(self.__process_items_batch, plex, batch_keys)
+                    pending[future] = (next_start // batch_size, batch_keys)
+                    next_start += len(batch_keys)
+
+                if self._event.is_set():
+                    for future, (_, batch_keys) in list(pending.items()):
+                        if future.cancel():
+                            pending.pop(future)
+                            total_results["unprocessed"] += len(batch_keys)
+
+                if not pending:
+                    break
+
+                done, _ = concurrent.futures.wait(
+                    pending,
+                    return_when=concurrent.futures.FIRST_COMPLETED
+                )
+                collect_done(done)
+
+            if next_start < total_keys_count:
+                total_results["unprocessed"] += total_keys_count - next_start
+
+        logger.info(f"处理完毕，完成批次数：{completed_batches}，异常批次数：{failed_batches}，"
+                    f"更新条目：{total_results['updated']}，失败条目：{total_results['failed']}，"
+                    f"跳过条目：{total_results['skipped']}，未处理条目：{total_results['unprocessed']}")
+        return total_results
+
+    @staticmethod
+    def __extract_tags(datas: Any, attribute_name: str) -> list:
+        """
+        从实体对象列表中提取指定属性的值。
+        :param datas: 实体对象列表。
+        :param attribute_name: 要提取的属性名称。
+        :return: 属性值列表。
+        """
+        return [getattr(data, attribute_name, None) for data in datas if
+                getattr(data, attribute_name, None)]
+
+    @staticmethod
+    def __convert_to_pinyin(text):
+        """将字符串转换为拼音首字母形式。"""
+        str_a = pypinyin.pinyin(text, style=pypinyin.FIRST_LETTER)
+        str_b = [str(str_a[i][0]).upper() for i in range(len(str_a))]
+        return "".join(str_b).replace("：", ":").replace("（", "(").replace("）", ")").replace("，", ",")
+
+    def __send_message(self, title: str, text: str):
+        """
+        发送消息
+        """
+        if not self._notify:
+            return
+
+        self.post_message(mtype=MessageType.SiteMessage, title=title, text=text)

--- a/plugins.v3/plexlocalization/pyproject.toml
+++ b/plugins.v3/plexlocalization/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "moviepilot-plugin-plexlocalization"
+dynamic = ["version"]
+requires-python = ">=3.12"
+dependencies = [
+    "pypinyin~=0.51.0",
+]

--- a/tests/v3/auxiliaryauth/test_auxiliaryauth.py
+++ b/tests/v3/auxiliaryauth/test_auxiliaryauth.py
@@ -1,0 +1,220 @@
+"""AuxiliaryAuth V3 的认证事件、服务筛选和生命周期合同测试。"""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from app.plugins import auxiliaryauth
+from app.plugins.auxiliaryauth import AuxiliaryAuth
+from app.runtime.extensions.plugin.contracts import supports_plugin_hook
+from app.schemas.event import AuthInterceptCredentials
+from app.schemas.types import ChainEventType
+from app.sdk.events import Event
+
+
+def _plugin(*, enabled: bool = True, mediaservers: list[str] | None = None) -> AuxiliaryAuth:
+    """构造不依赖完整插件 Runtime 的纯逻辑实例。"""
+    plugin = object.__new__(AuxiliaryAuth)
+    plugin.mediaserver_helper = MagicMock()
+    plugin._enabled = enabled
+    plugin._mediaservers = ["Plex A"] if mediaservers is None else mediaservers
+    plugin._allow_anonymous = False
+    return plugin
+
+
+def _service(name: str, *, inactive: bool = False, instance: bool = True) -> SimpleNamespace:
+    """构造媒体服务信息及可控的连接状态。"""
+    service_instance = (
+        SimpleNamespace(is_inactive=MagicMock(return_value=inactive))
+        if instance
+        else None
+    )
+    return SimpleNamespace(name=name, instance=service_instance, type="plex")
+
+
+def _event(*, channel: str = "Plex", service: str = "Plex A", cancel: bool = False) -> Event:
+    """构造经过认证事件 schema 校验的链式事件。"""
+    payload = AuthInterceptCredentials(
+        username="alice",
+        channel=channel,
+        service=service,
+        status="completed",
+        token="test-token",
+        cancel=cancel,
+    )
+    return Event(ChainEventType.AuthIntercept, payload)
+
+
+def test_v3_source_uses_sdk_boundaries_and_public_auth_schema() -> None:
+    """V3 实现通过公开 SDK 访问事件、日志和媒体服务，认证载荷使用公开 schema。"""
+    source_path = Path(__file__).parents[3] / "plugins.v3" / "auxiliaryauth" / "__init__.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+    assert AuxiliaryAuth.plugin_version == "2.0.0"
+    assert "app.sdk.events" in imported_modules
+    assert "app.sdk.logging" in imported_modules
+    assert "app.sdk.services" in imported_modules
+    assert "app.schemas.event" in imported_modules
+    assert not any(
+        module.startswith(
+            ("app.compat", "app.core", "app.helper", "app.log", "app.utils", "app.db")
+        )
+        for module in imported_modules
+    )
+
+
+def test_init_plugin_resets_state_and_parses_selection(monkeypatch) -> None:
+    """重载配置时应重置开关、媒体服务选择和历史匿名认证状态。"""
+    helper = MagicMock()
+    monkeypatch.setattr(auxiliaryauth, "MediaServerHelper", lambda: helper)
+    plugin = object.__new__(AuxiliaryAuth)
+    plugin._enabled = True
+    plugin._mediaservers = ["old"]
+    plugin._allow_anonymous = True
+
+    plugin.init_plugin({"enabled": False, "mediaservers": ("Plex A",), "allow_anonymous": False})
+
+    assert plugin.mediaserver_helper is helper
+    assert plugin.get_state() is False
+    assert plugin._mediaservers == ["Plex A"]
+    assert plugin._allow_anonymous is False
+
+    plugin.init_plugin()
+    assert plugin.get_state() is False
+    assert plugin._mediaservers == []
+    assert plugin._allow_anonymous is False
+
+
+def test_service_infos_returns_only_connected_selected_services() -> None:
+    """服务目录只保留配置选中的可用实例，并安全处理空实例。"""
+    plugin = _plugin(mediaservers=["Plex A", "Plex B", "Plex C"])
+    active = _service("Plex A")
+    inactive = _service("Plex B", inactive=True)
+    missing = _service("Plex C", instance=False)
+    plugin.mediaserver_helper.get_services.return_value = {
+        "Plex A": active,
+        "Plex B": inactive,
+        "Plex C": missing,
+    }
+
+    assert plugin.service_infos == {"Plex A": active}
+    plugin.mediaserver_helper.get_services.assert_called_once_with(
+        name_filters=["Plex A", "Plex B", "Plex C"]
+    )
+
+
+def test_service_infos_returns_none_without_selection_or_available_service() -> None:
+    """没有选中服务或没有可用实例时返回空结果。"""
+    plugin = _plugin(mediaservers=[])
+    assert plugin.service_infos is None
+    plugin.mediaserver_helper.get_services.assert_not_called()
+
+    plugin._mediaservers = ["Plex A"]
+    plugin.mediaserver_helper.get_services.return_value = {}
+    assert plugin.service_infos is None
+
+
+def test_disabled_plugin_does_not_touch_auth_event() -> None:
+    """停用插件必须保持认证事件不变，也不能查询媒体服务。"""
+    plugin = _plugin(enabled=False)
+    event = _event()
+
+    plugin.handle_auth_intercept(event)
+
+    assert event.event_data.cancel is False
+    assert event.event_data.source == "未知拦截源"
+    plugin.mediaserver_helper.get_services.assert_not_called()
+
+
+def test_already_cancelled_event_is_not_modified() -> None:
+    """已被其他处理器拦截的事件必须保持原状态。"""
+    plugin = _plugin()
+    event = _event(cancel=True)
+
+    plugin.handle_auth_intercept(event)
+
+    assert event.event_data.cancel is True
+    assert event.event_data.source == "未知拦截源"
+    plugin.mediaserver_helper.get_services.assert_not_called()
+
+
+@pytest.mark.parametrize("channel", ["Emby", "Jellyfin", "Plex"])
+def test_selected_connected_supported_channel_is_allowed(channel: str) -> None:
+    """三个受支持渠道在已选且连接的服务上允许认证通过。"""
+    plugin = _plugin()
+    service = _service("Plex A")
+    plugin.mediaserver_helper.get_services.return_value = {"Plex A": service}
+    event = _event(channel=channel)
+
+    plugin.handle_auth_intercept(event)
+
+    assert event.event_data.cancel is False
+    assert event.event_data.source == "未知拦截源"
+
+
+def test_supported_channel_is_intercepted_when_service_is_unavailable() -> None:
+    """受支持渠道找不到已连接服务时必须取消认证并标记来源。"""
+    plugin = _plugin()
+    plugin.mediaserver_helper.get_services.return_value = {
+        "Plex A": _service("Plex A", inactive=True)
+    }
+    event = _event(channel="Plex", service="Plex A")
+
+    plugin.handle_auth_intercept(event)
+
+    assert event.event_data.cancel is True
+    assert event.event_data.source == plugin.plugin_name
+
+
+def test_unsupported_channel_is_passed_through_without_service_lookup() -> None:
+    """未支持渠道不由插件判断，保持事件原状态并放行后续处理器。"""
+    plugin = _plugin()
+    event = _event(channel="Navidrome")
+
+    plugin.handle_auth_intercept(event)
+
+    assert event.event_data.cancel is False
+    assert event.event_data.source == "未知拦截源"
+    plugin.mediaserver_helper.get_services.assert_not_called()
+
+
+def test_lifecycle_and_empty_capabilities_are_explicit() -> None:
+    """插件无命令、API、后台服务和详情页时显式返回空能力。"""
+    plugin = _plugin(enabled=False)
+
+    assert plugin.get_command() == []
+    assert plugin.get_api() == []
+    assert plugin.get_page() is None
+    assert supports_plugin_hook(plugin, "get_page") is False
+    assert plugin.get_service() == []
+    plugin.stop_service()
+
+
+def test_form_exposes_configured_media_server_names() -> None:
+    """配置表单应从公开媒体服务助手读取服务名称，并提供空选择默认值。"""
+    plugin = _plugin(enabled=False)
+    plugin.mediaserver_helper.get_configs.return_value = {
+        "Plex A": SimpleNamespace(name="Plex A", type="plex"),
+        "Emby A": SimpleNamespace(name="Emby A", type="emby"),
+    }
+
+    form, defaults = plugin.get_form()
+    select = form[0]["content"][1]["content"][0]["content"][0]
+
+    assert select["component"] == "VSelect"
+    assert select["props"]["items"] == [
+        {"title": "Plex A", "value": "Plex A"},
+        {"title": "Emby A", "value": "Emby A"},
+    ]
+    assert defaults == {
+        "enabled": False,
+        "mediaservers": [],
+        "allow_anonymous": False,
+    }

--- a/tests/v3/plexautolanguages/test_plexautolanguages.py
+++ b/tests/v3/plexautolanguages/test_plexautolanguages.py
@@ -1,0 +1,402 @@
+"""PlexAutoLanguages V3 的宿主边界、配置和生命周期合同测试。"""
+
+from __future__ import annotations
+
+import ast
+import threading
+from pathlib import Path
+from queue import Queue
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app.plugins import plexautolanguages
+from app.plugins.plexautolanguages import PlexAutoLanguages
+from app.plugins.plexautolanguages.core.exceptions import InvalidConfiguration
+from app.plugins.plexautolanguages.core.plex_alert_handler import PlexAlertHandler
+from app.plugins.plexautolanguages.core.plex_server import PlexServer
+from app.plugins.plexautolanguages.core.plex_server_cache import PlexServerCache
+from app.plugins.plexautolanguages.core.utils.configuration import Configuration
+from app.plugins.plexautolanguages.languageprovider import LanguageProvider
+from app.runtime.extensions.plugin.contracts import supports_plugin_hook
+
+PLUGIN_ROOT = Path(__file__).parents[3] / "plugins.v3" / "plexautolanguages"
+
+
+def _service(
+        name: str = "Plex",
+        *,
+        inactive: bool = False,
+        host: str = "plex.example:32400",
+        token: str = "test-token",
+) -> SimpleNamespace:
+    """构造宿主媒体服务目录返回的最小 ServiceInfo 形状。"""
+    instance = SimpleNamespace(is_inactive=MagicMock(return_value=inactive))
+    config = SimpleNamespace(
+        name=name,
+        type="plex",
+        config={"host": host, "token": token},
+    )
+    return SimpleNamespace(
+        name=name,
+        type="plex",
+        instance=instance,
+        config=config,
+    )
+
+
+def _plugin(tmp_path: Path) -> PlexAutoLanguages:
+    """构造不启动网络线程的插件实例。"""
+    plugin = object.__new__(PlexAutoLanguages)
+    plugin.mediaserver_helper = MagicMock()
+    plugin._lang_provider = None
+    plugin._lang_thread = None
+    plugin._enabled = True
+    plugin._mediaserver = "Plex"
+    plugin._auto_switch = True
+    plugin._update_level = "show"
+    plugin._update_strategy = "all"
+    plugin._trigger_on_play = True
+    plugin._trigger_on_scan = True
+    plugin._event = threading.Event()
+    plugin.get_data_path = MagicMock(return_value=tmp_path)
+    return plugin
+
+
+def test_v3_source_uses_sdk_and_relative_plugin_boundaries() -> None:
+    """V3 源码使用公开 SDK，插件内部模块不通过宿主旧路径互相导入。"""
+    source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in PLUGIN_ROOT.rglob("*.py")
+    )
+
+    assert "from app.sdk.services import MediaServerHelper" in source
+    assert "from app.sdk.logging import logger" in source
+    assert "from app.sdk.network import UrlUtils" in source
+    for legacy_prefix in (
+        "app.compat",
+        "app.core",
+        "app.helper",
+        "app.log",
+        "app.utils",
+        "app.db",
+        "app.plugins.plexautolanguages",
+    ):
+        assert legacy_prefix not in source
+
+    for source_path in PLUGIN_ROOT.rglob("*.py"):
+        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+        absolute_plugin_imports = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.startswith("app.plugins.plexautolanguages")
+        ]
+        assert absolute_plugin_imports == []
+
+
+def test_v3_metadata_and_empty_capabilities_contract() -> None:
+    """插件元数据、空 API/命令/服务和空详情页能力保持明确。"""
+    plugin = _plugin(Path("/tmp/plexautolanguages-test"))
+
+    assert PlexAutoLanguages.plugin_version == "1.0.0"
+    assert plugin.get_command() == []
+    assert plugin.get_api() == []
+    assert plugin.get_service() == []
+    assert plugin.get_page() is None
+    assert supports_plugin_hook(plugin, "get_page") is False
+
+
+def test_service_info_uses_sdk_helper_and_filters_inactive_service(tmp_path: Path) -> None:
+    """服务查询必须限定 Plex 类型，并拒绝缺失或未连接的服务实例。"""
+    plugin = _plugin(tmp_path)
+    active = _service()
+    plugin.mediaserver_helper.get_service.return_value = active
+
+    assert plugin.service_info is active
+    plugin.mediaserver_helper.get_service.assert_called_once_with(
+        name="Plex",
+        type_filter="plex",
+    )
+
+    plugin.mediaserver_helper.get_service.return_value = _service(inactive=True)
+    assert plugin.service_info is None
+
+    plugin.mediaserver_helper.get_service.return_value = None
+    assert plugin.service_info is None
+
+
+def test_service_info_requires_selected_media_server(tmp_path: Path) -> None:
+    """未选择媒体服务器时不访问宿主服务目录。"""
+    plugin = _plugin(tmp_path)
+    plugin._mediaserver = None
+
+    assert plugin.service_info is None
+    plugin.mediaserver_helper.get_service.assert_not_called()
+
+
+def test_configuration_loads_default_and_user_yaml_under_data_path(tmp_path: Path) -> None:
+    """配置覆盖和缓存数据目录必须由插件数据路径提供，而非源码目录。"""
+    default_path = PLUGIN_ROOT / "config" / "default.yaml"
+    user_path = tmp_path / "user.yaml"
+    user_path.write_text(
+        "plexautolanguages:\n"
+        "  update_level: season\n"
+        "  ignore_labels: PAL_IGNORE, PAL_SKIP\n",
+        encoding="utf-8",
+    )
+
+    config = Configuration(default_path, user_path, tmp_path)
+
+    assert config.get("update_level") == "season"
+    assert config.get("ignore_labels") == ["PAL_IGNORE", " PAL_SKIP"]
+    assert config.get("data_dir") == tmp_path
+    assert not (PLUGIN_ROOT / "config" / "user.yaml").exists()
+
+
+def test_cache_initialization_writes_to_plugin_data_path(tmp_path: Path) -> None:
+    """缓存文件必须落在配置提供的插件数据目录，并可被下一实例读取。"""
+    data_path = tmp_path / "plugin-data"
+    plex = SimpleNamespace(
+        config=SimpleNamespace(get=lambda key: data_path if key == "data_dir" else None),
+        unique_id="plex-instance",
+        episodes=list,
+    )
+
+    cache = PlexServerCache(plex)
+
+    cache_path = data_path / "cache" / "plex-instance"
+    assert cache._cache_file_path == str(cache_path)
+    assert cache_path.is_file()
+
+    restored = PlexServerCache(plex)
+    assert restored.episode_parts == {}
+
+
+def test_plugin_writes_generated_user_yaml_to_get_data_path(tmp_path: Path) -> None:
+    """宿主 Plex 配置同步到用户 YAML 时只能写入实例数据目录。"""
+    plugin = _plugin(tmp_path)
+    service = _service(host="plex.example:32400", token="host-token")
+    plugin.mediaserver_helper.get_service.return_value = service
+
+    PlexAutoLanguages._PlexAutoLanguages__update_user_config(plugin)
+
+    user_yaml = tmp_path / "user.yaml"
+    assert user_yaml.is_file()
+    content = user_yaml.read_text(encoding="utf-8")
+    assert "http://plex.example:32400/" in content
+    assert "host-token" in content
+    assert not (PLUGIN_ROOT / "config" / "user.yaml").exists()
+
+
+def test_configuration_rejects_missing_plex_credentials(tmp_path: Path) -> None:
+    """缺少 Plex 地址或令牌时在建立外部连接前失败关闭。"""
+    default_path = tmp_path / "default.yaml"
+    default_path.write_text(
+        "plexautolanguages:\n"
+        "  plex:\n"
+        "    url: ''\n"
+        "    token: ''\n"
+        "  update_level: show\n"
+        "  update_strategy: all\n"
+        "  ignore_labels: []\n"
+        "  scheduler:\n"
+        "    enable: false\n"
+        "    schedule_time: '04:30'\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(InvalidConfiguration):
+        Configuration(default_path, tmp_path / "missing.yaml", tmp_path)
+
+
+def test_language_provider_handles_initialization_failure_and_health() -> None:
+    """Plex 初始化异常不会泄漏到后台线程，未建立连接时健康状态为假。"""
+    provider = object.__new__(LanguageProvider)
+    provider.logger = MagicMock()
+    provider.config = MagicMock()
+    provider.config.get.side_effect = lambda key: {
+        "plex.url": "http://plex.example:32400/",
+        "plex.token": "token",
+    }[key]
+    provider.plex = None
+    provider.alive = False
+    provider._stop_event = threading.Event()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "app.plugins.plexautolanguages.languageprovider.PlexServer",
+            MagicMock(side_effect=RuntimeError("connection failed")),
+        )
+        provider.init()
+
+    assert provider.plex is None
+    assert provider.is_healthy() is False
+    provider.logger.error.assert_called_once()
+
+
+def test_language_provider_runs_one_task_and_stops_plex() -> None:
+    """服务线程可完成一次监听任务，并按停止信号保存缓存和释放 Plex。"""
+    provider = object.__new__(LanguageProvider)
+    provider.scheduler = None
+    provider.stop_signal = False
+    provider.must_stop = False
+    provider.alive = False
+    provider.logger = MagicMock()
+    provider.plex = MagicMock()
+    provider._stop_event = threading.Event()
+    provider.init = lambda: None
+
+    def stop_after_listener(_callback):
+        provider.stop()
+
+    provider.plex.start_alert_listener.side_effect = stop_after_listener
+    provider.start()
+
+    provider.plex.save_cache.assert_called_once_with()
+    provider.plex.stop.assert_called_once_with()
+    assert provider.alive is False
+
+
+def test_alert_processor_logs_unexpected_errors_with_sdk_logger() -> None:
+    """单条告警异常必须留在处理线程内，并使用 SDK 日志支持的方法记录堆栈。"""
+    handler = object.__new__(PlexAlertHandler)
+    handler._plex = MagicMock()
+    handler._alerts_queue = Queue()
+    handler._stop_event = threading.Event()
+    alert = MagicMock()
+    alert.TYPE = "playing"
+    alert.message = {"type": "playing"}
+
+    def fail_processing(_plex) -> None:
+        handler._stop_event.set()
+        raise RuntimeError("invalid alert")
+
+    alert.process.side_effect = fail_processing
+    handler._alerts_queue.put(alert)
+
+    with patch("app.plugins.plexautolanguages.core.plex_alert_handler.logger") as sdk_logger:
+        handler._process_alerts()
+
+    sdk_logger.error.assert_called_once_with("Unable to process playing", exc_info=True)
+    sdk_logger.debug.assert_any_call(alert.message)
+
+
+def test_plugin_lifecycle_resets_state_and_stops_thread(tmp_path: Path, monkeypatch) -> None:
+    """配置重载先释放旧线程，停用后不残留运行句柄。"""
+    plugin = _plugin(tmp_path)
+    provider = MagicMock()
+    thread = MagicMock()
+    thread.is_alive.return_value = False
+    plugin._lang_provider = provider
+    plugin._lang_thread = thread
+
+    helper = MagicMock()
+    monkeypatch.setattr(plexautolanguages, "MediaServerHelper", lambda: helper)
+    plugin.init_plugin({"enabled": False})
+
+    provider.stop.assert_called_once_with()
+    thread.join.assert_called_once_with(timeout=10)
+    assert plugin.get_state() is False
+    assert plugin._lang_provider is None
+    assert plugin._lang_thread is None
+    assert plugin.get_page() is None
+
+
+def test_plugin_reload_does_not_replace_thread_that_failed_to_stop(tmp_path: Path, monkeypatch) -> None:
+    """旧线程未在等待窗口内退出时不得覆盖句柄或启动第二个监听线程。"""
+    plugin = _plugin(tmp_path)
+    provider = MagicMock()
+    thread = MagicMock()
+    thread.is_alive.return_value = True
+    plugin._lang_provider = provider
+    plugin._lang_thread = thread
+
+    helper = MagicMock()
+    new_provider = MagicMock()
+    monkeypatch.setattr(plexautolanguages, "MediaServerHelper", lambda: helper)
+    monkeypatch.setattr(plexautolanguages, "LanguageProvider", new_provider)
+
+    plugin.init_plugin(
+        {
+            "enabled": True,
+            "auto_switch": True,
+            "mediaserver": "Plex",
+        }
+    )
+
+    provider.stop.assert_called_once_with()
+    thread.join.assert_called_once_with(timeout=10)
+    assert plugin.stop_service() is False
+    assert plugin.get_state() is False
+    assert plugin._lang_provider is provider
+    assert plugin._lang_thread is thread
+    new_provider.assert_not_called()
+
+
+def test_connection_retry_wait_is_cancelled_by_stop_event(monkeypatch) -> None:
+    """Plex 连接失败后的等待必须响应停止事件，不能留下长时间重试线程。"""
+    stop_event = threading.Event()
+    server = object.__new__(PlexServer)
+    server._stop_event = stop_event
+    session = MagicMock()
+
+    def fail_and_stop(*_args, **_kwargs):
+        stop_event.set()
+        raise plexautolanguages.core.plex_server.RequestsConnectionError("offline")
+
+    monkeypatch.setattr(
+        plexautolanguages.core.plex_server,
+        "BasePlexServer",
+        fail_and_stop,
+    )
+
+    assert server._get_server("http://plex.example", "token", session) is None
+
+
+def test_stop_service_reports_quiesce_result(tmp_path: Path) -> None:
+    """宿主需要显式结果区分已停止线程和仍存活线程。"""
+    plugin = _plugin(tmp_path)
+    plugin._lang_provider = MagicMock()
+    plugin._lang_thread = MagicMock()
+    plugin._lang_thread.is_alive.return_value = False
+
+    assert plugin.stop_service() is True
+    assert plugin._lang_provider is None
+    assert plugin._lang_thread is None
+
+
+def test_plugin_start_uses_data_path_and_stops_cleanly(tmp_path: Path, monkeypatch) -> None:
+    """自动切换启动时用户配置落入数据目录，停用时线程可收敛。"""
+    plugin = _plugin(tmp_path)
+    helper = MagicMock()
+    helper.get_service.return_value = _service()
+    provider = MagicMock()
+    thread = MagicMock()
+    thread.is_alive.return_value = False
+
+    monkeypatch.setattr(plexautolanguages, "MediaServerHelper", lambda: helper)
+    monkeypatch.setattr(plexautolanguages, "LanguageProvider", lambda **_kwargs: provider)
+    monkeypatch.setattr(plexautolanguages.threading, "Thread", lambda **_kwargs: thread)
+
+    plugin.init_plugin(
+        {
+            "enabled": True,
+            "auto_switch": True,
+            "mediaserver": "Plex",
+            "update_level": "season",
+            "update_strategy": "next",
+            "trigger_on_play": False,
+            "trigger_on_scan": True,
+        }
+    )
+
+    assert plugin.get_state() is True
+    assert (tmp_path / "user.yaml").is_file()
+    thread.start.assert_called_once_with()
+    plugin.stop_service()
+    provider.stop.assert_called_once_with()
+    thread.join.assert_called_once_with(timeout=10)
+    assert plugin._lang_provider is None
+    assert plugin._lang_thread is None

--- a/tests/v3/plexlocalization/conftest.py
+++ b/tests/v3/plexlocalization/conftest.py
@@ -1,0 +1,17 @@
+"""Plex 中文本地化测试隔离。"""
+
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_stop_event():
+    """避免类级停止事件在测试模块和用例之间传播。"""
+    module = sys.modules.get("app.plugins.plexlocalization")
+    if module:
+        module.PlexLocalization._event.clear()
+    yield
+    module = sys.modules.get("app.plugins.plexlocalization")
+    if module:
+        module.PlexLocalization._event.clear()

--- a/tests/v3/plexlocalization/test_full_scan_pipeline.py
+++ b/tests/v3/plexlocalization/test_full_scan_pipeline.py
@@ -1,0 +1,828 @@
+"""Plex 中文本地化全量扫描管线测试。"""
+
+import concurrent.futures
+import threading
+import time
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from app.testing import stub_modules
+
+
+_pypinyin = ModuleType("pypinyin")
+_pypinyin.Style = SimpleNamespace(FIRST_LETTER="first_letter")
+_pypinyin.lazy_pinyin = lambda *args, **kwargs: []
+
+with stub_modules({"pypinyin": _pypinyin}):
+    from app.plugins.plexlocalization import PlexLocalization
+
+
+class _Response:
+    """提供分页 API 所需的最小响应。"""
+
+    def __init__(self, container, status_code=200):
+        self.status_code = status_code
+        self._container = container
+
+    def json(self):
+        """返回 Plex JSON 包装结构。"""
+        return {"MediaContainer": self._container}
+
+
+class _MalformedResponse(_Response):
+    """模拟状态码成功但响应体无法解析。"""
+
+    def __init__(self):
+        super().__init__({})
+
+    def json(self):
+        """模拟 Plex 返回非 JSON 响应。"""
+        raise ValueError("invalid json")
+
+
+class _MissingContainerResponse(_Response):
+    """模拟缺失 Plex 顶层包装字段的响应。"""
+
+    def __init__(self):
+        super().__init__({})
+
+    def json(self):
+        """返回缺失 MediaContainer 的对象。"""
+        return {}
+
+
+class _PagingPlex:
+    """按 endpoint 和 offset 返回测试页并记录请求。"""
+
+    def __init__(self, handler):
+        self._handler = handler
+        self.calls = []
+
+    @property
+    def starts(self):
+        """返回所有分页请求的起始位置。"""
+        return [call[1] for call in self.calls]
+
+    def get_data(self, *, endpoint, headers=None, timeout):
+        """调用页处理器，None 表示请求失败。"""
+        headers = headers or {}
+        start = int(headers.get("X-Plex-Container-Start", 0))
+        size = int(headers.get("X-Plex-Container-Size", 0))
+        self.calls.append((endpoint, start, size, timeout))
+        result = self._handler(endpoint, start)
+        if result is None:
+            return None
+        if isinstance(result, _Response):
+            return result
+        return _Response(result)
+
+
+class _MetadataPlex:
+    """模拟详情读取、原子 PUT 和批量验证。"""
+
+    def __init__(self, source_items, final_items=None):
+        self.source_items = source_items
+        self.final_items = final_items or source_items
+        self.put_calls = []
+        self.written_keys = set()
+        self.detail_request_sizes = []
+        self.verify_request_sizes = []
+        self.fail_verification = False
+        self.raise_on_detail_call = None
+        self.raise_on_put_key = None
+        self.on_first_put = None
+
+    def get_data(self, *, endpoint, timeout):
+        """写入前返回源状态，写入后返回最终状态。"""
+        keys = endpoint.rsplit("/", 1)[-1].split(",")
+        is_verification = bool(keys) and all(key in self.written_keys for key in keys)
+        if is_verification:
+            self.verify_request_sizes.append(len(keys))
+            if self.fail_verification:
+                return None
+            items = [self.final_items[key] for key in keys if key in self.final_items]
+        else:
+            self.detail_request_sizes.append(len(keys))
+            if self.raise_on_detail_call == len(self.detail_request_sizes):
+                raise RuntimeError("detail request failed")
+            items = [self.source_items[key] for key in keys if key in self.source_items]
+        return _Response({"Metadata": items})
+
+    def put_data(self, *, endpoint, params, timeout):
+        """记录单条写入并允许测试在首个 PUT 后触发停止。"""
+        if str(params["id"]) == self.raise_on_put_key:
+            raise RuntimeError("put failed")
+        self.put_calls.append({"endpoint": endpoint, "params": params, "timeout": timeout})
+        self.written_keys.add(str(params["id"]))
+        if len(self.put_calls) == 1 and self.on_first_put:
+            self.on_first_put()
+        return _Response({}, status_code=200)
+
+
+class _ConcurrentPlex:
+    """通过 barrier 记录真实同时请求数。"""
+
+    def __init__(self, worker_count):
+        self._barrier = threading.Barrier(worker_count)
+        self._lock = threading.Lock()
+        self.active_requests = 0
+        self.max_active_requests = 0
+
+    def get_data(self, *, endpoint, timeout):
+        """让首轮详情请求同时进入，验证线程上限。"""
+        keys = endpoint.rsplit("/", 1)[-1].split(",")
+        with self._lock:
+            self.active_requests += 1
+            self.max_active_requests = max(self.max_active_requests, self.active_requests)
+        try:
+            self._barrier.wait(timeout=2)
+            time.sleep(0.01)
+            items = [_media_item(key) for key in keys]
+            return _Response({"Metadata": items})
+        finally:
+            with self._lock:
+                self.active_requests -= 1
+
+
+def _plugin():
+    plugin = object.__new__(PlexLocalization)
+    plugin._timeout = 10
+    plugin._event.clear()
+    return plugin
+
+
+def _edit_plugin():
+    plugin = _plugin()
+    plugin._lock = False
+    plugin._tags = {"Action": "动作"}
+    plugin._PlexLocalization__convert_to_pinyin = lambda _title: "PX"
+    return plugin
+
+
+def _library(*, key=1, title="Movies", library_type="movie"):
+    return SimpleNamespace(key=key, title=title, type=library_type)
+
+
+def _metadata(start, count):
+    return [{"ratingKey": str(index)} for index in range(start, start + count)]
+
+
+def _media_item(rating_key, *, needs_update=False, final=False):
+    title = f"标题{rating_key}"
+    return {
+        "ratingKey": str(rating_key),
+        "librarySectionID": 1,
+        "type": "movie",
+        "title": title,
+        "titleSort": "PX" if final or not needs_update else title,
+        "Field": [],
+        "Genre": [],
+        "Style": [],
+        "Mood": [],
+    }
+
+
+def test_list_rating_keys_pages_until_total_size():
+    """完整库应按 500 条分页直到 totalSize。"""
+    def handler(_endpoint, start):
+        count = 500 if start == 0 else 2
+        return {
+            "offset": start,
+            "totalSize": 502,
+            "Metadata": _metadata(start, count),
+        }
+
+    plugin = _plugin()
+    plex = _PagingPlex(handler)
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "complete"
+    assert len(keys) == 502
+    assert plex.starts == [0, 500]
+    assert all(call[2] == 500 for call in plex.calls)
+
+
+def test_list_rating_keys_without_total_size_stops_on_short_page():
+    """缺少 totalSize 时短页应作为结束条件。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, start: {
+        "offset": start,
+        "Metadata": _metadata(start, 2),
+    })
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "complete"
+    assert keys == ["0", "1"]
+    assert plex.starts == [0]
+
+
+def test_list_rating_keys_without_total_size_stops_on_empty_page():
+    """缺少 totalSize 时完整页后的空页应结束枚举。"""
+    def handler(_endpoint, start):
+        return {
+            "offset": start,
+            "Metadata": _metadata(0, 500) if start == 0 else [],
+        }
+
+    plugin = _plugin()
+    plex = _PagingPlex(handler)
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "complete"
+    assert len(keys) == 500
+    assert plex.starts == [0, 500]
+
+
+def test_list_rating_keys_with_total_size_continues_after_short_page():
+    """totalSize 尚未达到时，短页不能被误判为完整枚举。"""
+    def handler(_endpoint, start):
+        count = 400 if start == 0 else 200
+        return {
+            "offset": start,
+            "totalSize": 600,
+            "Metadata": _metadata(start, count),
+        }
+
+    plugin = _plugin()
+    plex = _PagingPlex(handler)
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "complete"
+    assert len(keys) == 600
+    assert plex.starts == [0, 400]
+
+
+def test_list_rating_keys_advances_by_raw_metadata_count():
+    """缺少 ratingKey 的条目仍占用 Plex 分页位置。"""
+    def handler(_endpoint, start):
+        if start == 0:
+            metadata = _metadata(0, 500)
+            metadata[10] = {"title": "missing key"}
+        else:
+            metadata = [{"ratingKey": "last"}]
+        return {
+            "offset": start,
+            "totalSize": 501,
+            "Metadata": metadata,
+        }
+
+    plugin = _plugin()
+    plex = _PagingPlex(handler)
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "complete"
+    assert len(keys) == 500
+    assert keys[-1] == "last"
+    assert plex.starts == [0, 500]
+
+
+def test_list_rating_keys_fails_when_total_size_has_unexpected_empty_page():
+    """totalSize 尚未达到却返回空页时，枚举结果不可信。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, start: {
+        "offset": start,
+        "totalSize": 600,
+        "Metadata": _metadata(0, 500) if start == 0 else [],
+    })
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+    assert plex.starts == [0, 500]
+
+
+def test_list_rating_keys_rejects_mismatched_response_offset():
+    """响应 offset 与请求不一致时不能继续产生不可信结果。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, _start: {
+        "offset": 7,
+        "totalSize": 1,
+        "Metadata": _metadata(0, 1),
+    })
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+
+
+def test_list_rating_keys_rejects_repeated_nonempty_page():
+    """Plex 忽略分页起点并重复首个完整页时应停止。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, start: {
+        "offset": start,
+        "Metadata": _metadata(0, 500),
+    })
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+    assert plex.starts == [0, 500]
+
+
+def test_list_rating_keys_returns_failed_when_second_page_fails():
+    """第二页失败时不得把首个页面当成完整媒体库。"""
+    def handler(_endpoint, start):
+        if start == 500:
+            return None
+        return {"offset": 0, "totalSize": 600, "Metadata": _metadata(0, 500)}
+
+    plugin = _plugin()
+    plex = _PagingPlex(handler)
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+
+
+def test_list_rating_keys_returns_failed_for_malformed_payload():
+    """状态码成功但响应体结构异常时应转为服务级失败。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, _start: {"Metadata": None})
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+
+
+def test_list_rating_keys_returns_failed_without_media_container():
+    """缺失 MediaContainer 不能被误判为空库。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, _start: _MissingContainerResponse())
+
+    _, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert status == "failed"
+
+
+def test_generate_keys_fetches_collections_once_for_artist_library():
+    """artist 的三个 type 不应重复请求同一个合集端点。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda endpoint, start: {
+        "offset": start,
+        "Metadata": [{"ratingKey": endpoint.split("type=")[-1]}]
+        if "type=" in endpoint else [{"ratingKey": "collection"}],
+    })
+
+    keys, status = plugin._PlexLocalization__generate_all_rating_keys(
+        plex=plex,
+        libraries={7: _library(key=7, title="Music", library_type="artist")},
+        with_collection=True,
+    )
+
+    collection_calls = [call for call in plex.calls if call[0].endswith("/collections")]
+    assert status == "complete"
+    assert keys == ["8", "9", "10", "collection"]
+    assert len(collection_calls) == 1
+
+
+def test_generate_keys_deduplicates_across_types_and_collections():
+    """同一 ratingKey 跨普通端点和合集出现时只处理一次。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda endpoint, start: {
+        "offset": start,
+        "Metadata": [{"ratingKey": "same"}, {"ratingKey": "unique"}]
+        if "type=" in endpoint else [{"ratingKey": "same"}],
+    })
+
+    keys, status = plugin._PlexLocalization__generate_all_rating_keys(
+        plex=plex,
+        libraries={1: _library()},
+        with_collection=True,
+    )
+
+    assert status == "complete"
+    assert keys == ["same", "unique"]
+
+
+def test_list_rating_keys_stops_before_request_when_event_is_set():
+    """主程序停止插件后不应发起新的分页请求。"""
+    plugin = _plugin()
+    plex = _PagingPlex(lambda _endpoint, _start: {"Metadata": []})
+    plugin._event.set()
+
+    keys, status = plugin._PlexLocalization__list_rating_keys(
+        plex=plex, library=_library(), type_id=1
+    )
+
+    assert keys == []
+    assert status == "stopped"
+    assert plex.calls == []
+
+
+def test_batch_size_250_uses_100_100_50_detail_chunks():
+    """业务批次增大时 HTTP 详情读取仍应限制为 100 个 key。"""
+    source_items = {str(index): _media_item(index) for index in range(250)}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source_items)
+
+    result = plugin._PlexLocalization__process_items_batch(
+        plex=plex, rating_keys=list(source_items)
+    )
+
+    assert plex.detail_request_sizes == [100, 100, 50]
+    assert result == {"updated": 0, "failed": 0, "skipped": 250, "unprocessed": 0}
+
+
+def test_successful_puts_use_one_bulk_verification_get():
+    """同一子块中的成功 PUT 应合并回读。"""
+    source_items = {str(index): _media_item(index, needs_update=True) for index in range(3)}
+    final_items = {str(index): _media_item(index, needs_update=True, final=True) for index in range(3)}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source_items, final_items)
+
+    result = plugin._PlexLocalization__process_items_batch(
+        plex=plex, rating_keys=list(source_items)
+    )
+
+    assert len(plex.put_calls) == 3
+    assert plex.verify_request_sizes == [3]
+    assert result == {"updated": 3, "failed": 0, "skipped": 0, "unprocessed": 0}
+
+
+def test_201_successful_puts_use_100_100_1_verification_gets():
+    """跨多个子块的验证请求不得超过 100 个 key。"""
+    source_items = {str(index): _media_item(index, needs_update=True) for index in range(201)}
+    final_items = {
+        str(index): _media_item(index, needs_update=True, final=True)
+        for index in range(201)
+    }
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source_items, final_items)
+
+    result = plugin._PlexLocalization__process_items_batch(
+        plex=plex, rating_keys=list(source_items)
+    )
+
+    assert plex.verify_request_sizes == [100, 100, 1]
+    assert result["updated"] == 201
+
+
+def test_bulk_verification_marks_mismatched_item_failed():
+    """回读字段不一致的条目不能计为更新成功。"""
+    source = {"1": _media_item("1", needs_update=True)}
+    final = {"1": {**_media_item("1", needs_update=True, final=True), "titleSort": "wrong"}}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final)
+
+    result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1"])
+
+    assert result == {"updated": 0, "failed": 1, "skipped": 0, "unprocessed": 0}
+
+
+def test_bulk_verification_marks_missing_item_failed():
+    """Plex 批量回读缺失的条目应计失败。"""
+    source = {"1": _media_item("1", needs_update=True)}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final_items={})
+    plex.final_items = {}
+
+    result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1"])
+
+    assert result == {"updated": 0, "failed": 1, "skipped": 0, "unprocessed": 0}
+
+
+def test_bulk_verification_request_failure_marks_pending_items_failed():
+    """整次验证读取失败时所有待验证写入均应计失败。"""
+    source = {"1": _media_item("1", needs_update=True), "2": _media_item("2", needs_update=True)}
+    final = {key: _media_item(key, needs_update=True, final=True) for key in source}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final)
+    plex.fail_verification = True
+
+    result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1", "2"])
+
+    assert result == {"updated": 0, "failed": 2, "skipped": 0, "unprocessed": 0}
+
+
+def test_put_exception_only_fails_current_item():
+    """单条 PUT 异常不得覆盖同一子块内其他条目的结果。"""
+    source = {str(index): _media_item(index, needs_update=True) for index in range(1, 4)}
+    final = {
+        key: _media_item(key, needs_update=True, final=True)
+        for key in source
+    }
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final)
+    plex.raise_on_put_key = "2"
+
+    result = plugin._PlexLocalization__process_items_batch(
+        plex=plex, rating_keys=["1", "2", "3"]
+    )
+
+    assert plex.verify_request_sizes == [2]
+    assert result == {"updated": 2, "failed": 1, "skipped": 0, "unprocessed": 0}
+
+
+def test_verification_exception_only_fails_current_item():
+    """单条差异比较异常不得覆盖同一子块内其他条目的结果。"""
+    source = {str(index): _media_item(index, needs_update=True) for index in range(1, 4)}
+    final = {
+        key: _media_item(key, needs_update=True, final=True)
+        for key in source
+    }
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final)
+
+    def differences(item, expected_sort_title, expected_tags):
+        if item["ratingKey"] == "2":
+            raise RuntimeError("verification failed")
+        return []
+
+    with patch.object(
+        plugin,
+        "_PlexLocalization__metadata_differences",
+        side_effect=differences,
+    ):
+        result = plugin._PlexLocalization__process_items_batch(
+            plex=plex, rating_keys=["1", "2", "3"]
+        )
+
+    assert result == {"updated": 2, "failed": 1, "skipped": 0, "unprocessed": 0}
+
+
+def test_second_chunk_exception_keeps_first_chunk_results():
+    """后一子块异常不得覆盖前一子块已终结结果。"""
+    source_items = {str(index): _media_item(index) for index in range(150)}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source_items)
+    plex.raise_on_detail_call = 2
+
+    result = plugin._PlexLocalization__process_items_batch(
+        plex=plex, rating_keys=list(source_items)
+    )
+
+    assert result == {"updated": 0, "failed": 50, "skipped": 100, "unprocessed": 0}
+
+
+def test_stop_after_put_marks_unverified_write_failed():
+    """停止发生在 PUT 后时不得继续验证或误报成功。"""
+    source = {"1": _media_item("1", needs_update=True), "2": _media_item("2", needs_update=True)}
+    final = {key: _media_item(key, needs_update=True, final=True) for key in source}
+    plugin = _edit_plugin()
+    plex = _MetadataPlex(source, final)
+    plex.on_first_put = plugin._event.set
+
+    result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1", "2"])
+
+    assert result == {"updated": 0, "failed": 1, "skipped": 0, "unprocessed": 1}
+    assert plex.verify_request_sizes == []
+
+
+def test_pending_futures_never_exceed_twice_thread_count():
+    """数万级条目不能让 Future 数随总批次数增长。"""
+    plugin = _edit_plugin()
+    plex = SimpleNamespace()
+    observed_pending = []
+    real_wait = concurrent.futures.wait
+
+    def recording_wait(futures, *args, **kwargs):
+        observed_pending.append(len(futures))
+        return real_wait(futures, *args, **kwargs)
+
+    def skip_batch(_plex, batch_keys):
+        return {
+            "updated": 0,
+            "failed": 0,
+            "skipped": len(batch_keys),
+            "unprocessed": 0,
+        }
+
+    with patch("app.plugins.plexlocalization.concurrent.futures.wait", side_effect=recording_wait), \
+            patch.object(plugin, "_PlexLocalization__process_items_batch", side_effect=skip_batch):
+        result = plugin._PlexLocalization__process_rating_keys_in_batches(
+            plex=plex,
+            rating_keys=[str(index) for index in range(10_000)],
+            thread_count=3,
+            batch_size=100,
+        )
+
+    assert observed_pending
+    assert max(observed_pending) <= 6
+    assert result == {"updated": 0, "failed": 0, "skipped": 10_000, "unprocessed": 0}
+
+
+def test_second_page_failure_skips_all_puts_and_continues_next_service():
+    """一个服务枚举失败不应写入，也不应阻止独立服务继续。"""
+    plugin = _edit_plugin()
+    plugin._batch_size = 100
+    plugin._notify = False
+    first_plex = SimpleNamespace(put_calls=[])
+    second_plex = SimpleNamespace(put_calls=[])
+    services = {
+        "first": SimpleNamespace(name="First Plex", instance=first_plex),
+        "second": SimpleNamespace(name="Second Plex", instance=second_plex),
+    }
+    library = _library()
+    completed = {"updated": 0, "failed": 0, "skipped": 1, "unprocessed": 0}
+
+    with patch.object(plugin, "service_info", side_effect=lambda name: services[name]), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__generate_all_rating_keys",
+                side_effect=[([], "failed"), (["1"], "complete")],
+            ), patch.object(
+                plugin,
+                "_PlexLocalization__process_rating_keys_in_batches",
+                return_value=completed,
+            ) as process_batches, patch("app.plugins.plexlocalization.logger.warning") as warning:
+        plugin._PlexLocalization__loop_all(
+            service_libraries={"first": {1: library}, "second": {1: library}},
+            thread_count=3,
+        )
+
+    assert first_plex.put_calls == []
+    assert process_batches.call_count == 1
+    assert process_batches.call_args.kwargs["plex"] is second_plex
+    assert any("枚举不完整" in str(call.args[0]) for call in warning.call_args_list)
+
+
+def test_malformed_page_skips_service_and_continues_next_service():
+    """单个服务解析失败不得终止后续独立 Plex 服务。"""
+    plugin = _edit_plugin()
+    plugin._batch_size = 100
+    plugin._notify = False
+    first_plex = _PagingPlex(lambda _endpoint, _start: _MalformedResponse())
+    second_plex = _PagingPlex(lambda endpoint, start: {
+        "offset": start,
+        "Metadata": [] if endpoint.endswith("/collections") else [{"ratingKey": "1"}],
+    })
+    services = {
+        "first": SimpleNamespace(name="First Plex", instance=first_plex),
+        "second": SimpleNamespace(name="Second Plex", instance=second_plex),
+    }
+    completed = {"updated": 0, "failed": 0, "skipped": 1, "unprocessed": 0}
+
+    with patch.object(plugin, "service_info", side_effect=lambda name: services[name]), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__process_rating_keys_in_batches",
+                return_value=completed,
+            ) as process_batches:
+        plugin._PlexLocalization__loop_all(
+            service_libraries={"first": {1: _library()}, "second": {1: _library()}},
+            thread_count=3,
+        )
+
+    assert process_batches.call_count == 1
+    assert process_batches.call_args.kwargs["plex"] is second_plex
+
+
+def test_loop_defaults_to_three_threads():
+    """内部调用未显式传线程数时也应使用新默认值。"""
+    plugin = _edit_plugin()
+    plugin._batch_size = 100
+    plugin._notify = False
+    plex = SimpleNamespace()
+    service = SimpleNamespace(name="Plex", instance=plex)
+    library = _library()
+
+    with patch.object(plugin, "service_info", return_value=service), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__generate_all_rating_keys",
+                return_value=(["1"], "complete"),
+            ), patch.object(
+                plugin,
+                "_PlexLocalization__process_rating_keys_in_batches",
+                return_value={"updated": 0, "failed": 0, "skipped": 1, "unprocessed": 0},
+            ) as process_batches:
+        plugin._PlexLocalization__loop_all(
+            service_libraries={"plex": {1: library}}, thread_count=None
+        )
+
+    assert process_batches.call_args.kwargs["thread_count"] == 3
+
+
+def test_loop_final_log_includes_service_and_discovered_counts():
+    """最终日志应能核对完整服务的发现数与四项处理统计。"""
+    plugin = _edit_plugin()
+    plugin._batch_size = 100
+    plugin._notify = False
+    services = {
+        "first": SimpleNamespace(name="First Plex", instance=SimpleNamespace()),
+        "second": SimpleNamespace(name="Second Plex", instance=SimpleNamespace()),
+    }
+
+    def process_batches(*, rating_keys, **_kwargs):
+        return {"updated": 0, "failed": 0, "skipped": len(rating_keys), "unprocessed": 0}
+
+    with patch.object(plugin, "service_info", side_effect=lambda name: services[name]), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__generate_all_rating_keys",
+                side_effect=[(["1", "2"], "complete"), (["3"], "complete")],
+            ), patch.object(
+                plugin,
+                "_PlexLocalization__process_rating_keys_in_batches",
+                side_effect=process_batches,
+            ), patch("app.plugins.plexlocalization.logger.info") as info:
+        plugin._PlexLocalization__loop_all(
+            service_libraries={"first": {1: _library()}, "second": {1: _library()}},
+            thread_count=3,
+        )
+
+    final_log = str(info.call_args_list[-1].args[0])
+    assert "完整服务 2" in final_log
+    assert "发现 3" in final_log
+    assert "跳过 3" in final_log
+
+
+def test_stopped_log_preserves_previous_failed_service_count():
+    """先失败后停止时，最终日志仍应保留失败服务数。"""
+    plugin = _edit_plugin()
+    plugin._batch_size = 100
+    plugin._notify = False
+    services = {
+        "first": SimpleNamespace(name="First Plex", instance=SimpleNamespace()),
+        "second": SimpleNamespace(name="Second Plex", instance=SimpleNamespace()),
+    }
+
+    with patch.object(plugin, "service_info", side_effect=lambda name: services[name]), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__generate_all_rating_keys",
+                side_effect=[([], "failed"), ([], "stopped")],
+            ), patch("app.plugins.plexlocalization.logger.warning") as warning:
+        plugin._PlexLocalization__loop_all(
+            service_libraries={"first": {1: _library()}, "second": {1: _library()}},
+            thread_count=3,
+        )
+
+    final_log = str(warning.call_args_list[-1].args[0])
+    assert "失败服务 1" in final_log
+
+
+def test_stop_cancels_pending_batches_and_counts_unprocessed():
+    """停止后未运行的批次必须进入未处理统计。"""
+    plugin = _edit_plugin()
+    plex = SimpleNamespace()
+    total_keys = 1_000
+
+    def stop_after_first_batch(_plex, batch_keys):
+        plugin._event.set()
+        return {
+            "updated": 0,
+            "failed": 0,
+            "skipped": len(batch_keys),
+            "unprocessed": 0,
+        }
+
+    with patch.object(
+        plugin,
+        "_PlexLocalization__process_items_batch",
+        side_effect=stop_after_first_batch,
+    ):
+        result = plugin._PlexLocalization__process_rating_keys_in_batches(
+            plex=plex,
+            rating_keys=[str(index) for index in range(total_keys)],
+            thread_count=3,
+            batch_size=100,
+        )
+
+    assert sum(result.values()) == total_keys
+    assert result["unprocessed"] > 0
+
+
+def test_processing_http_concurrency_respects_configured_thread_count():
+    """实际详情请求并发应由用户线程配置控制。"""
+    for thread_count in (3, 2):
+        plugin = _edit_plugin()
+        plex = _ConcurrentPlex(worker_count=thread_count)
+        item_count = thread_count * 100
+
+        result = plugin._PlexLocalization__process_rating_keys_in_batches(
+            plex=plex,
+            rating_keys=[str(index) for index in range(item_count)],
+            thread_count=thread_count,
+            batch_size=100,
+        )
+
+        assert plex.max_active_requests == thread_count
+        assert result["skipped"] == item_count

--- a/tests/v3/plexlocalization/test_metadata_edits.py
+++ b/tests/v3/plexlocalization/test_metadata_edits.py
@@ -1,0 +1,350 @@
+"""Plex 中文本地化元数据原子编辑测试。"""
+
+import threading
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from app.testing import stub_modules
+
+
+_pypinyin = ModuleType("pypinyin")
+_pypinyin.Style = SimpleNamespace(FIRST_LETTER="first_letter")
+_pypinyin.lazy_pinyin = lambda *args, **kwargs: []
+
+with stub_modules({"pypinyin": _pypinyin}):
+    from app.plugins.plexlocalization import PlexLocalization
+
+
+class _Response:
+    """提供插件 HTTP 调用所需的最小响应契约。"""
+
+    def __init__(self, *, status_code=200, metadata=None):
+        self.status_code = status_code
+        self._metadata = metadata or []
+
+    def json(self):
+        """返回 Plex JSON API 的元数据包装结构。"""
+        return {"MediaContainer": {"Metadata": self._metadata}}
+
+    def __bool__(self):
+        """模拟 requests.Response 对错误状态码的布尔语义。"""
+        return self.status_code < 400
+
+
+class _FakePlex:
+    """记录 Plex 写入请求，并为最终回读提供指定元数据。"""
+
+    def __init__(self, final_item, status_code=200):
+        self.final_item = final_item
+        self.status_code = status_code
+        self.put_calls = []
+        self.get_calls = []
+
+    def put_data(self, *, endpoint, params, timeout):
+        """记录一次元数据编辑请求。"""
+        self.put_calls.append({"endpoint": endpoint, "params": params, "timeout": timeout})
+        return _Response(status_code=self.status_code)
+
+    def get_data(self, *, endpoint, timeout):
+        """返回写入完成后的条目状态。"""
+        self.get_calls.append({"endpoint": endpoint, "timeout": timeout})
+        return _Response(metadata=[self.final_item])
+
+
+def _plugin(sort_title="TSXK"):
+    plugin = object.__new__(PlexLocalization)
+    plugin._lock = False
+    plugin._timeout = 10
+    plugin._tags = {
+        "Action": "动作",
+        "Adventure": "冒险",
+        "Sci-Fi & Fantasy": "科幻与奇幻",
+    }
+    plugin._PlexLocalization__convert_to_pinyin = lambda title: sort_title
+    return plugin
+
+
+def _source_item():
+    return {
+        "ratingKey": "98824",
+        "librarySectionID": 42,
+        "type": "show",
+        "title": "吞噬星空",
+        "titleSort": "吞噬星空",
+        "Field": [],
+        "Genre": [
+            {"tag": "Action"},
+            {"tag": "Adventure"},
+            {"tag": "Sci-Fi & Fantasy"},
+            {"tag": "Unmapped"},
+        ],
+        "Style": [],
+        "Mood": [],
+    }
+
+
+def _final_item(title_sort="TSXK"):
+    return {
+        **_source_item(),
+        "titleSort": title_sort,
+        "Genre": [
+            {"tag": "动作"},
+            {"tag": "冒险"},
+            {"tag": "科幻与奇幻"},
+            {"tag": "Unmapped"},
+        ],
+    }
+
+
+def test_process_item_submits_sort_title_and_all_tags_in_one_request():
+    """同一条目的排序标题与标签应通过一次 PUT 原子提交。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item())
+
+    result = plugin._PlexLocalization__process_item(plex=plex, item=_source_item())
+
+    assert result is True
+    assert len(plex.put_calls) == 1
+    assert len(plex.get_calls) == 1
+    call = plex.put_calls[0]
+    assert call["endpoint"] == "/library/sections/42/all"
+    assert call["params"] == {
+        "type": 2,
+        "id": "98824",
+        "includeExternalMedia": 1,
+        "titleSort.value": "TSXK",
+        "titleSort.locked": 0,
+        "genre.locked": 0,
+        "genre[0].tag.tag": "动作",
+        "genre[1].tag.tag": "冒险",
+        "genre[2].tag.tag": "科幻与奇幻",
+        "genre[3].tag.tag": "Unmapped",
+        "genre[].tag.tag-": "Action,Adventure,Sci-Fi%20%26%20Fantasy",
+    }
+
+
+def test_process_item_reports_failure_when_final_sort_title_differs():
+    """最终回读不一致时不得把中间写入状态记录为成功。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item(title_sort=None))
+
+    with patch("app.plugins.plexlocalization.logger.info") as info, patch("app.plugins.plexlocalization.logger.warning") as warning:
+        result = plugin._PlexLocalization__process_item(plex=plex, item=_source_item())
+
+    assert result is False
+    assert len(plex.put_calls) == 1
+    assert len(plex.get_calls) == 1
+    assert any("更新元数据未完全生效" in str(call.args[0]) for call in warning.call_args_list)
+    assert not any("吞噬星空 < TSXK >" in str(call.args[0]) for call in info.call_args_list)
+
+
+def test_process_item_treats_null_sort_title_as_unset():
+    """Plex 返回 null 排序标题时仍应生成并写入拼音。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item())
+    item = {
+        **_source_item(),
+        "titleSort": None,
+        "Genre": [],
+    }
+
+    result = plugin._PlexLocalization__process_item(plex=plex, item=item)
+
+    assert result is True
+    assert len(plex.put_calls) == 1
+    assert plex.put_calls[0]["params"]["titleSort.value"] == "TSXK"
+
+
+def test_process_item_skips_write_when_relevant_fields_are_locked():
+    """排序标题和标签均已锁定时不应发送编辑请求。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item())
+    item = {
+        **_source_item(),
+        "Field": [
+            {"name": "titleSort", "locked": True},
+            {"name": "genre", "locked": True},
+        ],
+    }
+
+    result = plugin._PlexLocalization__process_item(plex=plex, item=item)
+
+    assert result is None
+    assert plex.put_calls == []
+    assert plex.get_calls == []
+
+
+def test_process_item_preserves_existing_sort_title_during_tag_only_update():
+    """仅更新标签时应携带并校验已有的未锁定排序标题。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item())
+    item = {
+        **_source_item(),
+        "titleSort": "TSXK",
+    }
+
+    result = plugin._PlexLocalization__process_item(plex=plex, item=item)
+
+    assert result is True
+    assert plex.put_calls[0]["params"]["titleSort.value"] == "TSXK"
+    assert plex.put_calls[0]["params"]["titleSort.locked"] == 0
+
+
+def test_process_item_skips_redundant_sort_title_equal_to_title():
+    """生成排序与原标题一致时无需写入 Plex。"""
+    plugin = _plugin(sort_title="2012")
+    plex = _FakePlex(final_item={})
+    item = {
+        **_source_item(),
+        "title": "2012",
+        "titleSort": None,
+        "Genre": [],
+    }
+
+    result = plugin._PlexLocalization__process_item(plex=plex, item=item)
+
+    assert result is None
+    assert plex.put_calls == []
+    assert plex.get_calls == []
+
+
+def test_process_item_logs_noop_skip_at_debug_level():
+    """无需更新的有效条目应在 debug 日志中标明标题和 ratingKey。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item={})
+    item = {
+        **_source_item(),
+        "titleSort": "TSXK",
+        "Genre": [{"tag": "动画"}],
+    }
+
+    with patch("app.plugins.plexlocalization.logger.debug") as debug:
+        result = plugin._PlexLocalization__process_item(plex=plex, item=item)
+
+    assert result is None
+    assert plex.put_calls == []
+    assert any(
+        "吞噬星空（ratingKey=98824）无需更新，跳过" in str(call.args[0])
+        for call in debug.call_args_list
+    )
+
+
+def test_process_item_logs_http_error_status_code():
+    """Plex 返回错误响应时日志应保留真实 HTTP 状态码。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item=_final_item(), status_code=500)
+
+    with patch("app.plugins.plexlocalization.logger.warning") as warning:
+        result = plugin._PlexLocalization__process_item(plex=plex, item=_source_item())
+
+    assert result is False
+    assert plex.get_calls == []
+    assert any("状态码：500" in str(call.args[0]) for call in warning.call_args_list)
+
+
+def test_positive_int_config_falls_back_only_for_invalid_values():
+    """线程数与批大小保持可配置，但零、负数和非法值应回退默认值。"""
+    parse = PlexLocalization._PlexLocalization__positive_int
+
+    assert parse("8", default=5) == 8
+    assert parse(0, default=5) == 5
+    assert parse(-2, default=100) == 100
+    assert parse(None, default=5) == 5
+    assert parse("invalid", default=100) == 100
+
+
+def test_positive_int_config_supports_new_thread_default():
+    """线程配置缺失时应使用新的安全默认值。"""
+    parse = PlexLocalization._PlexLocalization__positive_int
+
+    assert parse(None, default=3) == 3
+    assert parse("8", default=3) == 8
+
+
+def test_form_defaults_to_three_threads():
+    """表单默认线程数应限制 Plex 的初始并发压力。"""
+    plugin = object.__new__(PlexLocalization)
+
+    with patch.object(plugin, "_PlexLocalization__get_service_library_options", return_value=[]):
+        _, defaults = plugin.get_form()
+
+    assert defaults["thread_count"] == 3
+
+
+def test_init_plugin_defaults_thread_count_to_three():
+    """缺省配置初始化时应实际写入三线程默认值。"""
+    plugin = object.__new__(PlexLocalization)
+    plugin._scheduler = None
+
+    with patch("app.plugins.plexlocalization.MediaServerHelper"), \
+            patch.object(plugin, "_PlexLocalization__get_tags", return_value={"Action": "动作"}), \
+            patch.object(plugin, "stop_service"), \
+            patch("app.plugins.plexlocalization.BackgroundScheduler"), \
+            patch.object(plugin, "update_config"):
+        plugin.init_plugin({"tags_json": "{}"})
+
+    assert plugin._thread_count == 3
+
+
+def test_stop_service_sets_event_without_private_scheduler():
+    """主程序停止插件时不应依赖入库任务的私有 scheduler。"""
+    plugin = _plugin()
+    plugin._scheduler = None
+    plugin._scheduler_lock = threading.Lock()
+    plugin._event.clear()
+
+    plugin.stop_service()
+
+    assert plugin._event.is_set()
+
+
+def test_process_items_batch_aggregates_chunk_outcomes():
+    """业务批次应合并多个 HTTP 子块的四项结果。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item={})
+    rating_keys = [str(index) for index in range(150)]
+    with patch.object(
+        plugin,
+        "_PlexLocalization__process_items_chunk",
+        side_effect=[
+            {"updated": 10, "failed": 20, "skipped": 70, "unprocessed": 0},
+            {"updated": 5, "failed": 5, "skipped": 30, "unprocessed": 10},
+        ],
+    ):
+        result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=rating_keys)
+
+    assert result == {"updated": 15, "failed": 25, "skipped": 100, "unprocessed": 10}
+
+
+def test_process_items_batch_isolates_item_exceptions():
+    """单条异常应计为失败并继续处理同批后续条目。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item={})
+    items = [{"ratingKey": "1"}, {"ratingKey": "2"}, {"ratingKey": "3"}]
+
+    with patch.object(plugin, "_PlexLocalization__fetch_all_items", return_value=items), \
+            patch.object(
+                plugin,
+                "_PlexLocalization__prepare_item_edit",
+                side_effect=[None, RuntimeError("broken item"), None]
+            ) as prepare_item, patch("app.plugins.plexlocalization.logger.error") as error:
+        result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1", "2", "3"])
+
+    assert result == {"updated": 0, "failed": 1, "skipped": 2, "unprocessed": 0}
+    assert prepare_item.call_count == 3
+    assert any("ratingKey=2" in str(call.args[0]) for call in error.call_args_list)
+
+
+def test_process_items_batch_counts_missing_response_items_as_failed():
+    """批量读取缺失的请求条目应进入失败统计并保留其余结果。"""
+    plugin = _plugin()
+    plex = _FakePlex(final_item={})
+    items = [{"ratingKey": "1"}, {"ratingKey": "3"}]
+
+    with patch.object(plugin, "_PlexLocalization__fetch_all_items", return_value=items), \
+            patch.object(plugin, "_PlexLocalization__prepare_item_edit", return_value=None), \
+            patch("app.plugins.plexlocalization.logger.warning") as warning:
+        result = plugin._PlexLocalization__process_items_batch(plex=plex, rating_keys=["1", "2", "3"])
+
+    assert result == {"updated": 0, "failed": 1, "skipped": 2, "unprocessed": 0}
+    assert any("ratingKey=2" in str(call.args[0]) for call in warning.call_args_list)

--- a/tests/v3/plexlocalization/test_v3_migration.py
+++ b/tests/v3/plexlocalization/test_v3_migration.py
@@ -1,0 +1,203 @@
+"""Plex 中文本地化 V3 导入、事件和生命周期边界测试。"""
+
+import json
+import tomllib
+import threading
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+from app.schemas.system import ServiceInfo
+from app.schemas.types import EventType
+from app.sdk.events import Event
+from app.testing import stub_modules
+
+
+_pypinyin = ModuleType("pypinyin")
+_pypinyin.Style = type("Style", (), {"FIRST_LETTER": "first_letter"})
+_pypinyin.pinyin = lambda *args, **kwargs: [["A"]]
+
+with stub_modules({"pypinyin": _pypinyin}):
+    from app.plugins.plexlocalization import PlexLocalization
+
+
+def test_v3_plugin_uses_stable_imports_for_migrated_boundaries():
+    """V3 副本不能继续依赖已登记的历史 core/helper/log/utils 路径。"""
+    plugin_root = Path(__file__).parents[3] / "plugins.v3" / "plexlocalization"
+    source = "\n".join(path.read_text(encoding="utf-8") for path in plugin_root.glob("*.py"))
+
+    assert "from app.core." not in source
+    assert "from app.helper." not in source
+    assert "from app.log import" not in source
+    assert "from app.utils." not in source
+    assert "from app.modules." not in source
+    assert "from app.sdk." in source
+
+
+def test_v3_version_and_legacy_index_disable_fallback():
+    """V3 专用版本应与索引一致，并禁止 V2 实现再次回退加载。"""
+    repo_root = Path(__file__).parents[3]
+    package_v3 = json.loads((repo_root / "package.v3.json").read_text(encoding="utf-8"))
+    package_v2 = json.loads((repo_root / "package.v2.json").read_text(encoding="utf-8"))
+
+    metadata = package_v3["PlexLocalization"]
+    assert PlexLocalization.plugin_version == "3.0.0"
+    assert metadata["version"] == PlexLocalization.plugin_version
+    assert list(metadata["history"]) == ["v3.0.0"]
+    assert metadata["system_version"] == ">=3.0.0"
+    assert package_v2["PlexLocalization"]["v3"] is False
+
+
+def test_v3_dependency_manifest_declares_pypinyin():
+    """V3 插件的额外依赖必须由现代清单声明。"""
+    manifest = Path(__file__).parents[3] / "plugins.v3" / "plexlocalization" / "pyproject.toml"
+    with manifest.open("rb") as file:
+        project = tomllib.load(file)["project"]
+
+    assert project["name"] == "moviepilot-plugin-plexlocalization"
+    assert project["dynamic"] == ["version"]
+    assert project["dependencies"] == ["pypinyin~=0.51.0"]
+
+
+def test_transfer_event_uses_typed_snapshot_payload():
+    """整理完成事件应经 SDK 快照读取稳定的媒体和元数据字段。"""
+    plugin = object.__new__(PlexLocalization)
+    plugin._enabled = True
+    plugin._execute_transfer = True
+    plugin._delay = 0
+    plugin._transfer_time = None
+    plugin._scheduler = None
+    plugin._scheduler_lock = threading.Lock()
+    plugin._event = threading.Event()
+    scheduler = MagicMock()
+    scheduler.running = False
+    scheduler.get_jobs.return_value = [object()]
+    event = Event(
+        EventType.TransferComplete,
+        {
+            "meta": {"season_episode": "S01E02"},
+            "mediainfo": {"title_year": "测试 (2026)"},
+        },
+    )
+
+    with patch("app.plugins.plexlocalization.BackgroundScheduler", return_value=scheduler):
+        plugin.execute_transfer(event)
+
+    scheduler.add_job.assert_called_once()
+    assert plugin._transfer_time is not None
+
+
+def test_transfer_event_with_invalid_snapshot_does_not_schedule_work():
+    """缺少稳定事件载荷时应安全跳过，而不是依赖旧字典字段。"""
+    plugin = object.__new__(PlexLocalization)
+    plugin._enabled = True
+    plugin._execute_transfer = True
+    plugin._scheduler = None
+    plugin._scheduler_lock = threading.Lock()
+    plugin._event = threading.Event()
+    event = Event(EventType.TransferComplete, {"unexpected": True})
+
+    with patch("app.plugins.plexlocalization.BackgroundScheduler") as scheduler_cls:
+        plugin.execute_transfer(event)
+
+    scheduler_cls.assert_not_called()
+
+
+def test_consecutive_transfer_events_reuse_running_scheduler():
+    """连续入库只重排同一调度器任务，不能重复启动已运行的 Scheduler。"""
+    plugin = object.__new__(PlexLocalization)
+    plugin._enabled = True
+    plugin._execute_transfer = True
+    plugin._delay = 60
+    plugin._transfer_time = None
+    plugin._scheduler = None
+    plugin._scheduler_lock = threading.Lock()
+    plugin._event = threading.Event()
+    scheduler = MagicMock()
+    scheduler.get_jobs.return_value = [object()]
+    scheduler.running = False
+    event = Event(
+        EventType.TransferComplete,
+        {
+            "meta": {"season_episode": "S01E02"},
+            "mediainfo": {"title_year": "测试 (2026)"},
+        },
+    )
+
+    with patch("app.plugins.plexlocalization.BackgroundScheduler", return_value=scheduler):
+        plugin.execute_transfer(event)
+        scheduler.running = True
+        plugin.execute_transfer(event)
+
+    assert scheduler.remove_all_jobs.call_count == 2
+    assert scheduler.add_job.call_count == 2
+    scheduler.start.assert_called_once_with()
+
+
+def test_consecutive_transfer_events_with_real_scheduler():
+    """真实 APScheduler 运行后仍可被连续入库事件安全重排。"""
+    plugin = object.__new__(PlexLocalization)
+    plugin._enabled = True
+    plugin._execute_transfer = True
+    plugin._delay = 60
+    plugin._transfer_time = None
+    plugin._scheduler = None
+    plugin._scheduler_lock = threading.Lock()
+    plugin._event = threading.Event()
+    event = Event(
+        EventType.TransferComplete,
+        {
+            "meta": {"season_episode": "S01E02"},
+            "mediainfo": {"title_year": "测试 (2026)"},
+        },
+    )
+
+    try:
+        plugin.execute_transfer(event)
+        plugin.execute_transfer(event)
+        assert plugin._scheduler is not None
+        assert plugin._scheduler.running is True
+        assert len(plugin._scheduler.get_jobs()) == 1
+    finally:
+        plugin.stop_service()
+
+
+def test_service_info_handles_unavailable_service_instance():
+    """媒体服务配置存在但实例尚未建立时不得调用空对象方法。"""
+    plugin = object.__new__(PlexLocalization)
+    plugin.mediaserver_helper = MagicMock()
+    plugin.mediaserver_helper.get_service.return_value = ServiceInfo(name="Plex")
+
+    with patch("app.plugins.plexlocalization.logger") as logger:
+        assert plugin.service_info(name="Plex") is None
+
+    logger.warning.assert_called_once_with("媒体服务器 Plex 未连接，请检查配置")
+
+
+def test_invalid_cron_returns_no_service_instead_of_raising():
+    """非法周期配置不应阻断插件列表和其它插件的加载。"""
+    plugin = object.__new__(PlexLocalization)
+    plugin._enabled = True
+    plugin._cron = "not a cron"
+
+    with patch("app.plugins.plexlocalization.logger") as logger:
+        assert plugin.get_service() == []
+
+    logger.error.assert_called_once()
+
+
+def test_empty_config_resets_previous_lifecycle_state():
+    """空配置表示停用，重载不能残留上一轮调度和入库时间。"""
+    plugin = object.__new__(PlexLocalization)
+    plugin._scheduler = None
+    plugin._scheduler_lock = threading.Lock()
+    plugin._enabled = True
+    plugin._transfer_time = object()
+
+    with patch("app.plugins.plexlocalization.MediaServerHelper"):
+        plugin.init_plugin(None)
+
+    assert plugin._enabled is False
+    assert plugin._libraries == []
+    assert plugin._transfer_time is None
+    assert plugin.get_service() == []


### PR DESCRIPTION
三个插件此前仅有 V2 实现，在 V3 市场中依赖兼容回退。该批次为它们建立独立的 V3 实现，并按当前 V3 架构使用公开 SDK 或必要的 Plex 业务对象，不为单插件能力扩张宿主合同。

主要变化：

- 将 AuxiliaryAuth 升级至 2.0.0，迁移事件、日志和媒体服务目录访问，保持认证拦截合同。
- 将 PlexAutoLanguages 升级至 1.0.0，迁移媒体服务、网络和日志接口；配置与缓存写入插件数据目录，内部模块改用相对导入，并确保 Plex 连接重试可取消、旧线程未停止时不会启动新实例。
- 将 PlexLocalization 升级至 3.0.0，迁移配置、事件、媒体服务和工具接口，补充 V3 依赖清单；入库事件使用快照合同，调度器在连续事件和停止/重载场景下保持单实例。
- 在 `package.v2.json` 中关闭上述三个插件的 V3 fallback；PluginReOrder 明确不支持 V3，也同步标记 `v3:false`，不创建 V3 实现。
- 三个原插件均无 README，本次未新增 README。

验证：

- B3 聚焦测试：87 passed
- `tests/run.py`：CI、V3、V2 三组共 1615 passed
- Pylint：10.00/10
- Ruff、Python 编译、JSON、版本一致性、V3 依赖清单、兼容入口扫描、pre-push 和 `git diff --check` 均通过
