### PR TITLE
迁移 WeatherWidget、BrushManager、TorrentClassifier 到 V3

### DIFF
--- a/package.v2.json
+++ b/package.v2.json
@@ -126,7 +126,8 @@
         "history": {
             "v2.0": "MoviePilot V2 版本天气插件，优先使用 CloakBrowser 截图并保留 Playwright 兼容路径"
         },
-        "release": true
+        "release": true,
+        "v3": false
     },
     "BrushManager": {
         "name": "刷流种子整理",
@@ -140,6 +141,7 @@
             "v1.5.1": "兼容新版 Transmission SDK 字段，修正整理统计读取异常",
             "v1.5": "MoviePilot V2 版本刷流种子整理插件"
         },
+        "v3": false,
         "release": true
     },
     "TorrentClassifier": {
@@ -155,6 +157,7 @@
             "v1.5": "优化执行周期输入，需要MoviePilot v2.2.1+",
             "v1.4": "MoviePilot V2 版本种子关键字分类整理插件"
         },
+        "v3": false,
         "release": true
     },
     "HitAndRun": {

--- a/package.v3.json
+++ b/package.v3.json
@@ -180,5 +180,47 @@
             "v3.0.0": "迁移至 MoviePilot V3 配置、事件、媒体服务与工具接口，保持 Plex 中文本地化流程。"
         },
         "release": true
+    },
+    "BrushManager": {
+        "name": "刷流种子整理",
+        "description": "针对刷流种子进行整理操作。",
+        "version": "2.0.0",
+        "labels": "文件整理,刷流",
+        "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/brushmanager.png",
+        "author": "InfinityPacer",
+        "level": 1,
+        "system_version": ">=3.0.0",
+        "history": {
+            "v2.0.0": "MoviePilot V3 版本刷流种子整理插件"
+        },
+        "release": true
+    },
+    "TorrentClassifier": {
+        "name": "种子关键字分类整理",
+        "description": "通过匹配种子关键字进行自定义分类。",
+        "labels": "下载管理",
+        "version": "2.0.0",
+        "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/TorrentClassifier.png",
+        "author": "InfinityPacer",
+        "level": 1,
+        "system_version": ">=3.0.0",
+        "history": {
+            "v2.0.0": "迁移至 MoviePilot V3 稳定接口，保持种子关键字分类整理流程。"
+        },
+        "release": true
+    },
+    "WeatherWidget": {
+        "name": "天气",
+        "description": "定时推送天气，并在仪表盘中显示实时天气。",
+        "labels": "工具,仪表板",
+        "version": "3.0.0",
+        "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/weatherwidget.png",
+        "author": "InfinityPacer",
+        "level": 1,
+        "system_version": ">=3.0.0",
+        "history": {
+            "v3.0.0": "迁移至 MoviePilot V3 稳定接口与浏览器 SDK，保持天气仪表板和通知流程。"
+        },
+        "release": true
     }
 }

