### PR TITLE
发布 WebDAV备份 v2.0.1

### DIFF
--- a/package.v3.json
+++ b/package.v3.json
@@ -96,13 +96,13 @@
         "name": "WebDAV备份",
         "description": "定时通过 WebDAV 上传 MoviePilot V3 一致性数据库备份。",
         "labels": "工具",
-        "version": "2.0",
+        "version": "2.0.1",
         "icon": "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/webdavbackup.png",
         "author": "InfinityPacer",
         "level": 1,
         "system_version": ">=3.0.0",
         "history": {
-            "v2.0": "MoviePilot V3 版本WebDAV备份插件"
+            "v2.0.1": "支持上传主程序及插件 SQLite 数据库备份制品。"
         },
         "release": true
     },

--- a/plugins.v3/webdavbackup/__init__.py
+++ b/plugins.v3/webdavbackup/__init__.py
@@ -33,7 +33,7 @@ class WebDAVBackup(_PluginBase):
     plugin_name = "WebDAV备份"
     plugin_desc = "定时通过 WebDAV 备份 MoviePilot V3 数据库。"
     plugin_icon = "https://raw.githubusercontent.com/InfinityPacer/MoviePilot-Plugins/main/icons/webdavbackup.png"
-    plugin_version = "2.0"
+    plugin_version = "2.0.1"
     plugin_author = "InfinityPacer"
     author_url = "https://github.com/InfinityPacer"
     plugin_config_prefix = "webdavbackup_"


### PR DESCRIPTION
本次发布 WebDAV备份插件 v2.0.1。

变更：
- 同步上传主程序及插件 SQLite 数据库备份制品。
- 保持 PostgreSQL .dump 备份上传。

验证：
- 插件版本门禁通过。
- JSON 格式校验通过。
- git diff --check 通过。
- 前置功能 PR #416 已合并。