--- a/plugins.v3/brushmanager/__init__.py
+++ b/plugins.v3/brushmanager/__init__.py
@@ -1,0 +1,1090 @@
+import threading
+import time
+from datetime import datetime, timedelta
+from threading import Event
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from app.chain.transfer import TransferChain
+from app.sdk.config import settings
+from app.sdk.logging import logger
+from app.sdk.plugins import PluginManager
+from app.sdk.scheduler import start_scheduler_job
+from app.sdk.services import DownloaderHelper
+from app.modules.qbittorrent import Qbittorrent
+from app.modules.transmission import Transmission
+from app.plugins import _PluginBase
+from app.schemas import NotificationType, ServiceInfo
+
+lock = threading.Lock()
+
+
+class BrushManager(_PluginBase):
+    # 插件名称
+    plugin_name = "刷流种子整理"
+    # 插件描述
+    plugin_desc = "针对刷流种子进行整理操作。"
+    # 插件图标
+    plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/brushmanager.png"
+    # 插件版本
+    plugin_version = "2.0.0"
+    # 插件作者
+    plugin_author = "InfinityPacer"
+    # 作者主页
+    author_url = "https://github.com/InfinityPacer"
+    # 插件配置项ID前缀
+    plugin_config_prefix = "brushmanager_"
+    # 加载顺序
+    plugin_order = 23
+    # 可使用的用户级别
+    auth_level = 2
+
+    # region 私有属性
+    plugin_manager = None
+    downloader_helper = None
+    # QB分类数据源
+    _source_categories = None
+    # 目录地址数据源
+    _source_paths = None
+    # 选择的刷流插件
+    _brush_plugin = None
+    # 下载器
+    _downloader = None
+    # 移动目录
+    _move_path = None
+    # 种子分类
+    _category = None
+    # 种子标签
+    _tag = None
+    # 发送通知
+    _notify = None
+    # 自动分类
+    _auto_category = None
+    # 添加MP标签
+    _mp_tag = None
+    # 移除刷流标签
+    _remove_brush_tag = None
+    # 选择的种子
+    _torrent_hashes = None
+    # 刷流标签
+    _brush_tag = "刷流"
+    # 整理Tag
+    _organize_tag = "已整理"
+    # 退出事件
+    _event = Event()
+    # 定时器
+    _scheduler = None
+
+    # endregion
+
+    def init_plugin(self, config: dict = None):
+        self.plugin_manager = PluginManager()
+        self.downloader_helper = DownloaderHelper()
+
+        if not config:
+            logger.info("刷流种子整理出错，无法获取插件配置")
+            return False
+
+        self._source_paths = config.get("source_paths", None)
+        self._source_categories = config.get("source_categories", None)
+        self._brush_plugin = config.get("brush_plugin", None)
+        self._downloader = config.get("downloader", None)
+        self._move_path = config.get("move_path", None)
+        self._category = config.get("category", None)
+        self._tag = config.get("tag", None)
+        self._notify = config.get("notify", False)
+        self._auto_category = config.get("auto_category", False)
+        self._mp_tag = config.get("mp_tag", False)
+        self._remove_brush_tag = config.get("remove_brush_tag", False)
+        self._torrent_hashes = config.get("torrents", None)
+
+        self.__update_config(config=config)
+
+        # 停止现有任务
+        self.stop_service()
+
+        if not self._downloader:
+            self.__log_and_notify_error("没有配置下载器")
+            return
+
+        self.__organize()
+
+    @property
+    def service_info(self) -> Optional[ServiceInfo]:
+        """
+        服务信息
+        """
+        if not self._downloader:
+            logger.warning("尚未配置下载器，请检查配置")
+            return None
+
+        service = self.downloader_helper.get_service(name=self._downloader, type_filter="qbittorrent")
+        if not service:
+            logger.warning("获取下载器实例失败，请检查配置")
+            return None
+
+        if service.instance.is_inactive():
+            logger.warning(f"下载器 {self._downloader} 未连接，请检查配置")
+            return None
+
+        return service
+
+    @property
+    def downloader(self) -> Optional[Union[Qbittorrent, Transmission]]:
+        """
+        下载器实例
+        """
+        return self.service_info.instance if self.service_info else None
+
+    def get_state(self) -> bool:
+        """返回插件是否已配置下载器。"""
+        return bool(self._downloader)
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """本插件不注册远程命令。"""
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """本插件不暴露额外的 HTTP API。"""
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """
+        拼装插件配置页面，需要返回两块数据：1、页面配置；2、数据结构
+        """
+        # 已安装的刷流插件
+        plugin_options = self.__get_plugin_options()
+        category_options = self.__get_display_options(self._source_categories)
+        path_options = self.__get_display_options(self._source_paths)
+        torrent_options = self.__get_torrent_options()
+        downloader_options = [{"title": config.name, "value": config.name}
+                              for config in self.downloader_helper.get_configs().values()
+                              if config.type == "qbittorrent"]
+
+        return [
+            {
+                'component': 'VForm',
+                'content': [
+                    {
+                        'component': 'VTabs',
+                        'props': {
+                            'model': '_tabs',
+                            'fixed-tabs': True
+                        },
+                        'content': [
+                            {
+                                'component': 'VTab',
+                                'props': {
+                                    'value': 'base_tab'
+                                },
+                                'text': '基本配置'
+                            },
+                            {
+                                'component': 'VTab',
+                                'props': {
+                                    'value': 'data_tab'
+                                },
+                                'text': '数据配置'
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VWindow',
+                        'props': {
+                            'model': '_tabs',
+                            'style': {
+                                'padding-top': '24px',
+                                'padding-bottom': '24px'
+                            },
+                        },
+                        'content': [
+                            {
+                                'component': 'VWindowItem',
+                                'props': {
+                                    'value': 'base_tab'
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VRow',
+                                        'content': [
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VAutocomplete',
+                                                        'props': {
+                                                            'chips': True,
+                                                            'multiple': True,
+                                                            'model': 'torrents',
+                                                            'label': '选择种子',
+                                                            'items': torrent_options,
+                                                            'clearable': True,
+                                                            'menu-props': {
+                                                                'max-width': '-1px'
+                                                            },
+                                                            'hint': '选择要处理的种子',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'component': 'VRow',
+                                        'content': [
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12,
+                                                    'md': 3
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VSelect',
+                                                        'props': {
+                                                            'model': 'downloader',
+                                                            'label': '下载器',
+                                                            'items': downloader_options,
+                                                            'hint': '选择下载器',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12,
+                                                    'md': 3
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VSelect',
+                                                        'props': {
+                                                            'model': 'move_path',
+                                                            'label': '移动目录',
+                                                            'items': path_options,
+                                                            'clearable': True,
+                                                            'hint': '选择处理完成后移动的目录',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12,
+                                                    'md': 3
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VSelect',
+                                                        'props': {
+                                                            'model': 'category',
+                                                            'label': '种子分类',
+                                                            'items': category_options,
+                                                            'clearable': True,
+                                                            'hint': '选择种子的分类，仅适用QB',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12,
+                                                    'md': 3
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VTextField',
+                                                        'props': {
+                                                            'model': 'tag',
+                                                            'label': '添加种子标签',
+                                                            'clearable': True,
+                                                            'hint': '添加标签，如：待转移,剧情',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'component': 'VRow',
+                                        'content': [
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12,
+                                                    'md': 3
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VSwitch',
+                                                        'props': {
+                                                            'model': 'notify',
+                                                            'label': '发送通知',
+                                                            'hint': '是否在特定事件发生时发送通知',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12,
+                                                    'md': 3
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VSwitch',
+                                                        'props': {
+                                                            'model': 'auto_category',
+                                                            'label': '自动分类管理',
+                                                            'hint': '启用自动种子管理，仅适用QB',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12,
+                                                    'md': 3
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VSwitch',
+                                                        'props': {
+                                                            'model': 'mp_tag',
+                                                            'label': '添加MP标签',
+                                                            'hint': '为种子添加MoviePilot标签',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12,
+                                                    'md': 3
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VSwitch',
+                                                        'props': {
+                                                            'model': 'remove_brush_tag',
+                                                            'label': '移除刷流标签',
+                                                            'hint': '是否移除刷流标签',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VWindowItem',
+                                'props': {
+                                    'value': 'data_tab'
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VRow',
+                                        'content': [
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VSelect',
+                                                        'props': {
+                                                            'model': 'brush_plugin',
+                                                            'label': '刷流插件',
+                                                            'items': plugin_options,
+                                                            'hint': '选择要使用的刷流插件',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'component': 'VRow',
+                                        'content': [
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VTextarea',
+                                                        'props': {
+                                                            'model': 'source_categories',
+                                                            'label': '分类配置',
+                                                            'placeholder': '仅支持QB，每一行一个分类，格式为：'
+                                                                           'QB分类名称 或 分类名称:QB分类名称，'
+                                                                           '参考如下：\nMovie\n电影:Movie',
+                                                            'hint': '配置分类，格式为：QB分类名称 或 分类名称:QB分类名称',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        'component': 'VRow',
+                                        'content': [
+                                            {
+                                                'component': 'VCol',
+                                                'props': {
+                                                    'cols': 12
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'VTextarea',
+                                                        'props': {
+                                                            'model': 'source_paths',
+                                                            'label': '目录配置',
+                                                            'placeholder': '每一行一个目录，格式为：'
+                                                                           '目录地址 或 目录名称:目录地址，'
+                                                                           '参考如下：\n/volume1/Media/Movie'
+                                                                           '\n电影:/volume1/Media/Movie',
+                                                            'hint': '配置目录，格式为：目录地址 或 目录名称:目录地址',
+                                                            'persistent-hint': True
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal',
+                                            'text': '注意：请先在数据配置中初始化数据源，点击保存后再打开插件选择种子进行整理'
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ], {
+            "notify": True,
+            "mp_tag": True,
+            "remove_brush_tag": True,
+            "auto_category": True
+        }
+
+    def get_page(self) -> Optional[List[dict]]:
+        """本插件没有详情页。"""
+        return None
+
+    def stop_service(self):
+        """
+        退出插件
+        """
+        try:
+            if self._scheduler:
+                self._scheduler.remove_all_jobs()
+                if self._scheduler.running:
+                    self._event.set()
+                    self._scheduler.shutdown()
+                    self._event.clear()
+                self._scheduler = None
+        except Exception as e:
+            print(str(e))
+
+    def __update_config(self, config: dict):
+        """
+        更新配置
+        """
+        # 列出要排除的键
+        exclude_keys = ['torrents']
+
+        # 使用字典推导创建一个新字典，排除在 exclude_keys 列表中的键
+        filtered_config = {key: value for key, value in config.items() if key not in exclude_keys}
+
+        # 使用 filtered_config 进行配置更新
+        self.update_config(filtered_config)
+
+    def __organize(self):
+        """
+        整理选择的种子进行入库操作
+        """
+        with lock:
+            logger.info("开始准备整理入库任务 ...")
+            if not self._torrent_hashes:
+                logger.info("没有选择任何种子，取消整理")
+                return
+
+            downloader = self.downloader
+            if not downloader:
+                self.__log_and_notify_error("连接下载器出错，请检查连接")
+                return
+
+            torrents, error = downloader.get_torrents(ids=self._torrent_hashes)
+            if error:
+                self.__log_and_notify_error("连接下载器出错，请检查连接")
+                return
+
+            if not torrents:
+                self.__log_and_notify_error("在下载器中没有获取到对应的种子，请检查刷流任务")
+                return
+
+            logger.info(f"当前选择的种子数量为 {len(self._torrent_hashes)}，"
+                        f"实际在下载器中获取到的种子数量为 {len(torrents)}")
+
+            torrent_hash_titles = self.__get_all_hashes_and_titles(torrents)
+
+            logger.info(f"准备为 {len(torrent_hash_titles)} 个种子进行整理任务，种子详情为 {torrent_hash_titles}")
+
+            torrent_datas = self.__get_all_hashes_and_torrents(torrents)
+
+            if self.__is_qbittorrent():
+                self.__organize_for_qb(torrent_hash_titles=torrent_hash_titles, torrent_datas=torrent_datas)
+                self.__run_after_organize()
+            else:
+                logger.warning("当前只支持qbittorrent")
+
+    def __organize_for_qb(self, torrent_hash_titles: dict, torrent_datas):
+        """针对QB进行种子整理"""
+        # 获取下载器实例
+        downloader = self.downloader
+        if not downloader or not downloader.qbc:
+            self.__log_and_notify_error("连接下载器出错，请检查连接")
+            return
+
+        # 初始化成功和失败的计数器和列表
+        success_count = 0
+        failed_count = 0
+        success_titles = []
+        failed_titles = []
+
+        # 遍历所有种子
+        for torrent_hash, torrent_title in torrent_hash_titles.items():
+            success = True
+
+            if self._remove_brush_tag:
+                try:
+                    logger.info(f"正在为种子「{torrent_title}」[{torrent_hash}] 移除「{self._brush_tag}」标签")
+                    remove_result = downloader.remove_torrents_tag(ids=[torrent_hash], tag=self._brush_tag)
+                    if not remove_result:
+                        raise Exception(f"「{self._brush_tag}」标签移除失败，请检查下载器连接")
+                    logger.info(f"标签移除成功 - {torrent_hash}")
+                except Exception as e:
+                    logger.error(f"移除标签失败，种子哈希：{torrent_hash}，错误：{str(e)}")
+                    success = False
+
+            if self._mp_tag and success:
+                try:
+                    logger.info(f"正在为种子「{torrent_title}」[{torrent_hash}] "
+                                f"添加「{settings.TORRENT_TAG}」标签并移除「{self._organize_tag}」标签")
+                    remove_result = downloader.remove_torrents_tag(ids=[torrent_hash], tag=self._organize_tag)
+                    if not remove_result:
+                        raise Exception(f"「{self._organize_tag}」标签移除失败，请检查下载器连接")
+                    downloader.set_torrents_tag(ids=[torrent_hash], tags=[settings.TORRENT_TAG])
+                    logger.info(f"MP标签添加成功 - {torrent_hash}")
+                except Exception as e:
+                    logger.error(f"设置MP标签失败，种子哈希：{torrent_hash}，错误：{str(e)}")
+                    success = False
+
+            if self._tag and success:
+                try:
+                    logger.info(f"正在为种子「{torrent_title}」[{torrent_hash}] "
+                                f"添加「{self._tag}」标签")
+                    downloader.set_torrents_tag(ids=[torrent_hash], tags=[self._tag])
+                    logger.info(f"标签添加成功 - {torrent_hash}")
+                except Exception as e:
+                    logger.error(f"设置标签失败，种子哈希：{torrent_hash}，错误：{str(e)}")
+                    success = False
+
+            if self._category and success:
+                try:
+                    logger.info(f"正在为种子「{torrent_title}」[{torrent_hash}] 设置「{self._category}」分类")
+                    try:
+                        downloader.qbc.torrents_set_category(torrent_hashes=torrent_hash, category=self._category)
+                    except Exception as e:
+                        logger.warning(f"种子 「{torrent_title}」[{torrent_hash}] "
+                                    f"设置分类 {self._category} 失败：{str(e)}, 尝试创建分类再设置")
+                        downloader.qbc.torrents_create_category(name=self._category, save_path=self._move_path)
+                        downloader.qbc.torrents_set_category(torrent_hashes=torrent_hash, category=self._category)
+                    logger.info(f"分类设置成功 - {torrent_hash}")
+                except Exception as e:
+                    logger.error(f"设置分类失败，种子哈希：{torrent_hash}，错误：{str(e)}")
+                    success = False
+
+            # qb中的自动分类管理和目录为二选一的逻辑
+            if success:
+                if self._auto_category:
+                    try:
+                        logger.info(f"正在为种子「{torrent_title}」[{torrent_hash}] 开启自动分类管理")
+                        downloader.qbc.torrents_set_auto_management(torrent_hashes=torrent_hash,
+                                                                    enable=self._auto_category)
+                        logger.info(f"自动分类管理开启成功 - {torrent_hash}")
+                    except Exception as e:
+                        logger.error(f"自动分类管理开启失败，种子哈希：{torrent_hash}，错误：{str(e)}")
+                        success = False
+                else:
+                    if self._move_path:
+                        try:
+                            logger.info(f"正在为种子「{torrent_title}」[{torrent_hash}] 关闭自动分类管理")
+                            downloader.qbc.torrents_set_auto_management(torrent_hashes=torrent_hash,
+                                                                        enable=self._auto_category)
+                            logger.info(f"自动分类管理关闭成功 - {torrent_hash}")
+                        except Exception as e:
+                            logger.error(f"自动分类管理关闭失败，种子哈希：{torrent_hash}，错误：{str(e)}")
+                        try:
+                            logger.info(f"正在为种子「{torrent_title}」[{torrent_hash}] 修改保存路径 {self._move_path}")
+                            downloader.qbc.torrents_set_location(torrent_hashes=torrent_hash, location=self._move_path)
+                            logger.info(f"修改保存路径成功 - {torrent_hash}")
+                        except Exception as e:
+                            logger.error(f"修改保存路径失败，种子哈希：{torrent_hash}，错误：{str(e)}")
+                            success = False
+
+            # 更新成功或失败的计数器和列表
+            if success:
+                logger.info(f"「{torrent_title}」[{torrent_hash}] 操作完成，请等待后续入库")
+                success_count += 1
+                success_titles.append(torrent_title)
+            else:
+                logger.error(f"「{torrent_title}」[{torrent_hash}] 操作失败，请检查日志调整")
+                failed_count += 1
+                failed_titles.append(torrent_title)
+
+        # 构建简要的汇总消息
+        summary_message_parts = []
+        if success_count > 0:
+            success_details = "\n".join(success_titles)  # 使用换行符而不是逗号分隔种子标题
+            summary_message_parts.append(f"成功操作 {success_count} 个种子，请等待后续入库\n{success_details}")
+        if failed_count > 0:
+            failed_details = "\n".join(failed_titles)  # 使用换行符而不是逗号分隔种子标题
+            summary_message_parts.append(f"失败操作 {failed_count} 个种子，详细请查看日志\n{failed_details}")
+
+        summary_message = "\n\n".join(summary_message_parts)  # 使用两个换行符分隔成功和失败的部分
+
+        self.__send_message(title="【刷流种子整理详情】", text=summary_message)
+
+    def __get_torrent_options(self) -> List[dict]:
+        """获取种子选项列表"""
+        # 检查刷流插件是否已选择
+        if not self._brush_plugin:
+            logger.info("刷流插件尚未选择，无法获取到刷流任务")
+            return []
+
+        # 获取刷流任务数据
+        torrent_tasks = self.get_data("torrents", self._brush_plugin)
+        if not torrent_tasks:
+            logger.info(f"刷流插件：{self._brush_plugin}，没有获取到刷流任务")
+            return []
+
+        # 初始化任务选项列表
+        torrent_options = []
+
+        # 解析任务数据
+        for task_id, task_info in torrent_tasks.items():
+            # 检查任务是否已被删除
+            if task_info.get("deleted", False):
+                continue  # 如果已被删除，则跳过这个任务
+
+            # 格式化描述和标题
+            description = task_info.get("description")
+            size = f"{self.__bytes_to_gb(size_in_bytes=task_info.get('size')):.1f} GB"
+            title = f"{size} | {description} | {task_info.get('title')}" if description else task_info.get('title')
+
+            torrent_options.append({
+                "title": title,
+                "value": task_id,
+                "name": task_info.get('title')
+            })
+
+        # 根据创建时间排序，确保所有元素都有时间戳
+        torrent_options.sort(key=lambda x: torrent_tasks[x["value"]].get("time", 0), reverse=True)
+
+        # 添加序号到标题
+        for index, option in enumerate(torrent_options, start=1):
+            option["title"] = f"{index}. {option['title']}"
+
+        # 日志记录获取的任务
+        logger.info(f"刷流插件：{self._brush_plugin}，共获取到 {len(torrent_options)} 个刷流任务")
+
+        return torrent_options
+
+    def __get_plugin_options(self) -> List[dict]:
+        """获取插件选项列表"""
+        # 获取运行的插件选项
+        running_plugins = self.plugin_manager.get_running_plugin_ids()
+
+        # 需要检查的插件名称
+        filter_plugins = {"BrushFlow", "BrushFlowLowFreq"}
+
+        # 获取本地插件列表
+        local_plugins = self.plugin_manager.get_local_plugins()
+
+        # 初始化插件选项列表
+        plugin_options = []
+
+        # 从本地插件中筛选出符合条件的插件
+        for local_plugin in local_plugins:
+            if local_plugin.id in running_plugins and local_plugin.id in filter_plugins:
+                plugin_options.append({
+                    "title": f"{local_plugin.plugin_name} v{local_plugin.plugin_version}",
+                    "value": local_plugin.id,
+                    "name": local_plugin.plugin_name
+                })
+
+        # 重新编号，保证显示为 1. 2. 等
+        for index, option in enumerate(plugin_options, start=1):
+            option["title"] = f"{index}. {option.get('title')}"
+
+        return plugin_options
+
+    @staticmethod
+    def __get_display_options(source: str) -> List[dict]:
+        """根据源数据获取显示的选项列表"""
+        # 检查是否有可用的源数据
+        if not source:
+            return []
+
+        # 将源字符串分割为单独的列表并去除每一项的前后空格
+        categories = [category.strip() for category in source.split("\n") if category.strip()]
+
+        # 初始化分类选项列表
+        category_options = []
+
+        # 遍历分割后且清理过的分类数据，格式化并创建包含title, value, name的字典
+        for category in categories:
+            parts = category.split(":")
+            if len(parts) > 1:
+                display_name, name = parts[0].strip(), parts[1].strip()
+            else:
+                display_name = name = parts[0].strip()
+
+            # 将格式化后的数据添加到列表
+            category_options.append({
+                "title": display_name,
+                "value": name,
+                "name": display_name
+            })
+
+        return category_options
+
+    def __get_all_hashes_and_torrents(self, torrents):
+        """
+        获取torrents列表中所有种子的Hash值和对应的种子对象，存储在一个字典中
+
+        :param torrents: 包含种子信息的列表
+        :return: 一个字典，其中键是种子的Hash值，值是对应的种子对象
+        """
+        try:
+            all_hashes_torrents = {}
+            is_qbittorrent = self.__is_qbittorrent()
+
+            for torrent in torrents:
+                # 根据下载器类型获取Hash值
+                hash_value = torrent.get("hash") if is_qbittorrent else self.__get_transmission_hash(torrent)
+
+                if hash_value:
+                    all_hashes_torrents[hash_value] = torrent  # 直接将torrent对象存储为字典的值
+            return all_hashes_torrents
+        except Exception as e:
+            logger.error(f"get_all_hashes_and_torrents error: {e}")
+            return {}
+
+    def __get_all_hashes_and_titles(self, torrents):
+        """
+        获取torrents列表中所有种子的Hash值和标题，存储在一个字典中
+
+        :param torrents: 包含种子信息的列表
+        :return: 一个字典，其中键是种子的Hash值，值是种子的标题
+        """
+        try:
+            all_hashes_titles = {}
+            is_qbittorrent = self.__is_qbittorrent()
+
+            for torrent in torrents:
+                # 根据下载器类型获取Hash值和标题
+                hash_value = torrent.get("hash") if is_qbittorrent else self.__get_transmission_hash(torrent)
+                torrent_title = torrent.get("name") if is_qbittorrent else torrent.name
+
+                if hash_value and torrent_title:
+                    all_hashes_titles[hash_value] = torrent_title
+            return all_hashes_titles
+        except Exception as e:
+            logger.error(f"get_all_hashes_and_titles error: {e}")
+            return {}
+
+    def __get_torrent_info(self, torrent: Any) -> dict:
+        """
+        获取种子信息
+        """
+        date_now = int(time.time())
+        # QB
+        if self.__is_qbittorrent():
+            """
+            {
+              "added_on": 1693359031,
+              "amount_left": 0,
+              "auto_tmm": false,
+              "availability": -1,
+              "category": "tJU",
+              "completed": 67759229411,
+              "completion_on": 1693609350,
+              "content_path": "/mnt/sdb/qb/downloads/Steel.Division.2.Men.of.Steel-RUNE",
+              "dl_limit": -1,
+              "dlspeed": 0,
+              "download_path": "",
+              "downloaded": 67767365851,
+              "downloaded_session": 0,
+              "eta": 8640000,
+              "f_l_piece_prio": false,
+              "force_start": false,
+              "hash": "116bc6f3efa6f3b21a06ce8f1cc71875",
+              "infohash_v1": "116bc6f306c40e072bde8f1cc71875",
+              "infohash_v2": "",
+              "last_activity": 1693609350,
+              "magnet_uri": "magnet:?xt=",
+              "max_ratio": -1,
+              "max_seeding_time": -1,
+              "name": "Steel.Division.2.Men.of.Steel-RUNE",
+              "num_complete": 1,
+              "num_incomplete": 0,
+              "num_leechs": 0,
+              "num_seeds": 0,
+              "priority": 0,
+              "progress": 1,
+              "ratio": 0,
+              "ratio_limit": -2,
+              "save_path": "/mnt/sdb/qb/downloads",
+              "seeding_time": 615035,
+              "seeding_time_limit": -2,
+              "seen_complete": 1693609350,
+              "seq_dl": false,
+              "size": 67759229411,
+              "state": "stalledUP",
+              "super_seeding": false,
+              "tags": "",
+              "time_active": 865354,
+              "total_size": 67759229411,
+              "tracker": "https://tracker",
+              "trackers_count": 2,
+              "up_limit": -1,
+              "uploaded": 0,
+              "uploaded_session": 0,
+              "upspeed": 0
+            }
+            """
+            # ID
+            torrent_id = torrent.get("hash")
+            # 标题
+            torrent_title = torrent.get("name")
+            # 下载时间
+            if not torrent.get("added_on") or torrent.get("added_on") < 0:
+                dltime = 0
+            else:
+                dltime = date_now - torrent.get("added_on")
+            # 做种时间
+            if not torrent.get("completion_on") or torrent.get("completion_on") < 0:
+                seeding_time = 0
+            else:
+                seeding_time = date_now - torrent.get("completion_on")
+            # 分享率
+            ratio = torrent.get("ratio") or 0
+            # 上传量
+            uploaded = torrent.get("uploaded") or 0
+            # 平均上传速度 Byte/s
+            if dltime:
+                avg_upspeed = int(uploaded / dltime)
+            else:
+                avg_upspeed = uploaded
+            # 已未活动 秒
+            if not torrent.get("last_activity") or torrent.get("last_activity") < 0:
+                iatime = 0
+            else:
+                iatime = date_now - torrent.get("last_activity")
+            # 下载量
+            downloaded = torrent.get("downloaded")
+            # 种子大小
+            total_size = torrent.get("total_size")
+            # 添加时间
+            add_on = (torrent.get("added_on") or 0)
+            add_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(add_on))
+            # 种子标签
+            tags = torrent.get("tags")
+            # tracker
+            tracker = torrent.get("tracker")
+        # TR
+        else:
+            # ID
+            torrent_id = self.__get_transmission_hash(torrent)
+            # 标题
+            torrent_title = torrent.name
+            done_date = getattr(torrent, "date_done", None) or getattr(torrent, "done_date", None)
+            added_date = getattr(torrent, "date_added", None) or getattr(torrent, "added_date", None)
+            active_date = getattr(torrent, "date_active", None) or getattr(torrent, "activity_date", None)
+            # 做种时间
+            if (not done_date
+                    or done_date.timestamp() < 1):
+                seeding_time = 0
+            else:
+                seeding_time = date_now - int(done_date.timestamp())
+            # 下载耗时
+            if (not added_date
+                    or added_date.timestamp() < 1):
+                dltime = 0
+            else:
+                dltime = date_now - int(added_date.timestamp())
+            # 下载量
+            downloaded = int(torrent.total_size * torrent.progress / 100)
+            # 分享率
+            ratio = torrent.ratio or 0
+            # 上传量
+            uploaded = int(downloaded * torrent.ratio)
+            # 平均上传速度
+            if dltime:
+                avg_upspeed = int(uploaded / dltime)
+            else:
+                avg_upspeed = uploaded
+            # 未活动时间
+            if (not active_date
+                    or active_date.timestamp() < 1):
+                iatime = 0
+            else:
+                iatime = date_now - int(active_date.timestamp())
+            # 种子大小
+            total_size = torrent.total_size
+            # 添加时间
+            add_on = (added_date.timestamp() if added_date else 0)
+            add_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(add_on))
+            # 种子标签
+            tags = torrent.get("tags") or getattr(torrent, "labels", None) or []
+            # tracker
+            trackers = getattr(torrent, "trackers", None) or []
+            tracker = torrent.get("tracker") or (getattr(trackers[0], "announce", "") if trackers else "")
+
+        return {
+            "hash": torrent_id,
+            "title": torrent_title,
+            "seeding_time": seeding_time,
+            "ratio": ratio,
+            "uploaded": uploaded,
+            "downloaded": downloaded,
+            "avg_upspeed": avg_upspeed,
+            "iatime": iatime,
+            "dltime": dltime,
+            "total_size": total_size,
+            "add_time": add_time,
+            "add_on": add_on,
+            "tags": tags,
+            "tracker": tracker
+        }
+
+    @staticmethod
+    def __get_transmission_hash(torrent: Any) -> str:
+        """优先读取 transmission-rpc 的新属性，并兼容旧版对象。"""
+        return getattr(torrent, "hash_string", None) or getattr(torrent, "hashString", "")
+
+    def __is_qbittorrent(self):
+        """
+        判断是否为 qBittorrent
+        """
+        return self.downloader_helper.is_downloader("qbittorrent", self.service_info)
+
+    def __send_message(self, title: str, text: str):
+        """
+        发送消息
+        """
+        if not self._notify:
+            return
+
+        self.post_message(mtype=NotificationType.SiteMessage, title=title, text=text)
+
+    def __get_check_job_id(self):
+        if self._brush_plugin:
+            return "BrushFlowLowFreqCheck" if self._brush_plugin == "BrushFlowLowFreq" else "BrushFlowCheck"
+        return None
+
+    def __run_after_organize(self):
+        """整理后执行相关任务"""
+        self._scheduler = BackgroundScheduler(timezone=settings.TZ)
+
+        # 开启移除刷流标签，则调用刷流插件的Check任务
+        if self._remove_brush_tag:
+            logger.info(f"已开启移除刷流标签，调用站点刷流检查服务")
+            jobid = self.__get_check_job_id()
+            if jobid:
+                self._scheduler.add_job(lambda: start_scheduler_job(jobid), 'date',
+                                        run_date=datetime.now(
+                                            tz=pytz.timezone(settings.TZ)
+                                        ) + timedelta(seconds=3),
+                                        name="站点刷流检查服务 by 刷流种子整理)")
+
+        # 开启添加MP标签，则调用下载文件整理服务
+        if self._mp_tag:
+            logger.info(f"已开启添加MP标签，调用下载文件整理服务")
+            self._scheduler.add_job(lambda: TransferChain().process(), 'date',
+                                    run_date=datetime.now(
+                                        tz=pytz.timezone(settings.TZ)
+                                    ) + timedelta(seconds=3),
+                                    name="下载文件整理 by 刷流种子整理")
+
+        # 存在任务则启动任务
+        if self._scheduler.get_jobs():
+            # 启动服务
+            self._scheduler.print_jobs()
+            self._scheduler.start()
+
+    def __log_and_notify_error(self, message):
+        """
+        记录错误日志并发送系统通知
+        """
+        logger.error(message)
+        self.systemmessage.put(message, title="刷流种子整理")
+
+    @staticmethod
+    def __bytes_to_gb(size_in_bytes: float) -> float:
+        """
+        将字节单位的大小转换为千兆字节（GB）。
+
+        :param size_in_bytes: 文件大小，单位为字节。
+        :return: 文件大小，单位为千兆字节（GB）。
+        """
+        if not size_in_bytes:
+            return 0.0
+        return size_in_bytes / (1024 ** 3)

--- a/plugins.v3/torrentclassifier/__init__.py
+++ b/plugins.v3/torrentclassifier/__init__.py
@@ -1,0 +1,1073 @@
+from __future__ import annotations
+
+import io
+import re
+import threading
+import time
+from datetime import datetime, timedelta
+from threading import Event
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from ruamel.yaml import YAML, YAMLError
+
+from app.sdk.config import settings
+from app.sdk.services import DownloaderHelper
+from app.sdk.logging import logger
+from app.modules.qbittorrent import Qbittorrent
+from app.modules.transmission import Transmission
+from app.plugins import _PluginBase
+from .classifierconfig import ClassifierConfig, TorrentFilter, TorrentTarget
+from app.schemas import NotificationType, ServiceInfo
+
+lock = threading.Lock()
+
+
+class TorrentClassifier(_PluginBase):
+    # 插件名称
+    plugin_name = "种子关键字分类整理"
+    # 插件描述
+    plugin_desc = "通过匹配种子关键字进行自定义分类。"
+    # 插件图标
+    plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/TorrentClassifier.png"
+    # 插件版本
+    plugin_version = "2.0.0"
+    # 插件作者
+    plugin_author = "InfinityPacer"
+    # 作者主页
+    author_url = "https://github.com/InfinityPacer"
+    # 插件配置项ID前缀
+    plugin_config_prefix = "torrentclassifier_"
+    # 加载顺序
+    plugin_order = 50
+    # 可使用的用户级别
+    auth_level = 1
+
+    # region 私有属性
+    downloader_helper = None
+    # 是否开启
+    _enabled = False
+    # 立即运行一次
+    _onlyonce = False
+    # 任务执行间隔
+    _cron = None
+    # 发送通知
+    _notify = False
+    # 遍历规则匹配
+    _apply_all_rules = False
+    # 分类配置
+    _classifier_configs = None
+    # 下载器
+    _downloader = None
+    # 退出事件
+    _event = Event()
+    # 定时器
+    _scheduler = None
+
+    # endregion
+
+    def init_plugin(self, config: dict = None):
+        self.downloader_helper = DownloaderHelper()
+
+        if not config:
+            return False
+
+        # 停止现有任务
+        self.stop_service()
+
+        self._enabled = config.get("enabled", False)
+        self._onlyonce = config.get("onlyonce", False)
+        self._notify = config.get("notify", False)
+        self._cron = config.get("cron", None)
+        self._downloader = config.get("downloader", None)
+        self._apply_all_rules = config.get("apply_all_rules", False)
+        self._classifier_configs = self.__load_configs(config.get("classifier_configs", None))
+
+        if not self._downloader:
+            self.__log_and_notify_error("没有配置下载器")
+            return
+
+        if self._enabled or self._onlyonce:
+            if not self._classifier_configs:
+                self.__log_and_notify_error("获取配置项失败，请检查日志")
+                return
+
+        if self._onlyonce:
+            self._scheduler = BackgroundScheduler(timezone=settings.TZ)
+            self._scheduler.add_job(func=self.torrent_classifier,
+                                    trigger='date',
+                                    run_date=datetime.now(tz=pytz.timezone(settings.TZ)) + timedelta(seconds=3))
+            logger.info(f"种子关键字分类整理服务启动，立即运行一次")
+            self._onlyonce = False
+            config["onlyonce"] = False
+            self.update_config(config=config)
+            # 启动服务
+            if self._scheduler.get_jobs():
+                self._scheduler.print_jobs()
+                self._scheduler.start()
+
+    @property
+    def service_info(self) -> Optional[ServiceInfo]:
+        """
+        服务信息
+        """
+        if not self._downloader:
+            logger.warning("尚未配置下载器，请检查配置")
+            return None
+
+        service = self.downloader_helper.get_service(name=self._downloader, type_filter="qbittorrent")
+        if not service:
+            logger.warning("获取下载器实例失败，请检查配置")
+            return None
+
+        if service.instance.is_inactive():
+            logger.warning(f"下载器 {self._downloader} 未连接，请检查配置")
+            return None
+
+        return service
+
+    @property
+    def downloader(self) -> Optional[Union[Qbittorrent, Transmission]]:
+        """
+        下载器实例
+        """
+        return self.service_info.instance if self.service_info else None
+
+    def get_state(self):
+        return self._enabled
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """本插件不注册远程命令。"""
+        return []
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """本插件不暴露额外的 HTTP API。"""
+        return []
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """
+        拼装插件配置页面，需要返回两块数据：1、页面配置；2、数据结构
+        """
+        downloader_options = [{"title": config.name, "value": config.name}
+                              for config in self.downloader_helper.get_configs().values()
+                              if config.type == "qbittorrent"]
+        return [
+            {
+                'component': 'VForm',
+                'content': [
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'enabled',
+                                            'label': '启用插件',
+                                            'hint': '开启后插件将处于激活状态',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'notify',
+                                            'label': '发送通知',
+                                            'hint': '是否在特定事件发生时发送通知',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    "cols": 12,
+                                    "md": 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'apply_all_rules',
+                                            'label': '遍历规则匹配',
+                                            'hint': '遍历所有规则应用于每个种子',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'onlyonce',
+                                            'label': '立即运行一次',
+                                            'hint': '插件将立即运行一次',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VCronField',
+                                        'props': {
+                                            'model': 'cron',
+                                            'label': '执行周期',
+                                            'placeholder': '5位cron表达式',
+                                            'hint': '使用cron表达式指定执行周期，如 0 8 * * *',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    "cols": 12,
+                                    "md": 6
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'model': 'downloader',
+                                            'label': '下载器',
+                                            'items': downloader_options,
+                                            'hint': '选择下载器',
+                                            'persistent-hint': True
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAceEditor',
+                                        'props': {
+                                            'modelvalue': 'classifier_configs',
+                                            'lang': 'yaml',
+                                            'theme': 'monokai',
+                                            'style': 'height: 25rem'
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal',
+                                            'text': '注意：请详细阅读配置说明后，再参考示例规则进行配置'
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ], {
+            "enabled": False,
+            "notify": True,
+            "only_once": False,
+            "classifier_configs": self.__get_demo_config()
+        }
+
+    def get_page(self) -> List[dict]:
+        pass
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """
+        注册插件公共服务
+        [{
+            "id": "服务ID",
+            "name": "服务名称",
+            "trigger": "触发器：cron/interval/date/CronTrigger.from_crontab()",
+            "func": self.xxx,
+            "kwargs": {} # 定时器参数
+        }]
+        """
+        services = []
+
+        if self._enabled and self._cron:
+            services.append({
+                "id": "TorrentClassifier",
+                "name": "种子关键字分类整理",
+                "trigger": CronTrigger.from_crontab(self._cron),
+                "func": self.torrent_classifier,
+                "kwargs": {}
+            })
+
+        return services
+
+    def stop_service(self):
+        """
+        退出插件
+        """
+        try:
+            if self._scheduler:
+                self._scheduler.remove_all_jobs()
+                if self._scheduler.running:
+                    self._event.set()
+                    self._scheduler.shutdown()
+                    self._event.clear()
+                self._scheduler = None
+        except Exception as e:
+            print(str(e))
+
+    def torrent_classifier(self):
+        """
+        根据配置的规则整理并分类选定的种子
+        """
+        with lock:
+            if not self.__is_qbittorrent():
+                logger.warning("当前只支持qBittorrent")
+                return
+
+            downloader = self.downloader
+            if not downloader:
+                self.__log_and_notify_error("连接下载器出错，请检查连接")
+                return
+
+            if not self._classifier_configs:
+                logger.info("没有找到整理规则，跳过处理")
+                return
+
+            # 根据配置选择应用所有规则还是第一个匹配的规则
+            if self._apply_all_rules:
+                self.__apply_rules_to_each_seeds(downloader=downloader)
+            else:
+                torrents = self.__get_torrents(downloader=downloader)
+                torrent_datas = self.__get_all_hashes_and_torrents(torrents)
+                self.__apply_first_matching_rule_to_torrents(torrent_datas=torrent_datas)
+
+    def __get_torrents(self, downloader: Any) -> Optional[List[Any]]:
+        """
+        从下载器中获取当前所有种子的列表
+        """
+        torrents, error = downloader.get_torrents()
+        if error:
+            self.__log_and_notify_error("连接下载器出错，请检查连接")
+            return None
+
+        if not torrents:
+            logger.info("无法在下载器中找到种子，取消整理")
+            return None
+
+        return torrents
+
+    def __apply_rules_to_each_seeds(self, downloader: Any):
+        """
+        对每个种子应用所有配置的规则
+        """
+        summary_messages = []
+        # 遍历所有规则并记录序号
+        for index, config in enumerate(self._classifier_configs, start=1):
+            torrents = self.__get_torrents(downloader=downloader)
+            if not torrents:
+                continue
+
+            logger.info(f"正在准备执行规则 {index}")
+
+            torrent_datas = self.__get_all_hashes_and_torrents(torrents)
+            classifier_torrents = self.__get_should_classifier_torrents(torrent_datas=torrent_datas, config=config)
+            result = self.__torrent_classifier_for_qb(classifier_torrents=classifier_torrents)
+            if not result:
+                continue
+            success_count, failed_count, success_titles, failed_titles = result
+
+            # 构建当前规则的成功和失败消息
+            rule_summary_parts = []
+            if success_count > 0:
+                success_details = "\n".join(success_titles)
+                rule_summary_parts.append(f"成功整理 {success_count} 个种子\n{success_details}")
+            if failed_count > 0:
+                failed_details = "\n".join(failed_titles)
+                rule_summary_parts.append(f"失败整理 {failed_count} 个种子，详细请查看日志\n{failed_details}")
+
+            rule_summary_message = "\n\n".join(rule_summary_parts)
+            summary_messages.append(f"规则 {index} 的执行结果:\n{rule_summary_message}")
+            summary_messages.append("————————————————————")
+
+        if summary_messages:
+            # 发送所有规则的汇总消息
+            final_summary_message = "\n".join(summary_messages)
+            self.__send_message(title="【种子规则分类整理汇总】", text=final_summary_message)
+
+    def __apply_first_matching_rule_to_torrents(self, torrent_datas: dict):
+        """
+        对每个种子应用第一个匹配的规则
+        """
+        # 初始化成功和失败的计数器和列表
+        classifier_torrents = self.__get_should_classifier_torrents(torrent_datas=torrent_datas)
+        result = self.__torrent_classifier_for_qb(classifier_torrents=classifier_torrents)
+        if not result:
+            return
+        success_count, failed_count, success_titles, failed_titles = result
+
+        # 构建简要的汇总消息
+        summary_message_parts = []
+        if success_count > 0:
+            success_details = "\n".join(success_titles)  # 使用换行符而不是逗号分隔种子标题
+            summary_message_parts.append(f"成功整理 {success_count} 个种子\n{success_details}")
+        if failed_count > 0:
+            failed_details = "\n".join(failed_titles)  # 使用换行符而不是逗号分隔种子标题
+            summary_message_parts.append(f"失败整理 {failed_count} 个种子，详细请查看日志\n{failed_details}")
+
+        summary_message = "\n\n".join(summary_message_parts)  # 使用两个换行符分隔成功和失败的部分
+
+        self.__send_message(title="【种子关键字分类整理】", text=summary_message)
+
+    def __torrent_classifier_for_qb(self, classifier_torrents: dict) -> Optional[Tuple[int, int, List[str], List[str]]]:
+        """针对QB进行种子整理"""
+        # 获取下载器实例
+        downloader = self.downloader
+
+        success_count = 0
+        failed_count = 0
+        success_titles = []
+        failed_titles = []
+
+        if classifier_torrents:
+            logger.info(f"已获取到满足过滤方案的种子共 {len(classifier_torrents)} 个，继续整理")
+            torrent_info = "\n".join(
+                f"{self.__get_torrent_title(torrent=torrent)}({torrent_hash})"
+                for torrent_hash, (torrent, _) in classifier_torrents.items()
+            )
+            logger.debug(f"正在准备整理的种子信息 \n {torrent_info}")
+        else:
+            logger.info("没有获取到任何满足过滤方案的种子，取消后续整理")
+            return None
+
+        for torrent_hash, (torrent, config) in classifier_torrents.items():
+            config: ClassifierConfig
+            torrent_target = config.torrent_target
+            success = True
+
+            torrent_title = self.__get_torrent_title(torrent=torrent)
+            torrent_category = self.__get_torrent_category(torrent=torrent)
+            torrent_tags = self.__get_torrent_tags(torrent=torrent)
+
+            torrent_key = f"{torrent_title}({torrent_hash})"
+            logger.info(f"正在准备整理种子 {torrent_key}")
+
+            if torrent_target.remove_tags:
+                remove_tags = []
+                try:
+                    # 检查是否需要移除所有标签
+                    if '@all' in torrent_target.remove_tags:
+                        remove_tags = torrent_tags
+                        logger.info(f"正在为种子移除所有标签")
+                    else:
+                        remove_tags = torrent_target.remove_tags
+                        logger.info(f"正在为种子移除「{torrent_target.remove_tags}」标签")
+
+                    remove_result = downloader.remove_torrents_tag(ids=torrent_hash, tag=remove_tags)
+                    if not remove_result:
+                        raise Exception(f"标签移除失败，请检查下载器连接")
+                    logger.info(f"标签「{remove_tags}」移除成功")
+                except Exception as e:
+                    logger.error(f"标签「{remove_tags}」移除失败，错误：{str(e)}")
+                    success = False
+
+            if torrent_target.add_tags and success:
+                try:
+                    logger.info(f"正在为种子添加「{torrent_target.add_tags}」标签")
+                    downloader.set_torrents_tag(ids=torrent_hash, tags=torrent_target.add_tags)
+                    logger.info(f"标签「{torrent_target.add_tags}」添加成功")
+                except Exception as e:
+                    logger.error(f"标签「{torrent_target.add_tags}」添加失败，错误：{str(e)}")
+                    success = False
+
+            if torrent_target.change_category and success:
+                try:
+                    logger.info(f"正在为种子设置「{torrent_target.change_category}」分类")
+                    try:
+                        downloader.qbc.torrents_set_category(torrent_hashes=torrent_hash,
+                                                             category=torrent_target.change_category)
+                    except Exception as e:
+                        logger.warning(f"种子设置分类 {torrent_target.change_category} 失败：{str(e)}, 尝试创建分类再设置")
+                        downloader.qbc.torrents_create_category(name=torrent_target.change_category,
+                                                                save_path=torrent_target.change_directory)
+                        downloader.qbc.torrents_set_category(torrent_hashes=torrent_hash,
+                                                             category=torrent_target.change_category)
+                    logger.info(f"分类「{torrent_target.change_category}」设置成功")
+                except Exception as e:
+                    logger.error(f"分类「{torrent_target.change_category}」设置失败，错误：{str(e)}")
+                    success = False
+
+            # qb中的自动分类管理和目录为二选一的逻辑
+            if success:
+                if torrent_target.auto_category:
+                    try:
+                        logger.info(f"正在为种子开启自动分类管理")
+                        downloader.qbc.torrents_set_auto_management(torrent_hashes=torrent_hash,
+                                                                    enable=torrent_target.auto_category)
+                        logger.info(f"自动分类管理开启成功")
+                    except Exception as e:
+                        logger.error(f"自动分类管理开启失败，错误：{str(e)}")
+                        success = False
+                else:
+                    if torrent_target.change_directory:
+                        try:
+                            logger.info(f"正在为种子关闭自动分类管理")
+                            downloader.qbc.torrents_set_auto_management(torrent_hashes=torrent_hash,
+                                                                        enable=torrent_target.auto_category)
+                            logger.info(f"自动分类管理关闭成功")
+                        except Exception as e:
+                            logger.error(f"自动分类管理关闭失败，错误：{str(e)}")
+                        try:
+                            logger.info(f"正在为种子修改保存路径 {torrent_target.change_directory}")
+                            downloader.qbc.torrents_set_location(torrent_hashes=torrent_hash,
+                                                                 location=torrent_target.change_directory)
+                            logger.info(f"修改保存路径成功")
+                        except Exception as e:
+                            logger.error(f"修改保存路径失败，错误：{str(e)}")
+                            success = False
+
+                # 更新成功或失败的计数器和列表
+                if success:
+                    logger.info(f"{torrent_key} 整理成功")
+                    success_count += 1
+                    success_titles.append(torrent_title)
+                else:
+                    logger.error(f"{torrent_key} 整理失败，请检查日志")
+                    failed_count += 1
+                    failed_titles.append(torrent_title)
+
+        return success_count, failed_count, success_titles, failed_titles
+
+    def __get_should_classifier_torrents(self, torrent_datas: dict, config: Optional[ClassifierConfig] = None):
+        """获取需要整理的种子"""
+        classifier_torrents = {}
+        classifier_configs = self._classifier_configs if not config else [config]
+        # 遍历所有种子
+        for torrent_hash, torrent in torrent_datas.items():
+            torrent_title = self.__get_torrent_title(torrent=torrent)
+            should_classifier = True
+            for config in classifier_configs:
+                # 判断是否满足整理条件，不满足则跳过，满足则跳出
+                should, reason = self.__should_classifier(config=config, torrent=torrent)
+                if should:
+                    logger.debug(f"{torrent_title}({torrent_hash}) 满足过滤方案，已记录待后续整理")
+                    classifier_torrents[torrent_hash] = torrent, config
+                    should_classifier = True
+                    break
+                else:
+                    logger.debug(f"{torrent_title}({torrent_hash}) 不满足过滤方案，原因：{reason}")
+                    should_classifier = False
+                    continue
+
+            if not should_classifier:
+                logger.debug(f"{torrent_title}({torrent_hash}) 没有满足所有过滤方案，跳过")
+                continue
+
+        return classifier_torrents
+
+    def __should_classifier(self, config: ClassifierConfig, torrent: Any) -> (bool, str):
+        """判断是否满足整理条件"""
+        torrent_filter = config.torrent_filter
+        torrent_target = config.torrent_target
+        if not torrent_filter:
+            return False, "没有获取到整理规则"
+
+        torrent_title = self.__get_torrent_title(torrent=torrent)
+        torrent_category = self.__get_torrent_category(torrent=torrent)
+        torrent_tags = self.__get_torrent_tags(torrent=torrent)
+        torrent_auto_category = self.__get_torrent_auto_category(torrent=torrent)
+        torrent_path = self.__get_torrent_path(torrent=torrent)
+
+        # 判断当前属性是否已符合目标设置
+        match, reason = self.__matches_target_settings(torrent_target, torrent_path, torrent_category, torrent_tags,
+                                                       torrent_auto_category)
+        if match:
+            return False, "属性已完全符合目标设置，无需整理"
+        else:
+            logger.debug(f"存在种子属性不符合目标设置，前置过滤通过，原因：{reason}")
+
+        # 继续检查其他过滤条件
+        return self.__check_filters(torrent_filter, torrent_title, torrent_category, torrent_tags)
+
+    @staticmethod
+    def __matches_target_settings(torrent_target, torrent_path, torrent_category, torrent_tags,
+                                  torrent_auto_category) -> (bool, str):
+        """检查种子的当前设置是否符合目标设置"""
+        if torrent_target.auto_category != torrent_auto_category:
+            return False, f"自动分类 不符合目标值 {torrent_target.auto_category}"
+        if not torrent_target.auto_category and not (
+                torrent_target.change_directory and torrent_target.change_directory == torrent_path):
+            return False, f"存储目录 不符合目标值 {torrent_target.change_directory}"
+        if torrent_target.change_category and torrent_target.change_category != torrent_category:
+            return False, f"分类 不符合目标值 {torrent_target.change_category}"
+
+        def __calculate_target_tags():
+            """计算调整后应有的标签集合"""
+            if '@all' in torrent_target.remove_tags:
+                # 如果 '@all' 存在于 remove_tags 中，移除所有标签
+                modified_tags = set()
+            else:
+                # 否则仅移除指定标签
+                modified_tags = set(torrent_tags) - set(torrent_target.remove_tags)
+            # 添加需要的标签
+            modified_tags.update(torrent_target.add_tags)
+            return modified_tags
+
+        # 计算目标标签集
+        target_tags = __calculate_target_tags()
+        if target_tags != set(torrent_tags):
+            return False, f"标签 不符合目标值 {target_tags}"
+
+        return True, ""
+
+    @staticmethod
+    def __check_filters(torrent_filter, torrent_title, torrent_category, torrent_tags) -> (bool, str):
+        """应用过滤条件检查是否需要整理"""
+        if torrent_filter.torrent_title:
+            try:
+                if not torrent_title:
+                    return False, f"标题为空，不符合标题「{torrent_filter.torrent_title}」条件"
+
+                if not re.search(torrent_filter.torrent_title, torrent_title, re.I):
+                    return False, f"不符合标题「{torrent_filter.torrent_title}」条件"
+            except Exception as e:
+                return False, f"标题过滤失败，错误：{str(e)}"
+
+        if torrent_filter.torrent_category:
+            try:
+                if not torrent_category:
+                    return False, f"分类为空，不符合分类「{torrent_filter.torrent_category}」条件"
+
+                if torrent_filter.torrent_category != torrent_category:
+                    return False, f"不符合分类「{torrent_filter.torrent_category}」条件"
+            except Exception as e:
+                return False, f"分类过滤失败，错误：{str(e)}"
+
+        if torrent_filter.torrent_tags:
+            try:
+                if not torrent_tags:
+                    return False, f"标签为空，不符合标签「{torrent_filter.torrent_tags}」条件"
+
+                # 检查种子的标签列表是否至少与过滤标签列表中的一个标签匹配
+                if not any(tag in torrent_tags for tag in torrent_filter.torrent_tags):
+                    return False, f"不符合标签「{torrent_filter.torrent_tags}」条件"
+            except Exception as e:
+                return False, f"标签过滤失败，错误：{str(e)}"
+
+        return True, "OK"
+
+    def __get_all_hashes_and_torrents(self, torrents):
+        """
+        获取torrents列表中所有种子的Hash值和对应的种子对象，存储在一个字典中
+
+        :param torrents: 包含种子信息的列表
+        :return: 一个字典，其中键是种子的Hash值，值是对应的种子对象
+        """
+        try:
+            all_hashes_torrents = {}
+            for torrent in torrents:
+                # 根据下载器类型获取Hash值
+                if self.__is_qbittorrent():
+                    hash_value = torrent.get("hash")
+                else:
+                    hash_value = self.__get_transmission_hash(torrent)
+
+                if hash_value:
+                    all_hashes_torrents[hash_value] = torrent  # 直接将torrent对象存储为字典的值
+            return all_hashes_torrents
+        except Exception as e:
+            logger.error(f"get_all_hashes_and_torrents error: {e}")
+            return {}
+
+    def __get_torrent_title(self, torrent: Any) -> Optional[str]:
+        """获取种子标题"""
+        try:
+            if self.__is_qbittorrent():
+                return torrent.get("name")
+            else:
+                return torrent.name
+        except Exception as e:
+            print(str(e))
+            return None
+
+    def __get_torrent_category(self, torrent: Any) -> Optional[str]:
+        """获取种子分类"""
+        try:
+            return torrent.get("category").strip() if self.__is_qbittorrent() else None
+        except Exception as e:
+            print(str(e))
+            return None
+
+    def __get_torrent_tags(self, torrent: Any) -> List[str]:
+        """
+        获取种子标签
+        """
+        try:
+            return [str(tag).strip() for tag in torrent.get("tags").split(',')] \
+                if self.__is_qbittorrent() else torrent.labels or []
+        except Exception as e:
+            print(str(e))
+            return []
+
+    def __get_torrent_auto_category(self, torrent: Any) -> bool:
+        """
+        获取种子是否启用自动Torrent管理
+        """
+        try:
+            return torrent.get("auto_tmm", False) if self.__is_qbittorrent() else False
+        except Exception as e:
+            print(str(e))
+            return False
+
+    def __get_torrent_path(self, torrent: Any) -> Optional[str]:
+        """
+        获取种子保存路径
+        """
+        try:
+            return torrent.get("save_path", None) if self.__is_qbittorrent() else None
+        except Exception as e:
+            print(str(e))
+            return None
+
+    def __get_torrent_info(self, torrent: Any) -> dict:
+        """
+        获取种子信息
+        """
+        date_now = int(time.time())
+        # QB
+        if self.__is_qbittorrent():
+            """
+            {
+              "added_on": 1693359031,
+              "amount_left": 0,
+              "auto_tmm": false,
+              "availability": -1,
+              "category": "tJU",
+              "completed": 67759229411,
+              "completion_on": 1693609350,
+              "content_path": "/mnt/sdb/qb/downloads/Steel.Division.2.Men.of.Steel-RUNE",
+              "dl_limit": -1,
+              "dlspeed": 0,
+              "download_path": "",
+              "downloaded": 67767365851,
+              "downloaded_session": 0,
+              "eta": 8640000,
+              "f_l_piece_prio": false,
+              "force_start": false,
+              "hash": "116bc6f3efa6f3b21a06ce8f1cc71875",
+              "infohash_v1": "116bc6f306c40e072bde8f1cc71875",
+              "infohash_v2": "",
+              "last_activity": 1693609350,
+              "magnet_uri": "magnet:?xt=",
+              "max_ratio": -1,
+              "max_seeding_time": -1,
+              "name": "Steel.Division.2.Men.of.Steel-RUNE",
+              "num_complete": 1,
+              "num_incomplete": 0,
+              "num_leechs": 0,
+              "num_seeds": 0,
+              "priority": 0,
+              "progress": 1,
+              "ratio": 0,
+              "ratio_limit": -2,
+              "save_path": "/mnt/sdb/qb/downloads",
+              "seeding_time": 615035,
+              "seeding_time_limit": -2,
+              "seen_complete": 1693609350,
+              "seq_dl": false,
+              "size": 67759229411,
+              "state": "stalledUP",
+              "super_seeding": false,
+              "tags": "",
+              "time_active": 865354,
+              "total_size": 67759229411,
+              "tracker": "https://tracker",
+              "trackers_count": 2,
+              "up_limit": -1,
+              "uploaded": 0,
+              "uploaded_session": 0,
+              "upspeed": 0
+            }
+            """
+            # ID
+            torrent_id = torrent.get("hash")
+            # 标题
+            torrent_title = torrent.get("name")
+            # 下载时间
+            if not torrent.get("added_on") or torrent.get("added_on") < 0:
+                dltime = 0
+            else:
+                dltime = date_now - torrent.get("added_on")
+            # 做种时间
+            if not torrent.get("completion_on") or torrent.get("completion_on") < 0:
+                seeding_time = 0
+            else:
+                seeding_time = date_now - torrent.get("completion_on")
+            # 分享率
+            ratio = torrent.get("ratio") or 0
+            # 上传量
+            uploaded = torrent.get("uploaded") or 0
+            # 平均上传速度 Byte/s
+            if dltime:
+                avg_upspeed = int(uploaded / dltime)
+            else:
+                avg_upspeed = uploaded
+            # 已未活动 秒
+            if not torrent.get("last_activity") or torrent.get("last_activity") < 0:
+                iatime = 0
+            else:
+                iatime = date_now - torrent.get("last_activity")
+            # 下载量
+            downloaded = torrent.get("downloaded")
+            # 种子大小
+            total_size = torrent.get("total_size")
+            # 添加时间
+            add_on = (torrent.get("added_on") or 0)
+            add_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(add_on))
+            # 种子标签
+            tags = torrent.get("tags")
+            # tracker
+            tracker = torrent.get("tracker")
+            # 种子分类
+            category = torrent.get("category")
+        # TR
+        else:
+            # ID
+            torrent_id = self.__get_transmission_hash(torrent)
+            # 标题
+            torrent_title = torrent.name
+            done_date = getattr(torrent, "done_date", None) or getattr(torrent, "date_done", None)
+            added_date = getattr(torrent, "added_date", None) or getattr(torrent, "date_added", None)
+            active_date = getattr(torrent, "activity_date", None) or getattr(torrent, "date_active", None)
+            # 做种时间
+            if (not done_date
+                    or done_date.timestamp() < 1):
+                seeding_time = 0
+            else:
+                seeding_time = date_now - int(done_date.timestamp())
+            # 下载耗时
+            if (not added_date
+                    or added_date.timestamp() < 1):
+                dltime = 0
+            else:
+                dltime = date_now - int(added_date.timestamp())
+            # 下载量
+            downloaded = int(torrent.total_size * torrent.progress / 100)
+            # 分享率
+            ratio = torrent.ratio or 0
+            # 上传量
+            uploaded = int(downloaded * torrent.ratio)
+            # 平均上传速度
+            if dltime:
+                avg_upspeed = int(uploaded / dltime)
+            else:
+                avg_upspeed = uploaded
+            # 未活动时间
+            if (not active_date
+                    or active_date.timestamp() < 1):
+                iatime = 0
+            else:
+                iatime = date_now - int(active_date.timestamp())
+            # 种子大小
+            total_size = torrent.total_size
+            # 添加时间
+            add_on = (added_date.timestamp() if added_date else 0)
+            add_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(add_on))
+            # 种子标签
+            tags = torrent.get("tags") or getattr(torrent, "labels", None) or []
+            # tracker
+            trackers = getattr(torrent, "trackers", None) or []
+            tracker = torrent.get("tracker") or (getattr(trackers[0], "announce", "") if trackers else "")
+            # 种子分类
+            category = torrent.get("category")
+
+        return {
+            "hash": torrent_id,
+            "title": torrent_title,
+            "seeding_time": seeding_time,
+            "ratio": ratio,
+            "uploaded": uploaded,
+            "downloaded": downloaded,
+            "avg_upspeed": avg_upspeed,
+            "iatime": iatime,
+            "dltime": dltime,
+            "total_size": total_size,
+            "add_time": add_time,
+            "add_on": add_on,
+            "tags": tags,
+            "tracker": tracker,
+            "category": category
+        }
+
+    @staticmethod
+    def __get_transmission_hash(torrent: Any) -> str:
+        """优先读取 transmission-rpc 的新属性，并兼容旧版对象。"""
+        return getattr(torrent, "hash_string", None) or getattr(torrent, "hashString", "")
+
+    def __is_qbittorrent(self):
+        """
+        判断是否为 qBittorrent
+        """
+        return self.downloader_helper.is_downloader("qbittorrent", self.service_info)
+
+    def __send_message(self, title: str, text: str):
+        """
+        发送消息
+        """
+        if not self._notify:
+            return
+
+        self.post_message(mtype=NotificationType.SiteMessage, title=title, text=text)
+
+    def __log_and_notify_error(self, message):
+        """
+        记录错误日志并发送系统通知
+        """
+        logger.error(message)
+        self.systemmessage.put(message, title="种子关键字分类")
+
+    def __load_configs(self, config_str: Optional[str]) -> List[ClassifierConfig]:
+        """加载YAML配置字符串，并构造ClassifierConfig列表。
+
+        Args:
+        config_str (str): 配置内容的字符串。
+
+        Returns:
+        List[ClassifierConfig]: 从配置字符串解析出的配置列表。
+        """
+        if not config_str:
+            return []
+
+        yaml = YAML(typ="safe")
+        try:
+            data = yaml.load(io.StringIO(config_str))
+            return [ClassifierConfig(
+                torrent_filter=TorrentFilter(**item['torrent_filter']),
+                torrent_target=TorrentTarget(**item['torrent_target'])
+            ) for item in data]
+        except YAMLError as e:
+            self.__log_and_notify_error(f"YAML parsing error: {e}")
+            return []  # 返回空列表或根据需要做进一步的错误处理
+        except Exception as e:
+            self.__log_and_notify_error(f"Unexpected error during YAML parsing: {e}")
+            return []  # 处理任何意外的异常，返回空列表或其它适当的错误响应
+
+    @staticmethod
+    def __get_demo_config():
+        """获取默认配置"""
+        return """####### 配置说明 BEGIN #######
+# 1. 本配置文件用于管理种子文件的自动分类和标签管理，采用数组形式以支持多种筛选和应用规则。
+# 2. 配置文件中的「torrent_source」定义了种子的来源筛选条件；「torrent_target」定义了应对匹配种子执行的操作。
+# 3. 每个配置条目以「-」开头，表示配置文件的数组元素。
+# 4. 「remove_tags」字段支持使用特殊值「@all」，代表移除所有标签。
+# 5. 「auto_category」启用时开启QBittorrent的「自动Torrent管理」，并忽略「change_directory」配置项。
+####### 配置说明 END #######
+
+- torrent_filter:
+    # 种子来源部分定义：包括筛选种子的标题、分类和标签
+    # 种子标题的过滤条件，支持使用正则表达式匹配
+    torrent_title: '测试标题1'
+    # 种子必须属于的分类
+    torrent_category: '测试分类1'
+    # 种子必须具有的标签，多个标签时，任一满足即可
+    torrent_tags:
+      - '测试标签1'
+  torrent_target:
+    # 目标种子部分定义：包括修改目标目录、修改分类、新增标签和移除标签的设置
+    # 处理后种子的存储目录，auto_category 为 true 时不生效
+    change_directory: '/path/to/movies'
+    # 处理后的种子新分类
+    change_category: '测试新分类1'
+    # 添加到种子的新标签
+    add_tags:
+      - '测试新标签1'
+      - '测试新标签2'
+    # 移除的标签，使用 '@all' 清除所有标签
+    remove_tags:
+      - '@all'
+    # 是否启用自动分类
+    auto_category: true
+
+- torrent_filter:
+    # 种子标题的过滤条件，支持使用正则表达式匹配
+    torrent_title: '.*\\.测试标题2'
+    # 种子必须属于的分类
+    torrent_category: '测试分类2'
+    # 种子必须具有的标签，多个标签时，任一满足即可
+    torrent_tags:
+      - '测试标签2'
+      - 'Rock'
+  torrent_target:
+    # 处理后种子的存储目录，auto_category 为 true 时不生效
+    change_directory: '/path/to/music'
+    # 处理后的种子新分类
+    change_category: '测试新分类2'
+    # 添加到种子的新标签
+    add_tags:
+      - '测试新标签2'
+    # 移除的标签
+    remove_tags:
+      - '测试标签1'
+    # 是否启用自动分类
+    auto_category: false"""

--- a/plugins.v3/torrentclassifier/classifierconfig.py
+++ b/plugins.v3/torrentclassifier/classifierconfig.py
@@ -1,0 +1,37 @@
+# 该模块定义了用于管理基于YAML配置文件的种子文件分类的类。
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class TorrentFilter:
+    """数据类，用于存储种子来源的筛选标准，包括标题、分类和标签。"""
+    torrent_title: Optional[str] = None  # 用于匹配种子标题的正则表达式
+    torrent_category: Optional[str] = None  # 种子必须属于的分类
+    torrent_tags: Optional[List[str]] = field(default_factory=list)  # 种子必须具有的标签，多个标签时，任一满足即可
+
+    def __post_init__(self):
+        # 移除列表中的空字符串
+        self.torrent_tags = [tag for tag in self.torrent_tags if tag.strip()]
+
+
+@dataclass
+class TorrentTarget:
+    """数据类，用于存储匹配来源标准的种子的处理设置。"""
+    change_directory: Optional[str] = None  # 匹配种子移动到的目录（如果启用auto_category，则忽略此设置）
+    change_category: Optional[str] = None  # 为种子指定的新分类
+    add_tags: Optional[List[str]] = field(default_factory=list)  # 需要添加到种子的标签
+    remove_tags: Optional[List[str]] = field(default_factory=list)  # 需要从种子移除的标签，'@all' 表示移除所有标签
+    auto_category: Optional[bool] = False  # 是否启用自动分类管理
+
+    def __post_init__(self):
+        # 移除列表中的空字符串
+        self.add_tags = [tag for tag in self.add_tags if tag.strip()]
+        self.remove_tags = [tag for tag in self.remove_tags if tag.strip()]
+
+
+@dataclass
+class ClassifierConfig:
+    """整合种子来源和目标种子设置的数据类。"""
+    torrent_filter: TorrentFilter  # 种子来源配置
+    torrent_target: TorrentTarget  # 目标种子处理配置

--- a/plugins.v3/weatherwidget/__init__.py
+++ b/plugins.v3/weatherwidget/__init__.py
@@ -1,0 +1,1464 @@
+import base64
+import os
+import re
+import shutil
+import threading
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, List, Dict, Tuple, Optional
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from bs4 import BeautifulSoup
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.sdk.browser import launch_browser_context
+from app.sdk.config import settings
+from app.sdk.events import eventmanager, Event
+from app.sdk.logging import logger
+from app.sdk.plugins import PluginManager
+from app.plugins import _PluginBase
+from app.schemas import NotificationType
+from app.schemas.types import EventType
+from app.sdk.network import RequestUtils
+
+SCREENSHOT_DEVICES = {
+    "default": {
+        "mobile": {
+            "device": "iphone_13_pro_max",
+            "size": {}
+        },
+        "desktop": {
+            "device": "ipad_pro_11",
+            "size": {'width': 740, 'height': 1024}
+        }
+    },
+    "border": {
+        "mobile": {
+            "device": "iphone_13_pro_max",
+            "size": {}
+        },
+        "desktop": {
+            "device": "ipad_pro_11",
+            "size": {}
+        }
+    }
+}
+
+# 截图设备参数保持为插件本地常量，避免依赖浏览器内核的设备注册表。
+SCREENSHOT_DEVICE_CONTEXTS = {
+    "iphone_13_pro_max": {
+        "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) "
+                      "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1",
+        "viewport": {"width": 428, "height": 746},
+        "device_scale_factor": 3,
+        "is_mobile": True,
+        "has_touch": True
+    },
+    "ipad_pro_11": {
+        "user_agent": "Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) "
+                      "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1",
+        "viewport": {"width": 834, "height": 1194},
+        "device_scale_factor": 2,
+        "is_mobile": True,
+        "has_touch": True
+    }
+}
+
+class WeatherWidget(_PluginBase):
+    # region 全局定义
+
+    # 插件名称
+    plugin_name = "天气"
+    # 插件描述
+    plugin_desc = "定时推送天气，并在仪表盘中显示实时天气。"
+    # 插件图标
+    plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/weatherwidget.png"
+    # 插件版本
+    plugin_version = "3.0.0"
+    # 插件作者
+    plugin_author = "InfinityPacer"
+    # 作者主页
+    author_url = "https://github.com/InfinityPacer"
+    # 插件配置项ID前缀
+    plugin_config_prefix = "weatherwidget_"
+    # 加载顺序
+    plugin_order = 80
+    # 可使用的用户级别
+    auth_level = 1
+
+    # 私有属性
+    # enable
+    _enabled = None
+    # border
+    _border = None
+    # clear_cache
+    _clear_cache = None
+    # location
+    _location = None
+    # weather_url
+    _weather_url = None
+    # 启用自动主题
+    _auto_theme_enabled = None
+    # 自动高度
+    _auto_height = None
+    # use_dark_mode
+    _use_dark_mode = None
+    # adapt_mode
+    _adapt_mode = None
+    # component_size
+    _component_size = None
+    # weather_background
+    _weather_background = None
+    # weather_current_time
+    _weather_current_time = None
+    # weather_air_tag
+    _weather_air_tag = None
+    # weather_air_tag_background
+    _weather_air_tag_background = None
+    # location_url
+    _location_url = None
+    # 和风天气 API 密钥，优先使用插件配置，未配置时读取环境变量。
+    _weather_api_key = ""
+    # 环境变量密钥只供运行时使用，不应被写入插件配置。
+    _weather_api_key_configured = False
+    # 开启天气通知
+    _weather_notify = None
+    # 天气通知周期
+    _weather_notify_cron = None
+    # 消息类型
+    _weather_notify_type = None
+    # last_screenshot_time
+    _last_screenshot_time = None
+    # min_screenshot_span
+    _min_screenshot_span = 5 * 60
+    # 截图超时时间
+    _screenshot_timeout = 2 * 60
+    # 截图类型
+    _screenshot_type = None
+    # 天气刷新间隔
+    _refresh_interval = 1
+    # 定时器
+    _scheduler = None
+    # 退出事件
+    _event = None
+
+    # endregion
+
+    def init_plugin(self, config: dict = None):
+        self.stop_service()
+        self._event = threading.Event()
+        config = config or {}
+
+        self._enabled = bool(config.get("enabled", False))
+        self._border = config.get("border", False)
+        self._clear_cache = config.get("clear_cache", False)
+        self._location = config.get("location", "")
+        self._location_url = config.get("location_url", "")
+        configured_api_key = config.get("weather_api_key")
+        self._weather_api_key_configured = bool(str(configured_api_key or "").strip())
+        self._weather_api_key = str(
+            configured_api_key or os.getenv("QWEATHER_API_KEY", "")
+        ).strip()
+        self._weather_url = self.__get_weather_url()
+        self._auto_theme_enabled = config.get("auto_theme_enabled", True)
+        self._auto_height = config.get("auto_height", False)
+        self._last_screenshot_time = None
+        self._use_dark_mode = self.__should_use_dark_mode()
+        self._adapt_mode = config.get("adapt_mode", "compatibility")
+        self._component_size = config.get("component_size", "mini")
+        self._weather_notify = bool(config.get("weather_notify", True))
+        self._weather_notify_cron = config.get("weather_notify_cron")
+        self._weather_notify_type = config.get("weather_notify_type", "Plugin")
+        self._screenshot_type = self.__get_screenshot_type()
+        self._weather_background = config.get("weather_background",
+                                              "linear-gradient(225deg, #fee5ca, #e9f0ff 55%, #dce3fb)")
+        self._weather_current_time = config.get("weather_current_time",
+                                                datetime.now(tz=pytz.timezone(settings.TZ)).strftime('%Y-%m-%d %H:%M'))
+        self._weather_air_tag = config.get("weather_air_tag", " AQI 优 ")
+        self._weather_air_tag_background = config.get("weather_air_tag_background", "#95B359")
+
+        if self._clear_cache:
+            self.__save_data({})
+            self.__clear_image()
+
+        self.__update_config()
+
+        if not self._enabled:
+            return
+
+        if not self._location:
+            logger.error("城市不能为空")
+            return
+
+        if not self.__check_image():
+            logger.info("没有找到截图，立即运行一次截图任务")
+            self.__add_screenshot_task()
+
+    def get_state(self) -> bool:
+        return bool(self._enabled)
+
+    @staticmethod
+    def get_command() -> List[Dict[str, Any]]:
+        """
+            定义远程控制命令
+            :return: 命令关键字、事件、描述、附带数据
+            """
+        return [
+            {
+                "cmd": "/weather_notify",
+                "event": EventType.PluginAction,
+                "desc": "实时天气",
+                "category": "工具",
+                "data": {"action": "weather_notify"},
+            }
+        ]
+
+    def get_api(self) -> List[Dict[str, Any]]:
+        """
+        获取插件API
+        [{
+            "path": "/xx",
+            "endpoint": self.xxx,
+            "methods": ["GET", "POST"],
+            "summary": "API说明"
+        }]
+        """
+        return []
+
+    def __get_total_elements(self, image: str, key: str = "mobile") -> List[dict]:
+        """
+        组装汇总元素
+        """
+        if self._border:
+            return [
+                {
+                    'component': 'VCardItem',
+                    'content': [
+                        {
+                            'component': 'VCardTitle',
+                            'text': f"{self._location}"
+                        }
+                    ]
+                },
+                {
+                    'component': 'VCardItem',
+                    'props': {
+                        'class': 'w-full',
+                        'style': {
+                            'position': 'relative',
+                            'height': 'auto',
+                            'background': f'{self._weather_background}',
+                            'padding': "0"
+                        }
+                    },
+                    'content': [
+                        {
+                            'component': 'a',
+                            'props': {
+                                'href': f'{self._weather_url}',
+                                "target": "_blank"
+                            },
+                            'content': [
+                                {
+                                    'component': 'VImg',
+                                    'props': {
+                                        'src': f'{image}',
+                                        'height': 'auto' if key == 'mobile' else (
+                                            '264px' if self._adapt_mode == 'compatibility' else 'auto'),
+                                        'max-width': '100%',
+                                        'width': '100%'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        else:
+            return [
+                {
+                    'component': 'VCardItem',
+                    'props': {
+                        'class': 'w-full',
+                        'style': {
+                            'position': 'relative',
+                            'height': 'auto',
+                            'background': f'{self._weather_background}',
+                            'padding': 0 if self._adapt_mode == 'compatibility'
+                                            or key == 'mobile' or self._auto_height else '0 0 1.5rem',
+                        }
+                    },
+                    'content': [
+                        {
+                            'component': 'a',
+                            'props': {
+                                'href': f'{self._weather_url}',
+                                "target": "_blank"
+                            },
+                            'content': [
+                                {
+                                    'component': 'VImg',
+                                    'props': {
+                                        'src': f'{image}',
+                                        'height': 'auto' if self._auto_height or key == 'mobile' else (
+                                            '336px' if self._adapt_mode == 'compatibility' else '310px'),
+                                        'max-width': '100%',
+                                        'width': '100%',
+                                        'cover': False if self._adapt_mode == 'compatibility' else True,
+                                    }
+                                },
+                                {
+                                    'component': 'VCardText',
+                                    'props': {
+                                        'class': 'v-card-text w-full flex flex-row justify-start items-start absolute '
+                                                 'top-0 left-0 cursor-pointer'
+                                    },
+                                    'content': [
+                                        {
+                                            'component': 'VCardTitle',
+                                            'props': {
+                                                'class': 'mb-1 line-clamp-2 overflow-hidden text-ellipsis ...',
+                                                'style': {
+                                                    'color': 'rgb(231 227 252)'
+                                                    if self._use_dark_mode else 'rgb(58 53 65 / 87%)',
+                                                }
+                                            },
+                                            'text': self._location
+                                        }
+                                    ]
+                                },
+                                {
+                                    'component': 'VCardText',
+                                    'props': {
+                                        'class': 'w-full flex flex-row justify-end items-start absolute '
+                                                 'left-0 cursor-pointer',
+                                        'style': {
+                                            'top': '1rem',
+                                            'font-size': '12px',
+                                            'line-height': '12px',
+                                            'color': 'rgb(231 227 252)'
+                                            if self._use_dark_mode else 'rgb(58 53 65 / 87%)',
+                                            'text-align': 'right'
+                                        }
+                                    },
+                                    'text': self._weather_current_time,
+                                },
+                                {
+                                    'component': 'p',
+                                    'props': {
+                                        'class': 'w-full flex flex-row justify-end items-start absolute '
+                                                 'right-0 cursor-pointer',
+                                        'style': {
+                                            'top': '2.4rem',
+                                            'display': 'inline-block',
+                                            'width': '76px',
+                                            'padding-top': '4px',
+                                            'padding-bottom': '4px',
+                                            'margin-right': '20px',
+                                            'font-size': '15px',
+                                            'line-height': '16px',
+                                            'text-align': 'center',
+                                            'white-space': 'nowrap',
+                                            'border-radius': '14px',
+                                            'color': 'white',
+                                            "background-color": self._weather_air_tag_background
+                                        }
+                                    },
+                                    'text': self._weather_air_tag,
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+
+    def get_dashboard(self, key: str = None, user_agent: str = None) \
+            -> Optional[Tuple[Dict[str, Any], Dict[str, Any], List[dict]]]:
+        """
+        获取插件仪表盘页面，需要返回：1、仪表板cols配置字典；2、全局配置（自动刷新等）；2、仪表板页面元素配置json（含数据）
+        1、col配置参考：
+        {
+            "cols": 12, "md": 6
+        }
+        2、全局配置参考：
+        {
+            "refresh": 10, // 自动刷新时间，单位秒
+            "border": True, // 是否显示边框，默认True，为False时取消组件边框和边距，由插件自行控制
+        }
+        3、页面配置使用Vuetify组件拼装，参考：https://vuetifyjs.com/
+        """
+        # 根据UA获取设备类型
+        key = self.__detect_device_type(user_agent=user_agent).lower()
+        # 获取图片资源
+        image = self.__get_weather_base64_image(location=self._location, key=key)
+
+        # 列配置
+        size_to_cols_map = {
+            "mini": {"cols": 12, "md": 4},
+            "small": {"cols": 12, "md": 6},
+            "medium": {"cols": 12, "md": 8},
+            "large": {"cols": 12, "md": 12}
+        }
+        cols = size_to_cols_map.get(self._component_size, size_to_cols_map.get("mini"))
+
+        # 全局配置
+        attrs = {
+            "border": not image
+        }
+
+        # 拼装页面元素
+        if not image:
+            elements = [
+                {
+                    'component': 'VCardItem',
+                    'content': [
+                        {
+                            'component': 'div',
+                            'text': '暂无数据',
+                            'props': {
+                                'class': 'text-center'
+                            }
+                        }
+                    ]
+                }
+            ]
+        else:
+            elements = self.__get_total_elements(image=image, key=key)
+        return cols, attrs, elements
+
+    def get_form(self) -> Tuple[List[dict], Dict[str, Any]]:
+        """
+        拼装插件配置页面，需要返回两块数据：1、页面配置；2、数据结构
+        """
+        return [
+            {
+                'component': 'VForm',
+                'content': [
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'enabled',
+                                            'label': '启用插件',
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'border',
+                                            'label': '显示边框',
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 3
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'clear_cache',
+                                            'label': '清理缓存',
+                                        },
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'auto_theme_enabled',
+                                            'label': '自动主题',
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'auto_height',
+                                            'label': '自动高度',
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSwitch',
+                                        'props': {
+                                            'model': 'weather_notify',
+                                            'label': '开启天气通知',
+                                        },
+                                    }
+                                ],
+                            },
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'weather_notify_cron',
+                                            'label': '天气通知周期',
+                                            'placeholder': '5位cron表达式',
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'model': 'weather_notify_type',
+                                            'label': '消息类型',
+                                            'items': [{"title": item.value, "value": item.name}
+                                                      for item in NotificationType]
+                                        }
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'weather_api_key',
+                                            'label': '和风天气 API Key',
+                                            'type': 'password',
+                                            'clearable': True,
+                                            'hint': '未填写时读取 QWEATHER_API_KEY 环境变量',
+                                            'persistent-hint': True,
+                                        }
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'model': 'component_size',
+                                            'label': '组件规格',
+                                            'items': [
+                                                {"title": "迷你", "value": "mini"},
+                                                {"title": "小型", "value": "small"},
+                                                {"title": "中型", "value": "medium"},
+                                                {"title": "大型", "value": "large"}
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'location',
+                                            'label': '城市',
+                                            'placeholder': '城市地点',
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VTextField',
+                                        'props': {
+                                            'model': 'location_url',
+                                            'label': '城市链接',
+                                            'placeholder': '和风天气的城市天气链接',
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                    'md': 4
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VSelect',
+                                        'props': {
+                                            'model': 'adapt_mode',
+                                            'label': '适配方案',
+                                            'items': [
+                                                {'title': '兼容模式', 'value': 'compatibility'},
+                                                {'title': '画质模式', 'value': 'quality'}
+                                            ]
+                                        }
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal',
+                                            'text': '注意：通过在和风天气官网获取对应链接精确定位城市，如「秦淮区」的链接为'
+                                                    'https://www.qweather.com/weather/qinhuai-101190109.html，'
+                                                    '则在城市链接填写 qinhuai-101190109'
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal',
+                                            'text': '注意：数据异常时，可通过填写城市链接精确定位城市'
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'component': 'VRow',
+                        'content': [
+                            {
+                                'component': 'VCol',
+                                'props': {
+                                    'cols': 12,
+                                },
+                                'content': [
+                                    {
+                                        'component': 'VAlert',
+                                        'props': {
+                                            'type': 'info',
+                                            'variant': 'tonal',
+                                            'text': '天气数据来源于 '
+                                        },
+                                        'content': [
+                                            {
+                                                'component': 'a',
+                                                'props': {
+                                                    'href': 'https://www.qweather.com',
+                                                    'target': '_blank'
+                                                },
+                                                'content': [
+                                                    {
+                                                        'component': 'u',
+                                                        'text': '和风天气'
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                'component': 'span',
+                                                'text': '，再次感谢和风天气（https://www.qweather.com）提供的服务'
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ], {
+            "enabled": False,
+            "border": False,
+            "auto_theme_enabled": True,
+            "adapt_mode": "compatibility",
+            "weather_notify": True,
+            "weather_notify_cron": "0 8 * * *",
+            "auto_height": False,
+            "component_size": "mini"
+        }
+
+    def get_page(self) -> Optional[List[dict]]:
+        return None
+
+    def get_service(self) -> List[Dict[str, Any]]:
+        """
+        注册插件公共服务
+        [{
+            "id": "服务ID",
+            "name": "服务名称",
+            "trigger": "触发器：cron/interval/date/CronTrigger.from_crontab()",
+            "func": self.xxx,
+            "kwargs": {} # 定时器参数
+        }]
+        """
+
+        services = []
+
+        if self._enabled:
+            services.append({
+                "id": "RefreshWeather",
+                "name": "定时获取天气信息",
+                "trigger": "interval",
+                "func": self.__take_screenshots,
+                "kwargs": {"hours": self._refresh_interval}
+            })
+
+        if self._weather_notify and self._weather_notify_cron:
+            services.append({
+                "id": "NotifyWeather",
+                "name": "定时推送天气通知",
+                "trigger": CronTrigger.from_crontab(self._weather_notify_cron),
+                "func": self.notify_weather,
+                "kwargs": {}
+            })
+
+        return services
+
+    def stop_service(self):
+        """
+        退出插件
+        """
+        try:
+            if self._scheduler:
+                self._scheduler.remove_all_jobs()
+                if self._scheduler.running:
+                    self._event.set()
+                    self._scheduler.shutdown(wait=False)
+                    self._event.clear()
+                self._scheduler = None
+        except Exception as e:
+            logger.info(str(e))
+
+    def __update_config(self):
+        """保存插件配置"""
+        config = {
+            "enabled": self._enabled,
+            "border": self._border,
+            "location": self._location,
+            "location_url": self._location_url,
+            "weather_background": self._weather_background,
+            "weather_current_time": self._weather_current_time,
+            "weather_air_tag": self._weather_air_tag,
+            "weather_air_tag_background": self._weather_air_tag_background,
+            "auto_theme_enabled": self._auto_theme_enabled,
+            "auto_height": self._auto_height,
+            'adapt_mode': self._adapt_mode,
+            "component_size": self._component_size,
+            "weather_notify": self._weather_notify,
+            "weather_notify_cron": self._weather_notify_cron,
+            "weather_notify_type": self._weather_notify_type,
+        }
+        if self._weather_api_key_configured:
+            config["weather_api_key"] = self._weather_api_key
+        self.update_config(config)
+
+    def invoke_service(self, request: Request, location: str, apikey: str) -> Any:
+        """invokeService"""
+        return PluginManager().run_plugin_method(self.__class__.__name__, "get_weather_image", **{
+            "request": request,
+            "location": location,
+            "apikey": apikey
+        })
+
+    def get_weather_image(self, request: Request, location: str, apikey: str) -> Any:
+        """读取图片"""
+
+        if apikey != settings.API_TOKEN:
+            return None
+        if not location:
+            logger.error("没有地址信息，获取天气图片失败")
+            return None
+        # 每次请求时，获取一次最新的图片信息
+        self.__add_screenshot_task()
+        # 获取UA
+        user_agent = request.headers.get('user-agent', 'Unknown User-Agent')
+        key = self.__detect_device_type(user_agent=user_agent).lower()
+        # 这里实际上返回的是上一次的图片信息
+        image = self.__get_latest_image(key=key)
+        if not image:
+            return None
+        return Response(content=image.read_bytes(), media_type="image/jpeg")
+
+    def __get_weather_base64_image(self, location: str, key: str = "mobile") -> Optional[str]:
+        """获取base64图片"""
+        if not location:
+            logger.error("没有地址信息，获取天气图片失败")
+            return None
+        # 每次请求时，获取一次最新的图片信息
+        self.__add_screenshot_task()
+        # 这里实际上返回的是上一次的图片信息
+        image = self.__get_latest_image(key=key)
+        if not image:
+            return None
+        # 读取图片文件并编码为 base64
+        with open(image, "rb") as image_file:
+            encoded_string = base64.b64encode(image_file.read()).decode('utf-8')
+        return f"data:image/{image.suffix.replace('.', '')};base64,{encoded_string}"
+
+    def __add_screenshot_task(self):
+        """添加截图任务"""
+        if not self._enabled:
+            return
+
+        if not self._scheduler:
+            self._scheduler = BackgroundScheduler(timezone=settings.TZ)
+
+        if len(self._scheduler.get_jobs()):
+            logger.info("已经存在待执行的截图任务，清空任务并继续添加")
+            self._scheduler.remove_all_jobs()
+
+        self._scheduler.add_job(
+            func=self.__take_screenshots,
+            trigger="date",
+            run_date=datetime.now(tz=pytz.timezone(settings.TZ)) + timedelta(seconds=3),
+            name="获取一次天气信息",
+        )
+        logger.info("已添加截图任务，等待执行")
+        if self._scheduler.get_jobs():
+            self._scheduler.print_jobs()
+        if not self._scheduler.running:
+            self._scheduler.start()
+
+    def __update_with_log_screenshot_time(self, current_time: Optional[datetime]):
+        """更新截图时间"""
+        self._last_screenshot_time = current_time
+        if current_time:
+            logger.info(
+                f"截图记录更新，最后一次截图时间重置为 {self._last_screenshot_time.strftime('%Y-%m-%d %H:%M:%S')}")
+        else:
+            logger.info(f"截图记录更新，发生错误，最后一次截图时间重置为None")
+
+    def __take_screenshots(self):
+        """管理多设备截图任务"""
+        self.__get_images_path().mkdir(parents=True, exist_ok=True)
+        current_time = datetime.now(tz=pytz.timezone(settings.TZ))
+        if self._last_screenshot_time and self.__check_image():
+            time_since_last = (current_time - self._last_screenshot_time).total_seconds()
+            time_to_wait = self._min_screenshot_span - time_since_last
+            if time_since_last < self._min_screenshot_span:
+                logger.info(f"截图过快，最小截图间隔为 {self._min_screenshot_span} 秒。请在 {time_to_wait:.2f} 秒后重试。")
+                return
+
+        self.__update_with_log_screenshot_time(current_time=current_time)
+
+        if not self._weather_url:
+            logger.error("无法获取天气请求地址，请检查配置")
+            self.__update_with_log_screenshot_time(current_time=None)
+            return
+
+        try:
+            start_time = datetime.now()
+            self.__update_with_log_screenshot_time(current_time=current_time)
+            screenshot_devices = self.__get_screenshot_device()
+            if not screenshot_devices:
+                logger.error("获取截图设备失败，请检查")
+                self.__update_with_log_screenshot_time(current_time=None)
+                return
+            self._use_dark_mode = self.__should_use_dark_mode()
+            color_scheme = "dark" if self._use_dark_mode else "light"
+            self.__take_screenshots_by_browser(screenshot_devices=screenshot_devices,
+                                               color_scheme=color_scheme,
+                                               start_time=start_time)
+        except Exception as e:
+            logger.error(f"take_screenshots failed: {str(e)}")
+
+    def __take_screenshots_by_browser(self,
+                                      screenshot_devices: dict,
+                                      color_scheme: str,
+                                      start_time: datetime) -> None:
+        """使用宿主浏览器 SDK 为不同设备生成天气截图。"""
+        logger.info("正在准备截图服务，宿主浏览器内核启动中")
+        for key, device in screenshot_devices.items():
+            try:
+                logger.info(f'{key} 正在启动浏览器截图 ...')
+                self.__screenshot_element_by_browser(key=key, device=device, color_scheme=color_scheme)
+                elapsed_time = datetime.now() - start_time
+                logger.info(f'运行完毕，用时 {elapsed_time.total_seconds()} 秒')
+            except Exception as e:
+                logger.error(f"{key} 浏览器截图失败: {str(e)}")
+
+    @staticmethod
+    def __get_browser_context_options(device: dict, color_scheme: str) -> dict:
+        """生成宿主浏览器上下文参数。"""
+        context_options = SCREENSHOT_DEVICE_CONTEXTS.get(device.get("device"), {}).copy()
+        viewport = device.get("size") or context_options.get("viewport")
+        if viewport:
+            context_options["viewport"] = viewport
+        context_options["color_scheme"] = color_scheme
+        return context_options
+
+    @staticmethod
+    def __launch_browser_context(device: dict, color_scheme: str):
+        """启动用于天气截图的宿主浏览器上下文。"""
+        return launch_browser_context(
+            headless=True,
+            proxy=settings.PROXY_SERVER,
+            humanize=settings.CLOAKBROWSER_HUMANIZE,
+            human_preset=settings.CLOAKBROWSER_HUMAN_PRESET,
+            **WeatherWidget.__get_browser_context_options(
+                device=device,
+                color_scheme=color_scheme,
+            ),
+        )
+
+    def __screenshot_element_by_browser(self, key: str, device: dict, color_scheme: str = 'light') -> bool:
+        """使用宿主浏览器 SDK 执行单个截图任务。"""
+        current_time = datetime.now(tz=pytz.timezone(settings.TZ))
+        timestamp = current_time.strftime("%Y%m%d%H%M%S")
+        selector = ".c-city-weather-current"
+        image_path = self.__get_images_path() / f"{self.__get_screenshot_image_pre_path(key=key)}_{timestamp}.png"
+
+        logger.info(f"开始加载 {key} 页面: {self._weather_url}")
+        self.__update_with_log_screenshot_time(current_time=current_time)
+        context = None
+        page = None
+        try:
+            context = self.__launch_browser_context(device=device, color_scheme=color_scheme)
+            page = context.new_page()
+            size = device.get("size")
+            if size:
+                page.set_viewport_size(device.get("size"))
+            page.goto(self._weather_url)
+            page.wait_for_selector(selector, timeout=self._screenshot_timeout * 1000)
+            self.__reset_weather_style(page=page)
+            self.__reset_page_style(page=page, key=key)
+            logger.info(f"{key} 页面加载成功，标题: {page.title()}")
+            self.__update_with_log_screenshot_time(current_time=datetime.now(tz=pytz.timezone(settings.TZ)))
+            element = page.query_selector(selector)
+            if element:
+                box = element.bounding_box()
+                if box:
+                    # 裁剪区域向内收缩 2px，避免外层阴影或圆角边缘进入仪表盘图片。
+                    clip = {
+                        "x": box["x"] + 2,
+                        "y": box["y"] + 2,
+                        "width": box["width"] - 4,
+                        "height": box["height"] - 4
+                    }
+                    page.screenshot(path=image_path, clip=clip)
+                    logger.info(f"{key} 截图成功，截图路径: {image_path}")
+                else:
+                    element.screenshot(path=image_path)
+                    logger.info(f"{key} 截图成功，截图路径: {image_path}")
+                self.__manage_images(key=key)
+                self.__update_with_log_screenshot_time(current_time=datetime.now(tz=pytz.timezone(settings.TZ)))
+                return True
+            else:
+                logger.warning(f"{key} 未找到指定的选择器: {selector}")
+                self.__update_with_log_screenshot_time(current_time=None)
+                return False
+        except Exception as e:
+            logger.error(f"{key} 截图失败，URL: {self._weather_url}, 错误：{e}")
+            self.__update_with_log_screenshot_time(current_time=None)
+            return False
+        finally:
+            if page:
+                page.close()
+            if context:
+                context.close()
+
+    def __reset_page_style(self, page: Any, key: str = 'mobile'):
+        """重置页面样式"""
+
+        # 无边框模式时，调整右上角的样式显示效果
+        if not self._border:
+            # 重置时间为空
+            page.evaluate("""() => {
+                        const element = document.querySelector('.current-time');
+                        if (element) {
+                            element.style.display = 'block';
+                            element.style.height = '16px';
+                            element.textContent  = '';
+                        }
+                    }""")
+
+            # 移除空气质量
+            page.evaluate("""() => {
+                    const element = document.querySelector('.current-live .current-live__item > .air-tag');
+                    if (element) {
+                        element.remove();
+                    }
+                }""")
+
+        # 修改天气边框圆角为直角
+        page.evaluate("""() => {
+                    const element = document.querySelector('.c-city-weather-current');
+                    if (element) {
+                        element.style.borderRadius = '0';
+                    }
+                }""")
+
+        # 显示边框时，不需要重置其他样式
+        if self._border:
+            return
+
+        # # 修改天气背景Padding、Position
+        # page.evaluate("""() => {
+        #         const element = document.querySelector('.current-weather__bg');
+        #         if (element) {
+        #             element.style.paddingTop = '40px';
+        #             element.style.position = 'relative';
+        #         }
+        #     }""")
+
+        # 修改时间位置
+        # page.evaluate("""() => {
+        #         const element = document.querySelector('.current-time');
+        #         if (element) {
+        #             element.style.position = 'absolute';
+        #             element.style.right = '28px';
+        #             element.style.top = '10px';
+        #         }
+        #     }""")
+
+        # 修改空气质量位置
+
+        # page.evaluate("""(key) => {
+        #         const element = document.querySelector('.current-live .current-live__item > .air-tag');
+        #         if (element) {
+        #             element.style.top = key === 'mobile' ? '-36px' : '-41px';
+        #             //element.style.right = '28px';
+        #         }
+        #     }""", key)
+
+    def __reset_weather_style(self, page: Any):
+        """重置天气样式"""
+        # 获取指定元素
+        weather_element = page.query_selector('.c-city-weather-current')
+
+        # 获取元素的 CSS 样式
+        # css_background = weather_element.evaluate("el => getComputedStyle(el).background")
+        css_background_image = weather_element.evaluate("el => getComputedStyle(el).backgroundImage")
+
+        # if css_background:
+        #     self._weather_background = css_background
+        if css_background_image:
+            self._weather_background = css_background_image
+        else:
+            self._weather_background = "linear-gradient(225deg, #fee5ca, #e9f0ff 55%, #dce3fb)"
+
+        # 尝试获取页面中的时间，如果不存在，则使用当前时间
+        current_time_from_page = page.evaluate(
+            "() => document.querySelector('.current-time') ? document.querySelector('.current-time').textContent : ''")
+
+        if current_time_from_page:
+            self._weather_current_time = current_time_from_page
+        else:
+            # 获取当前时间并格式化为 'YYYY-MM-DD HH:MM' 格式
+            self._weather_current_time = datetime.now(tz=pytz.timezone(settings.TZ)).strftime('%Y-%m-%d %H:%M')
+
+        # 尝试获取页面中的空气质量标签
+        air_tag_from_page = page.evaluate("""() => {
+                                        const element = document.querySelector('.current-live .current-live__item > .air-tag');
+                                        if (element) {
+                                            return element ? element.textContent : '';
+                                        }
+                                    }""")
+
+        # 尝试获取页面中的空气质量标签和背景色
+        air_tag_details = page.evaluate("""
+                () => {
+                    const element = document.querySelector('.current-live .current-live__item > .air-tag');
+                    if (element) {
+                        return {
+                            text: element.textContent.trim(),
+                            backgroundColor: window.getComputedStyle(element, null).getPropertyValue('background-color')
+                        };
+                    } else {
+                        return { text: '', backgroundColor: '' };
+                    }
+                }
+            """)
+
+        if air_tag_details:
+            self._weather_air_tag = f" {air_tag_details.get('text', 'AQI 优')} "
+            self._weather_air_tag_background = air_tag_details.get("backgroundColor", "#95B359")
+        else:
+            # 如果没有找到空气质量标签或背景色，使用默认值
+            self._weather_air_tag = " AQI 优 "
+            self._weather_air_tag_background = "#95B359"  # 默认背景颜色
+
+        self.__update_config()
+        logger.info(f"更新天气背景样式为：{self._weather_background}")
+        logger.info(f"更新当前时间为：{self._weather_current_time}")
+        logger.info(f"更新空气质量为：{self._weather_air_tag}")
+        logger.info(f"更新空气质量背景色为：{self._weather_air_tag_background}")
+
+    def __manage_images(self, key: str, max_files: int = 5):
+        """管理图片文件，确保每种类型最多保留 max_files 张"""
+        files = sorted(self.__get_images_path().glob(f"{self.__get_screenshot_image_pre_path(key=key)}_*.png"),
+                       key=lambda x: x.stat().st_mtime)
+        if len(files) > max_files:
+            for file in files[:-max_files]:
+                file.unlink()
+                logger.info(f"删除旧图片: {file}")
+
+    def __check_image(self) -> bool:
+        """判断是否存在图片"""
+        files_exist = any(self.__get_images_path().glob(f"{self.__get_screenshot_image_pre_path()}_*.png"))
+        if not files_exist:
+            logger.error("没有找到图片信息")
+        return files_exist
+
+    def __get_latest_image(self, key: str) -> Optional[Path]:
+        """获取指定key的最新图片路径"""
+        # 搜索所有匹配的图片文件，并按修改时间排序
+        try:
+            image = max(self.__get_images_path().glob(f"{self.__get_screenshot_image_pre_path(key=key)}_*.png"),
+                        key=lambda x: x.stat().st_mtime)
+            if not image:
+                return None
+            if not image.exists():
+                return None
+            if not image.is_file():
+                return None
+            # 判断是否图片文件
+            if image.suffix.lower() not in [".jpg", ".png", ".gif", ".bmp", ".jpeg", ".webp"]:
+                return None
+            return image
+        except ValueError:
+            logger.error(f"{key}: 没有找到图片信息")
+            return None
+
+    def __get_weather_api_key(self) -> str:
+        """获取天气api密钥"""
+        return self._weather_api_key
+
+    def __get_weather_url(self) -> Optional[str]:
+        """获取天气Url"""
+        if not self._location:
+            logger.error("没有配置城市，无法获取对应的城市天气链接")
+            return None
+
+        if self._location_url:
+            return f"https://www.qweather.com/weather/{self._location_url}.html"
+
+        location_map = self.get_data("location")
+        if location_map:
+            weather_url = location_map.get(self._location, {}).get("fxLink")
+            if weather_url:
+                return weather_url
+        else:
+            location_map = {}
+
+        api_key = self.__get_weather_api_key()
+        if not api_key:
+            logger.error("未配置和风天气 API Key，无法查询城市链接")
+            return None
+
+        url = (f"https://geoapi.qweather.com/v2/city/lookup?"
+               f"key={api_key}&location={self._location}&lang=zh")
+
+        response = RequestUtils().get_res(url)
+        # URL 仅用于请求，不写入日志，避免第三方 API 密钥进入日志系统。
+        logger.info("请求和风天气获取城市详情信息：%s", self._location)
+        if not response:
+            logger.error("连接和风天气失败，未获取到响应信息")
+            return None
+        logger.info(f"响应信息: {response.text}")
+
+        if response.status_code != 200:
+            logger.error(f"连接和风天气失败, 状态码: {response.status_code}")
+            return None
+        else:
+            data = response.json()
+            if data.get('code') == "200":
+                remote_locations = data.get('location', [])
+                if remote_locations:
+                    first = remote_locations[0]
+                    weather_url = first.get("fxLink")
+                    logger.info(f"城市: {self._location} 获取到对应的城市天气链接为: {weather_url}")
+                    if weather_url:
+                        location_map[self._location] = first
+                        self.__save_data(location_map)
+                        return weather_url
+
+        logger.error(f"连接和风天气成功, 但获取详情信息失败")
+        return None
+
+    def __save_data(self, data: dict):
+        """保存插件数据"""
+        self.save_data("location", data)
+
+    def __clear_image(self):
+        """清理缓存图片"""
+        image_path = self.__get_images_path()
+        if image_path.exists():
+            # 删除目录及其所有内容
+            shutil.rmtree(image_path)
+            logger.info(f"目录 {image_path} 已清理")
+        else:
+            logger.info(f"目录 {image_path} 不存在")
+
+    @staticmethod
+    def __detect_device_type(user_agent: Optional[str]) -> str:
+        """根据UA获取设备类型"""
+        if not user_agent:
+            logger.info(f"无法获取UA，当前访问设备类型默认为 desktop")
+            return "desktop"
+
+        logger.info(f"detect_device_type user_agent: {user_agent}")
+        # 定义移动设备的关键字列表
+        mobile_keywords = ['Mobile', 'Android', 'iPhone', 'iPad']
+
+        # 检查UA中是否包含移动设备的关键字
+        for keyword in mobile_keywords:
+            if keyword in user_agent:
+                logger.info(f"当前访问设备类型为 mobile")
+                return 'mobile'
+
+        logger.info(f"当前访问设备类型为 desktop")
+        return 'desktop'
+
+    def __get_screenshot_type(self):
+        """获取截图类型"""
+        return "border" if self._border else "default"
+
+    def __get_images_path(self) -> Path:
+        """返回当前插件实例的截图缓存目录，确保分身之间互不共享文件。"""
+        return self.get_data_path() / "images"
+
+    def __get_screenshot_device(self) -> Optional[dict]:
+        """获取截图设备信息"""
+        screenshot_type = self._screenshot_type
+        screenshot_devices = SCREENSHOT_DEVICES.get(screenshot_type)
+        return screenshot_devices
+
+    def __get_screenshot_image_pre_path(self, key: str = None) -> str:
+        """获取截图前置路径"""
+        image_path = f"weather_{self._location}_{self._screenshot_type}"
+        return f"{image_path}_{key}" if key else image_path
+
+    def __should_use_dark_mode(self):
+        """是否启用暗黑模式"""
+        if not self._auto_theme_enabled:
+            return False
+
+        try:
+            response = RequestUtils(timeout=10).get_res(self._weather_url)
+            response.raise_for_status()
+        except Exception as e:
+            logger.error(f"请求天气信息失败: {e}")
+            return None
+
+        try:
+            # 正则表达式用于找到日出和日落时间
+            sunrise_pattern = r'"rise":"(\d{2}:\d{2})"'
+            sunset_pattern = r'"set":"(\d{2}:\d{2})"'
+
+            sunrise_match = re.search(sunrise_pattern, response.text)
+            sunset_match = re.search(sunset_pattern, response.text)
+
+            if sunrise_match and sunset_match:
+                sunrise_time_str = sunrise_match.group(1)
+                sunset_time_str = sunset_match.group(1)
+
+                # 转换时间字符串为datetime.time对象
+                sunrise_time = datetime.strptime(sunrise_time_str, '%H:%M').time()
+                sunset_time = datetime.strptime(sunset_time_str, '%H:%M').time()
+
+                # 获取当前时间（只关心时间，不关心日期）
+                current_time = datetime.now(tz=pytz.timezone(settings.TZ)).time()
+
+                if sunrise_time < sunset_time:
+                    # 日出和日落在同一天
+                    return not (sunrise_time <= current_time <= sunset_time)
+                else:
+                    # 跨天情况：日落发生在日出前（例如在极地地区）
+                    return not (sunset_time <= current_time <= sunrise_time)
+
+            return False
+        except re.error as e:
+            logger.error(f"Regex error: {e}")
+            return False
+        except ValueError as e:
+            logger.error(f"Date conversion error: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"Unexpected error: {e}")
+            return False
+
+    @eventmanager.register(EventType.PluginAction)
+    def notify_weather(self, event: Event = None):
+        """推送天气通知"""
+        if not self._weather_notify:
+            return
+
+        if event:
+            logger.info(f"event： {event}")
+            event_data = event.event_data
+            if not event_data or event_data.get("action") != "weather_notify":
+                return
+
+        weather_report = self.__resolve_weather()
+        self.post_message(mtype=NotificationType[self._weather_notify_type], title="【实时天气】", text=weather_report)
+        return
+
+    def __resolve_weather(self) -> Optional[str]:
+        """解析当前天气"""
+        try:
+            response = RequestUtils(timeout=10).get_res(self._weather_url)
+            response.raise_for_status()
+        except Exception as e:
+            logger.error(f"请求天气信息失败: {e}")
+            return None
+
+        try:
+            # 使用 BeautifulSoup 解析 HTML
+            soup = BeautifulSoup(response.text, 'html.parser')
+
+            weather_report_parts = []
+
+            # 提取当前时间
+            current_time = soup.find("p", class_="current-time")
+            if current_time:
+                weather_report_parts.append(f"当前时间: {current_time.text.strip()}")
+
+            # 提取温度
+            temperature = soup.find("div", class_="current-live__item")
+            if temperature:
+                temperature = temperature.find_next_sibling().p
+                if temperature:
+                    weather_report_parts.append(f"温度: {temperature.text.strip()}")
+
+            # 提取天气状况
+            weather_condition = soup.find("div", class_="current-live__item")
+            if weather_condition:
+                weather_condition = weather_condition.find_next_sibling().p.find_next_sibling()
+                if weather_condition:
+                    weather_report_parts.append(f"天气状况: {weather_condition.text.strip()}")
+
+            # 提取空气质量
+            air_quality = soup.find("a", class_="air-tag")
+            if air_quality:
+                weather_report_parts.append(f"空气质量: {air_quality.text.strip()}")
+
+            # 提取基本天气数据
+            basic_items = soup.find_all("div", class_="current-basic___item")
+            for item in basic_items:
+                # 提取每个项目的内容(p0)和标题(p1)
+                p0 = item.find("p")
+                p1 = p0.find_next_sibling("p") if p0 else None
+
+                if p0 and p1:
+                    content = p0.text.strip()
+                    label = p1.text.strip()
+                    weather_report_parts.append(f"{label}: {content}")
+
+            # 提取天气汇总
+            weather_abstract = soup.find("div", class_="current-abstract")
+            if weather_abstract:
+                weather_report_parts.append(f"\n{weather_abstract.text.strip()}")
+
+            # 构建和返回最终的天气报告
+            if not weather_report_parts:
+                return "未能获取天气信息"
+            return "\n".join(weather_report_parts)
+        except Exception as e:
+            logger.error(f"解析天气信息时出错: {e}")
+            return None

--- a/tests/v3/brushmanager/test_brushmanager.py
+++ b/tests/v3/brushmanager/test_brushmanager.py
@@ -1,0 +1,124 @@
+"""BrushManager V3 的下载器字段、公开边界和生命周期合同测试。"""
+
+import ast
+import warnings
+from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from app.plugins.brushmanager import BrushManager
+
+from .torrent_sdk_fixtures import (
+    force_transmission_plugin,
+    make_tr_legacy_torrent,
+    make_tr_v7_torrent,
+)
+
+
+def _call(torrent):
+    """在不连接下载器的情况下调用种子信息转换。"""
+    plugin = force_transmission_plugin(object.__new__(BrushManager))
+    with patch.object(
+        BrushManager,
+        "service_info",
+        new_callable=PropertyMock,
+        return_value=object(),
+    ):
+        return plugin._BrushManager__get_torrent_info(torrent)
+
+
+class TestTransmissionTorrentInfo:
+    """Transmission 新旧 SDK 字段都应转换为刷流统计信息。"""
+
+    def test_transmission_rpc_v7_fields_without_deprecation_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            info = _call(make_tr_v7_torrent())
+
+        assert info["hash"] == "tr_hash_1"
+        assert info["seeding_time"] > 0
+        assert info["dltime"] > 0
+        assert info["iatime"] > 0
+        assert info["add_on"] == 900
+        assert info["tags"] == ["tag1"]
+        assert info["tracker"] == "https://tracker/announce"
+
+    def test_legacy_transmission_fields(self):
+        info = _call(make_tr_legacy_torrent())
+
+        assert info["hash"] == "tr_hash_1"
+        assert info["seeding_time"] > 0
+        assert info["dltime"] > 0
+        assert info["iatime"] > 0
+        assert info["add_on"] == 900
+        assert info["tags"] == ["tag1"]
+        assert info["tracker"] == "https://tracker/announce"
+
+
+def test_v3_source_uses_public_sdk_boundaries():
+    """V3 源码使用稳定 SDK，不引入旧路径或调度器内部门面。"""
+    source_path = Path(__file__).parents[3] / "plugins.v3" / "brushmanager" / "__init__.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+    assert {
+        "app.chain.transfer",
+        "app.sdk.config",
+        "app.sdk.logging",
+        "app.sdk.plugins",
+        "app.sdk.scheduler",
+        "app.sdk.services",
+        "app.modules.qbittorrent",
+        "app.modules.transmission",
+    } <= imported_modules
+    assert not any(
+        module.startswith(
+            (
+                "app.compat",
+                "app.core",
+                "app.helper",
+                "app.log",
+                "app.utils",
+                "app.db.models",
+                "app.sdk._legacy",
+            )
+        )
+        for module in imported_modules
+    )
+    assert "app.scheduler" not in imported_modules
+
+
+def test_v3_lifecycle_and_empty_capabilities_are_explicit():
+    """未配置下载器时插件停用，并显式声明没有额外命令、API 和详情页。"""
+    plugin = object.__new__(BrushManager)
+
+    assert plugin.get_state() is False
+    assert plugin.get_command() == []
+    assert plugin.get_api() == []
+    assert plugin.get_page() is None
+
+
+def test_v3_plugin_version():
+    assert BrushManager.plugin_version == "2.0.0"
+
+
+def test_mp_tag_schedules_transfer_without_brush_plugin(monkeypatch):
+    """MP 标签整理不应依赖可选刷流插件的检查任务。"""
+    plugin = object.__new__(BrushManager)
+    plugin._mp_tag = True
+    plugin._remove_brush_tag = False
+    plugin._brush_plugin = None
+    scheduler = MagicMock()
+    scheduler.get_jobs.return_value = [object()]
+    monkeypatch.setattr(
+        "app.plugins.brushmanager.BackgroundScheduler",
+        lambda **_kwargs: scheduler,
+    )
+
+    plugin._BrushManager__run_after_organize()
+
+    scheduler.add_job.assert_called_once()
+    scheduler.start.assert_called_once_with()

--- a/tests/v3/brushmanager/torrent_sdk_fixtures.py
+++ b/tests/v3/brushmanager/torrent_sdk_fixtures.py
@@ -1,0 +1,74 @@
+"""下载器 SDK 字段测试夹具。"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from transmission_rpc import Torrent
+
+
+def make_tr_v7_torrent(**overrides):
+    """构造 transmission-rpc 7.x 的真实 Torrent 对象。"""
+    fields = {
+        "id": 1,
+        "name": "TR.Test",
+        "hashString": "tr_hash_1",
+        "doneDate": 1000,
+        "addedDate": 900,
+        "activityDate": 1100,
+        "totalSize": 4096000,
+        "sizeWhenDone": 4096000,
+        "percentDone": 1.0,
+        "downloadedEver": 4096000,
+        "uploadedEver": 8192000,
+        "uploadRatio": 2.0,
+        "secondsDownloading": 100,
+        "secondsSeeding": 200,
+        "rateUpload": 300,
+        "status": 6,
+        "labels": ["tag1"],
+        "trackers": [{"announce": "https://tracker/announce"}],
+        "trackerStats": [
+            {"tier": 0, "lastAnnounceResult": "OK"},
+            {"tier": -1, "lastAnnounceResult": "SKIP"},
+        ],
+    }
+    fields.update(overrides)
+    return Torrent(fields=fields)
+
+
+def make_tr_legacy_torrent(**overrides):
+    """构造旧 transmission-rpc 风格的 Torrent 替身。"""
+    now = datetime.fromtimestamp(1000, timezone.utc)
+    base = {
+        "hashString": "tr_hash_1",
+        "name": "TR.Test",
+        "date_done": now,
+        "date_added": datetime.fromtimestamp(900, timezone.utc),
+        "date_active": datetime.fromtimestamp(1100, timezone.utc),
+        "total_size": 4096000,
+        "progress": 100,
+        "ratio": 2.0,
+        "status": "seeding",
+        "labels": ["tag1"],
+        "trackers": [SimpleNamespace(announce="https://tracker/announce")],
+        "tracker_stats": [
+            SimpleNamespace(tier=0, last_announce_result="OK"),
+            SimpleNamespace(tier=-1, last_announce_result="SKIP"),
+        ],
+        "fields": {"size_when_done": 4096000},
+    }
+    base.update(overrides)
+    torrent = SimpleNamespace(**base)
+    torrent.get = lambda key, default=None: getattr(torrent, key, default)
+    if not hasattr(torrent, "size_when_done"):
+        torrent.size_when_done = torrent.fields.get("size_when_done", torrent.total_size)
+    return torrent
+
+
+def force_transmission_plugin(plugin):
+    """将绕过初始化的插件实例固定到 Transmission 分支。"""
+    plugin.downloader_helper = MagicMock()
+    plugin.downloader_helper.is_downloader.return_value = False
+    return plugin

--- a/tests/v3/torrentclassifier/test_torrentclassifier.py
+++ b/tests/v3/torrentclassifier/test_torrentclassifier.py
@@ -1,0 +1,148 @@
+"""TorrentClassifier V3 公开宿主边界与种子分类合同测试。"""
+
+import ast
+import json
+import warnings
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import PropertyMock, patch
+
+from app.plugins.torrentclassifier import TorrentClassifier
+from app.plugins.torrentclassifier.classifierconfig import TorrentFilter, TorrentTarget
+
+from .torrent_sdk_fixtures import (
+    force_transmission_plugin,
+    make_tr_legacy_torrent,
+    make_tr_v7_torrent,
+)
+
+
+REPO_ROOT = Path(__file__).parents[3]
+PLUGIN_SOURCE = REPO_ROOT / "plugins.v3/torrentclassifier/__init__.py"
+
+
+def _call_torrent_info(torrent):
+    """在不启动宿主服务的情况下调用种子信息映射。"""
+    plugin = force_transmission_plugin(object.__new__(TorrentClassifier))
+    with patch.object(TorrentClassifier, "service_info", new_callable=PropertyMock, return_value=object()):
+        return plugin._TorrentClassifier__get_torrent_info(torrent)
+
+
+def test_v3_source_uses_public_sdk_and_relative_plugin_imports():
+    """V3 实现使用公开 SDK，且不依赖旧导入兼容层或宿主内部会话。"""
+    source = PLUGIN_SOURCE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(PLUGIN_SOURCE))
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+    assert {
+        "app.sdk.config",
+        "app.sdk.logging",
+        "app.sdk.services",
+    } <= imported_modules
+    assert "app.plugins.torrentclassifier" not in source
+    assert "from .classifierconfig import" in source
+    assert not any(
+        module.startswith(
+            (
+                "app.compat",
+                "app.core",
+                "app.helper",
+                "app.log",
+                "app.utils",
+                "app.db.models",
+                "app.sdk._legacy",
+            )
+        )
+        for module in imported_modules
+    )
+
+
+def test_v3_metadata_and_legacy_index_are_consistent():
+    """V3 索引、源码版本和旧代回退阻断标志保持一致。"""
+    package_v3 = json.loads((REPO_ROOT / "package.v3.json").read_text(encoding="utf-8"))
+    package_v2 = json.loads((REPO_ROOT / "package.v2.json").read_text(encoding="utf-8"))
+    metadata = package_v3["TorrentClassifier"]
+
+    assert TorrentClassifier.plugin_version == "2.0.0"
+    assert metadata["version"] == TorrentClassifier.plugin_version
+    assert metadata["system_version"] == ">=3.0.0"
+    assert list(metadata["history"]) == ["v2.0.0"]
+    assert metadata["history"]["v2.0.0"]
+    assert package_v2["TorrentClassifier"]["v3"] is False
+
+
+def test_v3_empty_capabilities_are_explicit():
+    """未注册命令和 API 时直接返回空列表，保持 V3 合同类型一致。"""
+    plugin = object.__new__(TorrentClassifier)
+
+    assert plugin.get_command() == []
+    assert plugin.get_api() == []
+
+
+def test_transmission_rpc_v7_fields_are_read_without_deprecation_warnings():
+    """Transmission 新字段和标签映射应保持可用且不触发旧属性告警。"""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        info = _call_torrent_info(make_tr_v7_torrent())
+
+    assert info["hash"] == "tr_hash_1"
+    assert info["seeding_time"] > 0
+    assert info["dltime"] > 0
+    assert info["iatime"] > 0
+    assert info["add_on"] == 900
+    assert info["tags"] == ["tag1"]
+    assert info["tracker"] == "https://tracker/announce"
+
+
+def test_legacy_transmission_fields_remain_supported():
+    """旧 transmission-rpc 字段仍可映射为分类整理所需统计信息。"""
+    info = _call_torrent_info(make_tr_legacy_torrent())
+
+    assert info["hash"] == "tr_hash_1"
+    assert info["seeding_time"] > 0
+    assert info["dltime"] > 0
+    assert info["iatime"] > 0
+    assert info["add_on"] == 900
+    assert info["tags"] == ["tag1"]
+    assert info["tracker"] == "https://tracker/announce"
+
+
+def test_transmission_hash_prefers_current_rpc_field():
+    """优先使用新版 hash_string，避免读取可能已弃用的 hashString。"""
+    torrent = SimpleNamespace(hash_string="new-hash", hashString="legacy-hash")
+
+    assert TorrentClassifier._TorrentClassifier__get_transmission_hash(torrent) == "new-hash"
+
+
+def test_yaml_config_and_target_matching_preserve_classifier_contract():
+    """YAML 规则和目标前置过滤应保留标签清理及目录匹配语义。"""
+    plugin = object.__new__(TorrentClassifier)
+    configs = plugin._TorrentClassifier__load_configs(
+        "- torrent_filter:\n"
+        "    torrent_title: 'Test'\n"
+        "    torrent_tags: ['tag1', '']\n"
+        "  torrent_target:\n"
+        "    change_directory: '/downloads'\n"
+        "    add_tags: ['tag2', '']\n"
+        "    remove_tags: ['tag1', '']\n"
+    )
+
+    assert len(configs) == 1
+    assert configs[0].torrent_filter == TorrentFilter(torrent_title="Test", torrent_tags=["tag1"])
+    target = configs[0].torrent_target
+    assert target == TorrentTarget(
+        change_directory="/downloads",
+        add_tags=["tag2"],
+        remove_tags=["tag1"],
+    )
+    assert TorrentClassifier._TorrentClassifier__matches_target_settings(
+        target,
+        "/downloads",
+        None,
+        ["tag2"],
+        False,
+    )[0] is True

--- a/tests/v3/torrentclassifier/torrent_sdk_fixtures.py
+++ b/tests/v3/torrentclassifier/torrent_sdk_fixtures.py
@@ -1,0 +1,71 @@
+"""TorrentClassifier 下载器字段测试夹具。"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from transmission_rpc import Torrent
+
+
+def make_tr_v7_torrent(**overrides):
+    """构造 transmission-rpc 7.x 的真实 Torrent 对象。"""
+    fields = {
+        "id": 1,
+        "name": "TR.Test",
+        "hashString": "tr_hash_1",
+        "doneDate": 1000,
+        "addedDate": 900,
+        "activityDate": 1100,
+        "totalSize": 4096000,
+        "sizeWhenDone": 4096000,
+        "percentDone": 1.0,
+        "downloadedEver": 4096000,
+        "uploadedEver": 8192000,
+        "uploadRatio": 2.0,
+        "secondsDownloading": 100,
+        "secondsSeeding": 200,
+        "rateUpload": 300,
+        "status": 6,
+        "labels": ["tag1"],
+        "trackers": [{"announce": "https://tracker/announce"}],
+        "trackerStats": [
+            {"tier": 0, "lastAnnounceResult": "OK"},
+            {"tier": -1, "lastAnnounceResult": "SKIP"},
+        ],
+    }
+    fields.update(overrides)
+    return Torrent(fields=fields)
+
+
+def make_tr_legacy_torrent(**overrides):
+    """构造旧 transmission-rpc 风格的 Torrent 替身。"""
+    torrent = SimpleNamespace(
+        hashString="tr_hash_1",
+        name="TR.Test",
+        date_done=datetime.fromtimestamp(1000, timezone.utc),
+        date_added=datetime.fromtimestamp(900, timezone.utc),
+        date_active=datetime.fromtimestamp(1100, timezone.utc),
+        total_size=4096000,
+        progress=100,
+        ratio=2.0,
+        status="seeding",
+        labels=["tag1"],
+        trackers=[SimpleNamespace(announce="https://tracker/announce")],
+        tracker_stats=[
+            SimpleNamespace(tier=0, last_announce_result="OK"),
+            SimpleNamespace(tier=-1, last_announce_result="SKIP"),
+        ],
+        fields={"size_when_done": 4096000},
+        **overrides,
+    )
+    torrent.get = lambda key, default=None: getattr(torrent, key, default)
+    if not hasattr(torrent, "size_when_done"):
+        torrent.size_when_done = torrent.fields.get("size_when_done", torrent.total_size)
+    return torrent
+
+
+def force_transmission_plugin(plugin):
+    """将绕过初始化的插件实例固定到 Transmission 分支。"""
+    plugin.downloader_helper = MagicMock()
+    plugin.downloader_helper.is_downloader.return_value = False
+    return plugin

--- a/tests/v3/weatherwidget/test_weatherwidget.py
+++ b/tests/v3/weatherwidget/test_weatherwidget.py
@@ -1,0 +1,331 @@
+"""WeatherWidget V3 的公开接口、缓存生命周期和天气解析合同测试。"""
+
+from __future__ import annotations
+
+import ast
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import app.plugins.weatherwidget as weatherwidget
+from app.plugins.weatherwidget import WeatherWidget
+from app.runtime.extensions.plugin.contracts import supports_plugin_hook
+
+
+PLUGIN_ROOT = Path(__file__).parents[3] / "plugins.v3" / "weatherwidget"
+
+
+def _plugin(data_path: Path) -> WeatherWidget:
+    """构造不启动调度器、网络或宿主插件 Runtime 的测试实例。"""
+    plugin = object.__new__(WeatherWidget)
+    plugin._enabled = True
+    plugin._border = False
+    plugin._weather_notify = True
+    plugin._weather_notify_cron = "0 8 * * *"
+    plugin._refresh_interval = 1
+    plugin._scheduler = None
+    plugin._event = threading.Event()
+    plugin._location = "南京"
+    plugin._location_url = ""
+    plugin._weather_api_key = ""
+    plugin._weather_api_key_configured = False
+    plugin._weather_url = "https://www.qweather.com/weather/nanjing.html"
+    plugin._auto_theme_enabled = False
+    plugin._auto_height = False
+    plugin._use_dark_mode = False
+    plugin._adapt_mode = "compatibility"
+    plugin._component_size = "mini"
+    plugin._weather_background = "#fff"
+    plugin._weather_current_time = "2026-08-31 12:00"
+    plugin._weather_air_tag = " AQI 优 "
+    plugin._weather_air_tag_background = "#95B359"
+    plugin._screenshot_type = "default"
+    plugin._last_screenshot_time = None
+    plugin.get_data_path = MagicMock(return_value=data_path)
+    return plugin
+
+
+def test_v3_source_uses_public_sdk_boundaries() -> None:
+    """V3 入口使用公开 SDK，不依赖旧兼容路径或旧浏览器实现。"""
+    source_path = PLUGIN_ROOT / "__init__.py"
+    source = source_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(source_path))
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+    assert "app.sdk.browser" in imported_modules
+    assert "app.sdk.config" in imported_modules
+    assert "app.sdk.events" in imported_modules
+    assert "app.sdk.logging" in imported_modules
+    assert "app.sdk.network" in imported_modules
+    assert "app.sdk.plugins" in imported_modules
+    assert not any(
+        module.startswith(
+            ("app.compat", "app.core", "app.helper", "app.log", "app.utils", "app.db")
+        )
+        for module in imported_modules
+    )
+    assert "from cloakbrowser" not in source
+    assert "sync_playwright" not in source
+    assert not hasattr(weatherwidget, "IMAGES_PATH")
+
+
+def test_v3_metadata_and_capability_contract() -> None:
+    """插件版本、命令、页面和 API 能力符合 V3 索引合同。"""
+    plugin = _plugin(Path("/tmp/weatherwidget-test"))
+
+    assert WeatherWidget.plugin_version == "3.0.0"
+    assert WeatherWidget.plugin_name == "天气"
+    assert plugin.get_command()[0]["cmd"] == "/weather_notify"
+    assert plugin.get_api() == []
+    assert plugin.get_page() is None
+    assert supports_plugin_hook(plugin, "get_page") is True
+
+
+def test_init_plugin_resets_state_without_reusing_previous_config(monkeypatch) -> None:
+    """重载空配置时应停用插件并清空旧配置，且不触发真实网络。"""
+    plugin = _plugin(Path("/tmp/weatherwidget-test"))
+    plugin._WeatherWidget__update_config = MagicMock()
+    monkeypatch.setattr(
+        WeatherWidget,
+        "_WeatherWidget__get_weather_url",
+        lambda _self: "https://weather.example/current",
+    )
+    monkeypatch.setattr(
+        WeatherWidget,
+        "_WeatherWidget__should_use_dark_mode",
+        lambda _self: False,
+    )
+
+    plugin.init_plugin({"enabled": False, "location": "上海", "weather_notify": False})
+
+    assert plugin.get_state() is False
+    assert plugin._location == "上海"
+    assert plugin._weather_url == "https://weather.example/current"
+    assert plugin._weather_notify is False
+    assert plugin._event is not None
+
+    plugin.init_plugin()
+
+    assert plugin.get_state() is False
+    assert plugin._location == ""
+    assert plugin._weather_notify is True
+    assert plugin._weather_notify_cron is None
+
+
+def test_init_plugin_keeps_environment_key_ephemeral(monkeypatch) -> None:
+    """初始化时从环境变量读取的密钥不得被视为用户配置。"""
+    plugin = _plugin(Path("/tmp/weatherwidget-test"))
+    plugin._WeatherWidget__update_config = MagicMock()
+    monkeypatch.setenv("QWEATHER_API_KEY", "environment-key")
+    monkeypatch.setattr(
+        WeatherWidget,
+        "_WeatherWidget__get_weather_url",
+        lambda _self: None,
+    )
+    monkeypatch.setattr(
+        WeatherWidget,
+        "_WeatherWidget__should_use_dark_mode",
+        lambda _self: False,
+    )
+
+    plugin.init_plugin({"enabled": False, "location": "南京"})
+
+    assert plugin._weather_api_key == "environment-key"
+    assert plugin._weather_api_key_configured is False
+
+
+def test_weather_api_key_is_configured_without_source_literal_or_url_logging(monkeypatch):
+    """天气 API 密钥来自受控配置，日志不得包含完整请求 URL。"""
+    source = (PLUGIN_ROOT / "__init__.py").read_text(encoding="utf-8")
+    assert "bdd98ec1d87747f3a2e8b1741a5af796" not in source
+
+    plugin = _plugin(Path("/tmp/weatherwidget-test"))
+    plugin._weather_api_key = "configured-key"
+    plugin.get_data = MagicMock(return_value={})
+    response = SimpleNamespace(status_code=200, json=lambda: {"code": "400"}, text="{}")
+    request = MagicMock(return_value=response)
+    monkeypatch.setattr(
+        weatherwidget,
+        "RequestUtils",
+        lambda: SimpleNamespace(get_res=request),
+    )
+    log = MagicMock()
+    monkeypatch.setattr(weatherwidget, "logger", log)
+
+    assert plugin._WeatherWidget__get_weather_url() is None
+    request.assert_called_once()
+    assert "configured-key" in request.call_args.args[0]
+    assert all(
+        "configured-key" not in str(call)
+        for call in log.info.call_args_list
+    )
+
+
+def test_environment_api_key_is_not_persisted():
+    """环境变量密钥仅供运行时请求，不得写入插件配置。"""
+    plugin = _plugin(Path("/tmp/weatherwidget-test"))
+    plugin._weather_api_key = "environment-key"
+    plugin._weather_api_key_configured = False
+    update_config = MagicMock()
+    plugin.update_config = update_config
+
+    plugin._WeatherWidget__update_config()
+
+    persisted_config = update_config.call_args.args[0]
+    assert "weather_api_key" not in persisted_config
+    assert "environment-key" not in str(persisted_config)
+
+
+def test_configured_api_key_is_persisted():
+    """用户在插件配置中填写的密钥仍应随配置保存。"""
+    plugin = _plugin(Path("/tmp/weatherwidget-test"))
+    plugin._weather_api_key = "configured-key"
+    plugin._weather_api_key_configured = True
+    update_config = MagicMock()
+    plugin.update_config = update_config
+
+    plugin._WeatherWidget__update_config()
+
+    persisted_config = update_config.call_args.args[0]
+    assert persisted_config["weather_api_key"] == "configured-key"
+
+
+def test_get_service_exposes_refresh_and_notification_jobs() -> None:
+    """启用插件时应声明截图刷新和天气通知两个宿主调度服务。"""
+    plugin = _plugin(Path("/tmp/weatherwidget-test"))
+    plugin._WeatherWidget__take_screenshots = MagicMock()
+
+    services = plugin.get_service()
+
+    assert [service["id"] for service in services] == [
+        "RefreshWeather",
+        "NotifyWeather",
+    ]
+    assert services[0]["kwargs"] == {"hours": 1}
+    assert services[1]["kwargs"] == {}
+
+
+def test_instance_cache_paths_are_isolated(tmp_path: Path) -> None:
+    """截图必须写入实例数据目录，不能在模块导入期共享全局缓存目录。"""
+    first = _plugin(tmp_path / "first")
+    second = _plugin(tmp_path / "second")
+
+    first_path = first._WeatherWidget__get_images_path()
+    second_path = second._WeatherWidget__get_images_path()
+
+    assert first_path == tmp_path / "first" / "images"
+    assert second_path == tmp_path / "second" / "images"
+    assert first_path != second_path
+
+
+def test_browser_screenshot_uses_host_sdk_and_closes_resources(tmp_path, monkeypatch) -> None:
+    """截图通过宿主浏览器 SDK 完成，并在成功后关闭页面和上下文。"""
+    plugin = _plugin(tmp_path)
+    image_dir = tmp_path / "images"
+    image_dir.mkdir()
+
+    class FakeElement:
+        def bounding_box(self):
+            return None
+
+        def screenshot(self, path):
+            Path(path).write_bytes(b"png")
+
+    class FakePage:
+        def __init__(self):
+            self.element = FakeElement()
+            self.closed = False
+
+        def goto(self, _url):
+            return None
+
+        def wait_for_selector(self, _selector, timeout):
+            assert timeout == plugin._screenshot_timeout * 1000
+
+        def query_selector(self, _selector):
+            return self.element
+
+        def title(self):
+            return "天气"
+
+        def close(self):
+            self.closed = True
+
+    class FakeContext:
+        def __init__(self):
+            self.page = FakePage()
+            self.closed = False
+
+        def new_page(self):
+            return self.page
+
+        def close(self):
+            self.closed = True
+
+    context = FakeContext()
+    launcher = MagicMock(return_value=context)
+    monkeypatch.setattr(weatherwidget, "launch_browser_context", launcher)
+    monkeypatch.setattr(
+        WeatherWidget,
+        "_WeatherWidget__reset_weather_style",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        WeatherWidget,
+        "_WeatherWidget__reset_page_style",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        WeatherWidget,
+        "_WeatherWidget__manage_images",
+        MagicMock(),
+    )
+
+    success = plugin._WeatherWidget__screenshot_element_by_browser(
+        key="mobile",
+        device={"device": "iphone_13_pro_max", "size": {}},
+        color_scheme="dark",
+    )
+
+    assert success is True
+    launcher.assert_called_once()
+    assert launcher.call_args.kwargs["headless"] is True
+    assert launcher.call_args.kwargs["color_scheme"] == "dark"
+    assert context.page.closed is True
+    assert context.closed is True
+    assert list(image_dir.glob("weather_南京_default_mobile_*.png"))
+
+
+def test_resolve_weather_parses_current_report(monkeypatch) -> None:
+    """天气页面解析应提取当前时间、温度、状况、空气质量和基础指标。"""
+    plugin = _plugin(Path("/tmp/weatherwidget-test"))
+    response = SimpleNamespace(
+        text="""
+        <p class="current-time">2026-08-31 12:00</p>
+        <div class="current-live__item"></div>
+        <div><p>28°C</p><p>晴</p></div>
+        <a class="air-tag">优</a>
+        <div class="current-basic___item"><p>3级</p><p>风力</p></div>
+        <div class="current-abstract">适宜出行</div>
+        """,
+        raise_for_status=MagicMock(),
+    )
+    client = MagicMock()
+    client.get_res.return_value = response
+    monkeypatch.setattr(weatherwidget, "RequestUtils", lambda **_kwargs: client)
+
+    report = plugin._WeatherWidget__resolve_weather()
+
+    assert report is not None
+    assert "当前时间: 2026-08-31 12:00" in report
+    assert "温度: 28°C" in report
+    assert "天气状况: 晴" in report
+    assert "空气质量: 优" in report
+    assert "风力: 3级" in report
+    assert "适宜出行" in report
+    response.raise_for_status.assert_called_once_with()


### PR DESCRIPTION
本 PR 将 WeatherWidget、BrushManager、TorrentClassifier 迁移为 MoviePilot V3 实现，并更新 V3 市场索引。

主要变化：
- 新增三个 `plugins.v3` 实现，使用公开 SDK、Chain、Oper/Module 边界及 V3 生命周期合同。
- V2 索引中的三个条目标记 `v3: false`，避免 V3 宿主继续回退到旧实现。
- WeatherWidget 使用宿主浏览器 SDK，并确保环境变量中的和风天气密钥仅用于运行时请求，不写回插件配置；显式插件配置仍按用户设置保存。
- BrushManager 修正 MP 标签整理任务不应依赖可选刷流插件检查任务的问题。
- Transmission 新旧字段均由聚焦测试覆盖，未新增 README。

验证：
- V3 focused pytest：24 passed
- CI 测试：59 passed
- 受影响 V2 测试：4 passed（仅既有 `hashString` 弃用警告）
- Python 编译、JSON、插件版本门禁、旧入口/硬编码密钥扫描、`git diff --check`：通过

真实浏览器和下载器运行态未在本地执行，仍由 CI 与部署环境验证。
